### PR TITLE
deploy: add OpenTopoMap tile proxy routes alongside OSM

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,7 +3,7 @@
 Distribution stack for wadamesh: a **VPS nginx origin behind Cloudflare**.
 
 ```
-tiles.wadamesh.com     →CF (HTTP, edge-cached) →  nginx → tile.openstreetmap.org
+tiles.wadamesh.com     →CF (HTTP, edge-cached) →  nginx → OpenTopoMap / OpenStreetMap
 firmware.wadamesh.com  →CF (cache bins)        →  nginx → /srv/wadamesh/firmware
 flasher.wadamesh.com   →CF (HTTPS)             →  web flasher        (TODO — see below)
 wadamesh.com           →CF (HTTPS)             →  landing page       (later)

--- a/deploy/nginx/tiles.wadamesh.com.conf
+++ b/deploy/nginx/tiles.wadamesh.com.conf
@@ -1,4 +1,4 @@
-# tiles.wadamesh.com — OSM tile proxy for the wadamesh map tab.
+# tiles.wadamesh.com — map-tile proxy for the wadamesh map tab.
 #
 # The firmware fetches plain HTTP (on-device HTTPS isn't workable: mbedTLS wants
 # ~30 KB heap for a handshake and only ~5 KB is free after Wi-Fi associates), so
@@ -6,13 +6,15 @@
 # at the edge; this origin keeps a second 14-day disk cache.
 #
 # The device also can only decode JPEG cheaply (SJPG/TJpgDec -> RGB565 in
-# stripes); PNG decode (lodepng) needs a 256 KB ARGB8888 buffer per tile. OSM
-# only serves PNG, so the device requests `.jpg` and a local transcode service
-# (tile-transcode.py on 127.0.0.1:5005) fetches the OSM PNG and re-encodes it as
-# JPEG. The legacy `.png` passthrough (used by the website / older callers) is
-# kept alongside it.
+# stripes); PNG decode (lodepng) needs a 256 KB ARGB8888 buffer per tile.
+# OpenTopoMap and OpenStreetMap both serve PNG, so the device requests `.jpg`
+# and a local transcode service (tile-transcode.py on 127.0.0.1:5005) fetches
+# the upstream PNG and re-encodes it as JPEG. The root path serves OpenTopoMap
+# (the touch UI default); `/osm/...jpg` serves classic OpenStreetMap. The
+# legacy `.png` passthrough (used by the website / older callers) is kept
+# alongside it.
 #
-#   device --HTTP--> CF --HTTP--> nginx (this) --> 127.0.0.1:5005 --HTTPS--> OSM
+#   device --HTTP--> CF --HTTP--> nginx (this) --> 127.0.0.1:5005 --HTTPS--> OpenTopoMap / OSM
 #                                                    PNG -> JPEG (Pillow)
 #
 # Deploy:
@@ -34,14 +36,14 @@ server {
     listen [::]:80;
     server_name tiles.wadamesh.com;
 
-    # Re-resolve the OSM upstream (for the .png passthrough) at request time. A
+    # Re-resolve the upstream tile host (for the .png passthrough) at request time. A
     # literal hostname in proxy_pass fails with "no resolver defined" on a fresh
     # box; a variable + resolver works.
     resolver 1.1.1.1 8.8.8.8 valid=300s;
     resolver_timeout 5s;
 
     # Primary path the firmware uses: /{z}/{x}/{y}.jpg -> local transcode service
-    # (fetches the OSM PNG, re-encodes as JPEG). The regex is DOUBLE-QUOTED on
+    # (fetches the OpenTopoMap PNG, re-encodes as JPEG). The regex is DOUBLE-QUOTED on
     # purpose: nginx's lexer otherwise treats { and } (quantifiers) as block
     # delimiters and refuses to start.
     location ~ "^/(?<z>[0-9]{1,2})/(?<x>[0-9]{1,7})/(?<y>[0-9]{1,7})\.jpg$" {
@@ -50,6 +52,44 @@ server {
 
         proxy_cache wadamesh_tiles;
         proxy_cache_key "jpg:$z/$x/$y";
+        proxy_cache_valid 200 14d;
+        proxy_cache_valid 404 1d;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock on;
+        add_header X-Cache-Status $upstream_cache_status always;
+        add_header Cache-Control "public, max-age=2592000" always;
+
+        proxy_buffering on;
+        proxy_read_timeout 20s;
+        proxy_connect_timeout 5s;
+    }
+
+    # Explicit OpenStreetMap preset for the device's "background map" button.
+    location ~ "^/osm/(?<z>[0-9]{1,2})/(?<x>[0-9]{1,7})/(?<y>[0-9]{1,7})\.jpg$" {
+        proxy_pass http://127.0.0.1:5005/osm/$z/$x/$y.jpg;
+        proxy_set_header Host "tiles.wadamesh.com";
+
+        proxy_cache wadamesh_tiles;
+        proxy_cache_key "osm-jpg:$z/$x/$y";
+        proxy_cache_valid 200 14d;
+        proxy_cache_valid 404 1d;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock on;
+        add_header X-Cache-Status $upstream_cache_status always;
+        add_header Cache-Control "public, max-age=2592000" always;
+
+        proxy_buffering on;
+        proxy_read_timeout 20s;
+        proxy_connect_timeout 5s;
+    }
+
+    # Explicit OpenTopoMap alias (root path above is already OpenTopoMap).
+    location ~ "^/opentopo/(?<z>[0-9]{1,2})/(?<x>[0-9]{1,7})/(?<y>[0-9]{1,7})\.jpg$" {
+        proxy_pass http://127.0.0.1:5005/opentopo/$z/$x/$y.jpg;
+        proxy_set_header Host "tiles.wadamesh.com";
+
+        proxy_cache wadamesh_tiles;
+        proxy_cache_key "opentopo-jpg:$z/$x/$y";
         proxy_cache_valid 200 14d;
         proxy_cache_valid 404 1d;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
@@ -77,7 +117,7 @@ server {
         proxy_connect_timeout 5s;
     }
 
-    # Legacy direct PNG passthrough -> OSM (kept for the website / older callers).
+    # Legacy direct PNG passthrough -> OpenStreetMap (kept for the website / older callers).
     location ~ "^/(\d{1,2})/(\d{1,7})/(\d{1,7})\.png$" {
         set $osm_upstream "tile.openstreetmap.org";
         proxy_pass https://$osm_upstream/$1/$2/$3.png;
@@ -98,7 +138,7 @@ server {
     # Tiny landing so a human hitting the bare hostname isn't met with 404.
     location = / {
         default_type text/plain;
-        return 200 "wadamesh tile proxy\n\nUsage: GET /{z}/{x}/{y}.jpg  (HTTP only)\nUpstream: tile.openstreetmap.org (PNG transcoded to JPEG)\n";
+        return 200 "wadamesh tile proxy\n\nUsage:\n  /{z}/{x}/{y}.jpg           -> OpenTopoMap (default)\n  /osm/{z}/{x}/{y}.jpg       -> OpenStreetMap\n  /opentopo/{z}/{x}/{y}.jpg  -> OpenTopoMap\n";
     }
 
     location / { return 404; }

--- a/deploy/tile-transcode.py
+++ b/deploy/tile-transcode.py
@@ -39,6 +39,7 @@ except ImportError:
     sys.exit("ERROR: pip install flask pillow requests")
 
 OSM_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+OPENTOPO_URL = "https://tile.opentopomap.org/{z}/{x}/{y}.png"
 # OSM tile policy: identify yourself with a contactable UA. This is what OSM
 # sees — the device never talks to OSM directly.
 OSM_UA = "wadamesh-tile-proxy/1.0 (+https://wadamesh.com)"
@@ -57,29 +58,23 @@ _session = requests.Session()
 _session.headers.update({"User-Agent": OSM_UA, "Accept": "image/png,image/*"})
 
 
-@app.get("/<int:z>/<int:x>/<int:y>.jpg")
-def tile(z: int, x: int, y: int):
-    # Range-check before touching OSM so we can't be turned into an open proxy.
-    if not (0 <= z <= 19):
-        abort(404)
-    n = 1 << z
-    if not (0 <= x < n and 0 <= y < n):
-        abort(404)
-
+def _fetch_tile_png(upstream_url: str, z: int, x: int, y: int):
     try:
-        r = _session.get(OSM_URL.format(z=z, x=x, y=y), timeout=REQUEST_TIMEOUT,
+        r = _session.get(upstream_url.format(z=z, x=x, y=y), timeout=REQUEST_TIMEOUT,
                          stream=True)
     except requests.RequestException:
         abort(502)
 
     if r.status_code != 200:
-        # Pass OSM's status through (404 = empty/sea tile — nginx caches it).
         abort(r.status_code if r.status_code in (404, 429) else 502)
 
     raw = r.raw.read(MAX_TILE_BYTES + 1, decode_content=True)
     if len(raw) > MAX_TILE_BYTES:
         abort(502)
+    return raw
 
+
+def _tile_response_from_png(raw: bytes):
     try:
         img = Image.open(io.BytesIO(raw)).convert("RGB")
         out = io.BytesIO()
@@ -89,6 +84,36 @@ def tile(z: int, x: int, y: int):
 
     return Response(out.getvalue(), mimetype="image/jpeg",
                     headers={"Cache-Control": "public, max-age=2592000"})
+
+
+@app.get("/<int:z>/<int:x>/<int:y>.jpg")
+def tile(z: int, x: int, y: int):
+    if not (0 <= z <= 19):
+        abort(404)
+    n = 1 << z
+    if not (0 <= x < n and 0 <= y < n):
+        abort(404)
+    return _tile_response_from_png(_fetch_tile_png(OPENTOPO_URL, z, x, y))
+
+
+@app.get("/osm/<int:z>/<int:x>/<int:y>.jpg")
+def tile_osm(z: int, x: int, y: int):
+    if not (0 <= z <= 19):
+        abort(404)
+    n = 1 << z
+    if not (0 <= x < n and 0 <= y < n):
+        abort(404)
+    return _tile_response_from_png(_fetch_tile_png(OSM_URL, z, x, y))
+
+
+@app.get("/opentopo/<int:z>/<int:x>/<int:y>.jpg")
+def tile_opentopo(z: int, x: int, y: int):
+    if not (0 <= z <= 19):
+        abort(404)
+    n = 1 << z
+    if not (0 <= x < n and 0 <= y < n):
+        abort(404)
+    return _tile_response_from_png(_fetch_tile_png(OPENTOPO_URL, z, x, y))
 
 
 @app.get("/elev")


### PR DESCRIPTION
## Summary

- Default tile route (`/{z}/{x}/{y}.jpg`) now serves **OpenTopoMap** (terrain relief) — matches the touch UI default map style
- New `/osm/{z}/{x}/{y}.jpg` route for explicit OpenStreetMap tiles
- New `/opentopo/{z}/{x}/{y}.jpg` route as explicit OpenTopoMap alias
- `tile-transcode.py` refactored into `_fetch_tile_png` + `_tile_response_from_png` helpers, eliminating duplication
- README and nginx config comments updated

## Test plan

- [ ] `curl -I http://tiles.wadamesh.com/12/2048/1398.jpg` → 200, cache HIT on 2nd request
- [ ] `curl -I http://tiles.wadamesh.com/osm/12/2048/1398.jpg` → 200 (OSM road tiles)
- [ ] `curl -I http://tiles.wadamesh.com/opentopo/12/2048/1398.jpg` → 200 (topo tiles)
- [ ] Out-of-range tile → 404
