### PR TITLE
ui-touch: persist the map "Show link lines" toggle across reboots

### DIFF
--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -35,7 +35,7 @@ static bool s_begun = false;
 // short read (→ treat as absent → defaults); `ver` lets later builds add fields.
 static const char* KEY_CFG = "cfg";
 static const uint16_t TOUCH_CFG_MAGIC = 0x5743;   // 'WC' (WadaCfg)
-static const uint8_t  TOUCH_CFG_VER   = 19;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab
+static const uint8_t  TOUCH_CFG_VER   = 20;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab; v20 map_show_links
 
 // Defaults (kept identical to the historical per-key defaults).
 static const uint16_t DEFAULT_SCREEN_TIMEOUT_S = 20;
@@ -90,6 +90,7 @@ struct __attribute__((packed)) TouchCfg {
   uint8_t  nav_scroll_keys[2]; // keyboard-nav scroll keys (ASCII): scroll-up, scroll-down — v16 (trailing)
   uint8_t  notify_new_contact;// toast/chip when a contact is auto-discovered (bool) — v17 (trailing)
   uint8_t  show_sensors_tab;  // V4 Expansion Kit: show the Sensors tab + Home env widget (bool, default 1) — v19 (trailing)
+  uint8_t  map_show_links;    // show self->contact link lines on the map (bool, default 1) — v20 (trailing)
 };
 
 static TouchCfg s_cfg;
@@ -168,6 +169,7 @@ static void cfgSetDefaults(TouchCfg& c) {
 #endif
   c.notify_new_contact = 1;     // default: show the new-contact toast (preserve prior behaviour)
   c.show_sensors_tab   = 1;     // default: show the V4 Expansion-Kit Sensors tab + Home env widget
+  c.map_show_links     = 1;     // default: show self->contact link lines
 }
 
 // Persist the whole blob using the same end()/begin(RW)/put/end()/begin(RO)
@@ -825,6 +827,15 @@ bool touchPrefsGetMapShowContacts() {
 bool touchPrefsSetMapShowContacts(bool on) {
   if (!s_begun) touchPrefsBegin();
   s_cfg.map_show_contacts = on ? 1 : 0;
+  return cfgFlush();
+}
+bool touchPrefsGetMapShowLinks() {
+  if (!s_begun) touchPrefsBegin();
+  return s_cfg.map_show_links != 0;
+}
+bool touchPrefsSetMapShowLinks(bool on) {
+  if (!s_begun) touchPrefsBegin();
+  s_cfg.map_show_links = on ? 1 : 0;
   return cfgFlush();
 }
 bool touchPrefsGetAppGridLarge() {

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -98,6 +98,8 @@ bool touchPrefsGetMapShowTileXYZ();
 bool touchPrefsSetMapShowTileXYZ(bool on);
 bool touchPrefsGetMapShowContacts();
 bool touchPrefsSetMapShowContacts(bool on);
+bool touchPrefsGetMapShowLinks();
+bool touchPrefsSetMapShowLinks(bool on);
 
 /* App drawer: large grid (one fewer column → bigger icons + labels, for low vision).
  * Default false = the compact grid (T-Deck 4 cols / Heltec V4 3 cols). */

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -19362,6 +19362,9 @@ static void mapOptLinesCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
   lv_obj_t* sw = lv_event_get_target(e);
   s_map_show_links = lv_obj_has_state(sw, LV_STATE_CHECKED);
+#if defined(ESP32)
+  touchPrefsSetMapShowLinks(s_map_show_links);
+#endif
   renderMapMarkers();   // rebuild links to reflect the new state
 }
 
@@ -31294,6 +31297,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   s_map_show_coords   = touchPrefsGetMapShowCoords();     // per-element map text/marker visibility
   s_map_show_tilexyz  = touchPrefsGetMapShowTileXYZ();
   s_map_show_contacts = touchPrefsGetMapShowContacts();
+  s_map_show_links    = touchPrefsGetMapShowLinks();     // dotted self->contact link lines
   { const uint8_t pz = touchPrefsGetMapZoom();    // restore the last user-set map zoom
     if (pz >= k_map_zoom_min && pz <= k_map_zoom_max) s_map_zoom = pz; }
   s_map_zoom_buttons = touchPrefsGetMapZoomButtons();   // map zoom control: slider (default) vs +/- buttons


### PR DESCRIPTION
### Problem
In the map options popup, the **Show link lines** toggle did not survive a
reboot (hardware or software) — it always reverted to its default.

### Root cause
The four sibling map-option toggles (Show coordinates, Show tile z/x/y, Show
contacts, Night mode) persist via `TouchPrefsStore`, but the link-lines switch
only set the runtime `s_map_show_links` in `mapOptLinesCb` and never wrote a
pref, so the value was lost on every boot.

### Fix
- Add a trailing `map_show_links` field to `TouchCfg` (cfg **v20**, default `1`
  to preserve the current "links on" behaviour).
- Save it from `mapOptLinesCb` and load it at boot in `UITask::begin()`,
  mirroring the existing map toggles exactly.

Because the field is trailing and the loader is size-tolerant (defaults are
applied first, then the stored blob is copied over), existing configs migrate
cleanly — no settings are reset on update.

### Testing
Built for `LilyGo_TDeck_companion_radio_touch` and flashed on a T-Deck Plus.
Toggled **Show link lines**, rebooted (both soft and hard) — the setting is now
retained. Verified the other map options (coords / tile z-x-y / contacts /
night) still persist correctly across the v19→v20 migration.