### PR TITLE
ui-touch: show post author instead of room name for room-server messages

### DIFF
--- a/src/AbstractUITask.h
+++ b/src/AbstractUITask.h
@@ -72,6 +72,20 @@ public:
     (void)is_flood; (void)snr_q4; (void)rssi;
     newMsgFromPub(path_len, from_pub, from_name, text, msgcount);
   }
+  /** Room-server post. Like newMsgFromPubWithMeta, but from_pub/from_name
+   *  identify the ROOM (the chat thread) while `author_name` is the resolved
+   *  display name of the original poster — a room signed message attributes
+   *  the author only by a pubkey prefix, never in the text body. Default
+   *  ignores the author and behaves like a normal message, so non-touch UIs
+   *  are unaffected. */
+  virtual void newRoomMsgFromPubWithMeta(uint8_t path_len, bool is_flood,
+                                         const uint8_t* from_pub, const char* from_name,
+                                         const char* author_name,
+                                         const char* text, int msgcount,
+                                         int8_t snr_q4, int8_t rssi) {
+    (void)author_name;
+    newMsgFromPubWithMeta(path_len, is_flood, from_pub, from_name, text, msgcount, snr_q4, rssi);
+  }
   virtual void notify(UIEventType t = UIEventType::none) = 0;
   virtual void appendDiag(const char* message) { (void)message; }
   /** Notify UI of an advert reception. `is_new=true` means the contact is NOT in

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -1875,7 +1875,14 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
      * serial was disconnected, which meant after a channel message arrived
      * over TCP/BLE g_last_event stayed at `channelMessage` and the next DM
      * was routed into the channel thread (or vice versa). */
-    _ui->notify(UIEventType::contactMessage);
+    // A TXT_TYPE_SIGNED_PLAIN with a 4-byte sender_prefix is a room-server
+    // post: `from` is the room (the thread) and the author is identified only
+    // by the prefix — the text is the bare body. Plain DMs/channel msgs are
+    // unchanged.
+    const bool is_room_post =
+        (txt_type == TXT_TYPE_SIGNED_PLAIN) && extra && extra_len >= 4;
+    _ui->notify(is_room_post ? UIEventType::roomMessage
+                             : UIEventType::contactMessage);
     // Pass RX metadata so the touch UI can surface it via the bubble's
     // long-press Info sheet. SNR comes off the packet itself (most accurate
     // per-message); RSSI is the radio's last-RSSI, which is current since
@@ -1885,8 +1892,29 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
     const bool   is_flood = pkt->isRouteFlood();
     uiStashRxMeta(pkt);   // capture route + scope for the per-message Info popup
     _last_sender_ts = sender_timestamp;   // embedded send-time -> UI bubble ts (room history replay)
-    _ui->newMsgFromPubWithMeta(path_len, is_flood, from.id.pub_key, from.name,
-                               text, history_count, snr_q4, rssi);
+    if (is_room_post) {
+      // Resolve the post's author from the signed message's sender_prefix.
+      // Prefer a saved contact's name; fall back to our own node name for
+      // posts we authored (replayed during sync), else a short hex of the
+      // prefix so the bubble never just shows the room's own name.
+      char author_buf[16];
+      const char* author_name;
+      ContactInfo* author = lookupContactByPubKey(extra, 4);
+      if (author && author->name[0]) {
+        author_name = author->name;
+      } else if (memcmp(extra, self_id.pub_key, 4) == 0) {
+        author_name = _prefs.node_name;
+      } else {
+        mesh::Utils::toHex(author_buf, (uint8_t*)extra, 4);
+        author_name = author_buf;
+      }
+      _ui->newRoomMsgFromPubWithMeta(path_len, is_flood, from.id.pub_key,
+                                     from.name, author_name, text,
+                                     history_count, snr_q4, rssi);
+    } else {
+      _ui->newMsgFromPubWithMeta(path_len, is_flood, from.id.pub_key, from.name,
+                                 text, history_count, snr_q4, rssi);
+    }
   }
   // CLI command replies don't belong in the chat thread but the touch UI
   // *does* want them — they're the response to whatever was typed into the

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -29167,9 +29167,11 @@ void UITask::msgRead(int msgcount) { _msgcount = msgcount; }
 // drift from the plain path. `meta_flags` is 0 (no RX metadata) when called
 // from base newMsg; the touch UI ignores zero-meta entries in the Info popup.
 void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* text, int msgcount,
-                        uint8_t meta_flags, int8_t snr_q4, int8_t rssi) {
+                        uint8_t meta_flags, int8_t snr_q4, int8_t rssi,
+                        const char* sender_override) {
   (void)path_len;
   _msgcount = msgcount;
+  const bool have_sender_override = (sender_override && sender_override[0]);
   bool channel = (g_last_event == UIEventType::channelMessage);
   const char* thread = channel
       ? (from_name && from_name[0] ? from_name : "#unknown")
@@ -29182,7 +29184,7 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
   char parsed_sender[MAX_SENDER_NAME + 1];
   parsed_sender[0] = '\0';
   const char* body = text ? text : "";
-  if (channel && text) {
+  if (channel && text && !have_sender_override) {
     const char* colon = strstr(text, ": ");
     if (colon) {
       int slen = static_cast<int>(colon - text);
@@ -29193,9 +29195,11 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
       }
     }
   }
-  const char* sender = channel
+  const char* sender = have_sender_override
+      ? sender_override
+      : (channel
       ? (parsed_sender[0] ? parsed_sender : (from_name && from_name[0] ? from_name : "node"))
-      : (from_name && from_name[0] ? from_name : "node");
+      : (from_name && from_name[0] ? from_name : "node"));
 
 #if defined(ESP32)
   // Blocked-by-name sender: a channel/room bot we have no pubkey to target via
@@ -29293,6 +29297,33 @@ void UITask::newMsgFromPubWithMeta(uint8_t path_len, bool is_flood,
   newMsgImpl(path_len, from_name, text, msgcount, meta_flags, snr_q4, rssi);
   // Mirror newMsgFromPub's contact-pub plumbing so the newly-arrived DM
   // resolves back to its contact entry for replies.
+  if (!from_pub || !from_name || !from_name[0]) return;
+  const int t = findThreadByName(from_name, false);
+  if (t < 0) return;
+  _ui_threads[t].mesh_contact_idx = -1;
+  memcpy(_ui_threads[t].mesh_contact_pub, from_pub, PUB_KEY_SIZE);
+  memcpy(_ui_threads[t].mesh_contact_key6, from_pub, 6);
+  if (!_ui_threads[t].channel && t == _active_thread_idx) {
+    _active_dm_contact_set = true;
+    memcpy(_active_dm_contact_pub, from_pub, sizeof(_active_dm_contact_pub));
+  }
+  syncThreadMeshSlots(from_name, false);
+}
+
+void UITask::newRoomMsgFromPubWithMeta(uint8_t path_len, bool is_flood,
+                                       const uint8_t* from_pub, const char* from_name,
+                                       const char* author_name,
+                                       const char* text, int msgcount,
+                                       int8_t snr_q4, int8_t rssi) {
+  if (from_pub && touchPrefsIsIgnored(from_pub)) return;   // blocked room — drop
+  const uint8_t meta_flags = MSG_META_HAS_RX | (is_flood ? MSG_META_IS_FLOOD : 0);
+  // The thread is the room (from_name); the per-message sender label is the
+  // resolved author. g_last_event is roomMessage here, so newMsgImpl keeps the
+  // thread DM-style (channel=false) — matching the thread the user opens by
+  // tapping the room contact — while the timeline shows the author label for
+  // room threads (thread_is_room).
+  newMsgImpl(path_len, from_name, text, msgcount, meta_flags, snr_q4, rssi, author_name);
+  // Map the room thread back to the room contact so replies/login resolve.
   if (!from_pub || !from_name || !from_name[0]) return;
   const int t = findThreadByName(from_name, false);
   if (t < 0) return;

--- a/src/ui-touch/UITask.h
+++ b/src/ui-touch/UITask.h
@@ -196,7 +196,8 @@ private:
                     uint16_t in_scope = 0);
   // Shared core for newMsg / newMsgFromPubWithMeta — see UITask.cpp.
   void newMsgImpl(uint8_t path_len, const char* from_name, const char* text, int msgcount,
-                  uint8_t meta_flags, int8_t snr_q4, int8_t rssi);
+                  uint8_t meta_flags, int8_t snr_q4, int8_t rssi,
+                  const char* sender_override = nullptr);
 public:
   /** Match an arriving ACK (4-byte hash) against the last few outgoing DMs
    *  and flip their delivery state to DELIV_DELIVERED so the chat detail
@@ -402,6 +403,11 @@ public:
                               const uint8_t* from_pub, const char* from_name,
                               const char* text, int msgcount,
                               int8_t snr_q4, int8_t rssi) override;
+  void newRoomMsgFromPubWithMeta(uint8_t path_len, bool is_flood,
+                                 const uint8_t* from_pub, const char* from_name,
+                                 const char* author_name,
+                                 const char* text, int msgcount,
+                                 int8_t snr_q4, int8_t rssi) override;
   void notify(UIEventType t = UIEventType::none) override;
   void logRxFrame(float snr, float rssi, const uint8_t* raw, int len) override;
   void discoveredContact(const ContactInfo& contact, bool is_new, uint8_t path_len) override;


### PR DESCRIPTION
Closes #32 

### Problem
When logged in to a room server, every message in the room thread is
attributed to the room server's own name instead of the actual author
(#32).

### Root cause
Room posts arrive as `TXT_TYPE_SIGNED_PLAIN`, where the author is identified
only by the 4-byte `sender_prefix`; the text is the bare body (confirmed in
upstream `simple_room_server/MyMesh.cpp` and `BaseChatMesh.cpp`). The on-device
display path in `MyMesh::queueMessage` ignored the prefix and passed
`from.name` (the room contact), so all posts showed the room name. The
serial/companion frame already carries the prefix and is unaffected.

### Fix
- Resolve the author from `sender_prefix` via `lookupContactByPubKey(prefix, 4)`
  (saved contact name → own node name for self-authored posts → hex prefix).
- Pass it as the per-message sender through a new `newRoomMsgFromPubWithMeta`
  hook; the room remains the thread (channel=false). The timeline already
  renders a per-message sender label for room threads (`thread_is_room`).
- Emit the existing (previously unused) `UIEventType::roomMessage` for room posts.

Plain DMs, channels, and the serial/companion path are unchanged. The new
AbstractUITask hook defaults to the existing behaviour, so non-touch UIs are
unaffected.

### Testing
Built for `LilyGo_TDeck_companion_radio_touch` and flashed on a T-Deck Plus
(firmware beta 12). Room posts now show the author per message; unknown authors
fall back to a hex prefix; the room thread stays a single thread.