### PR TITLE
ui-touch: custom WAV notification sounds (per-event: message / DM / @-mention)

### DIFF
--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -542,10 +542,12 @@ bool touchPrefsSetLockWallpaper(const char* path) {
 }
 
 static const char* soundFileKey(int slot) {
+  // Distinct from the on/off keys snd_msg/snd_dm/snd_men (those are uchar) —
+  // a uchar and a String must not share an NVS key.
   switch (slot) {
-    case TOUCH_SND_DM:  return "snd_dm";
-    case TOUCH_SND_MEN: return "snd_men";
-    default:            return "snd_msg";
+    case TOUCH_SND_DM:  return "sndf_dm";
+    case TOUCH_SND_MEN: return "sndf_men";
+    default:            return "sndf_msg";
   }
 }
 int touchPrefsGetSoundFile(int slot, char* out, int out_cap) {
@@ -1301,6 +1303,11 @@ bool touchPrefsGetSoundMentions() {
   return s_prefs.getUChar("snd_men", 1) != 0;
 }
 void touchPrefsSetSoundMentions(bool on) { if (!s_begun) touchPrefsBegin(); prefsPutUChar("snd_men", on ? 1 : 0); }
+bool touchPrefsGetSoundDirect() {
+  if (!s_begun) touchPrefsBegin();
+  return s_prefs.getUChar("snd_dm", 1) != 0;
+}
+void touchPrefsSetSoundDirect(bool on) { if (!s_begun) touchPrefsBegin(); prefsPutUChar("snd_dm", on ? 1 : 0); }
 bool touchPrefsGetDiscoveredAutoEvict() {
   if (!s_begun) touchPrefsBegin();
   return s_prefs.getUChar("dsc_evict", 1) != 0;

--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -541,6 +541,37 @@ bool touchPrefsSetLockWallpaper(const char* path) {
   return ok;
 }
 
+static const char* soundFileKey(int slot) {
+  switch (slot) {
+    case TOUCH_SND_DM:  return "snd_dm";
+    case TOUCH_SND_MEN: return "snd_men";
+    default:            return "snd_msg";
+  }
+}
+int touchPrefsGetSoundFile(int slot, char* out, int out_cap) {
+  if (!out || out_cap <= 0) return 0;
+  out[0] = '\0';
+  if (!s_begun) touchPrefsBegin();
+  String v = prefsGetStr(soundFileKey(slot), String(""));
+  int n = (int)v.length();
+  if (n > out_cap - 1) n = out_cap - 1;
+  if (n > TOUCH_SOUND_PATH_MAXLEN - 1) n = TOUCH_SOUND_PATH_MAXLEN - 1;
+  memcpy(out, v.c_str(), (size_t)n);
+  out[n] = '\0';
+  return n;
+}
+bool touchPrefsSetSoundFile(int slot, const char* path) {
+  if (!s_begun) touchPrefsBegin();
+  s_prefs.end();
+  if (!s_prefs.begin(TOUCH_NS, false)) return false;
+  bool ok;
+  if (!path || !path[0]) { s_prefs.remove(soundFileKey(slot)); ok = true; }   // empty => built-in chime
+  else                     ok = s_prefs.putString(soundFileKey(slot), path) > 0;
+  s_prefs.end();
+  s_begun = s_prefs.begin(TOUCH_NS, true);
+  return ok;
+}
+
 int touchPrefsGetTimeOffsetHours() {
   if (!s_begun) touchPrefsBegin();
   int v = (int)s_cfg.time_offs;

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -268,6 +268,8 @@ uint8_t touchPrefsGetDiscoveredMaxHops();      // auto-delete discovered nodes h
 void    touchPrefsSetDiscoveredMaxHops(uint8_t hops);
 bool    touchPrefsGetSoundMentions();          // default true
 void    touchPrefsSetSoundMentions(bool on);
+bool    touchPrefsGetSoundDirect();            // direct/DM chime on/off, default true
+void    touchPrefsSetSoundDirect(bool on);
 uint8_t touchPrefsGetSoundVolume();            // 0..100, default 70
 void    touchPrefsSetSoundVolume(uint8_t vol);
 

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -271,6 +271,14 @@ void    touchPrefsSetSoundMentions(bool on);
 uint8_t touchPrefsGetSoundVolume();            // 0..100, default 70
 void    touchPrefsSetSoundVolume(uint8_t vol);
 
+/** Per-event notification sound FILE (empty = built-in chime). Slot:
+ *  0 = message, 1 = direct/DM, 2 = @-mention. Stored as a path pref like the
+ *  lock wallpaper ("" | "/sounds/x.wav" | "sd:/x.wav"). T-Deck only. */
+enum { TOUCH_SND_MSG = 0, TOUCH_SND_DM = 1, TOUCH_SND_MEN = 2 };
+constexpr int TOUCH_SOUND_PATH_MAXLEN = 128;
+int  touchPrefsGetSoundFile(int slot, char* out, int out_cap);
+bool touchPrefsSetSoundFile(int slot, const char* path);
+
 /** Tanmatsu keyboard backlight brightness, 0–100 %. Default 100. Separate from
  *  screen brightness (touchPrefsGet/SetBrightness) and volume (…SoundVolume). */
 uint8_t touchPrefsGetKbdBacklight();

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -5769,6 +5769,13 @@ static void toggleMessageSoundCb(lv_event_t* e) {
   touchPrefsSetSoundMessages(on);
   if (on) uiSoundPreview();
 }
+// Direct/DM-sound switch (own on/off + own slot sound).
+static void toggleDirectSoundCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  const bool on = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
+  touchPrefsSetSoundDirect(on);
+  if (on) uiPlaySlot(TOUCH_SND_DM);
+}
 // @-mention-sound switch (distinct chime; lets you keep mentions on with messages off).
 static void toggleMentionSoundCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
@@ -8787,16 +8794,23 @@ static void buildDeviceSettings(int sec) {
     lv_obj_add_event_cb(sw, toggleBuzzerCb, LV_EVENT_VALUE_CHANGED, nullptr);
     y += LV_MAX(34, rh + 12);
   }
-  // Message sounds switch (under the master).
+  // Per-event on/off switches: Message, DM, @-mention (under the master Sound).
   {
-    int rh = settingsRowLabel(body, y, 6, "Messages", COLOR_SUB, nullptr, 56);
+    int rh = settingsRowLabel(body, y, 6, "Message sound", COLOR_SUB, nullptr, 56);
     lv_obj_t* sw = lv_switch_create(body);
     lv_obj_align(sw, LV_ALIGN_TOP_RIGHT, 0, y);
     if (touchPrefsGetSoundMessages()) lv_obj_add_state(sw, LV_STATE_CHECKED);
     lv_obj_add_event_cb(sw, toggleMessageSoundCb, LV_EVENT_VALUE_CHANGED, nullptr);
     y += LV_MAX(34, rh + 12);
   }
-  // @-mention sounds switch (distinct chime).
+  {
+    int rh = settingsRowLabel(body, y, 6, "DM sound", COLOR_SUB, nullptr, 56);
+    lv_obj_t* sw = lv_switch_create(body);
+    lv_obj_align(sw, LV_ALIGN_TOP_RIGHT, 0, y);
+    if (touchPrefsGetSoundDirect()) lv_obj_add_state(sw, LV_STATE_CHECKED);
+    lv_obj_add_event_cb(sw, toggleDirectSoundCb, LV_EVENT_VALUE_CHANGED, nullptr);
+    y += LV_MAX(34, rh + 12);
+  }
   {
     int rh = settingsRowLabel(body, y, 6, "@ mention sound", COLOR_SUB, nullptr, 56);
     lv_obj_t* sw = lv_switch_create(body);
@@ -15280,7 +15294,7 @@ static void fmSetWallpaperCb(lv_event_t* e) {
 static char      s_fm_snd_path[208] = {0};
 static bool      s_fm_snd_on_sd     = false;
 static lv_obj_t* s_fm_snd_root      = nullptr;
-static void fmSndClose() { if (s_fm_snd_root) { lv_obj_del(s_fm_snd_root); s_fm_snd_root = nullptr; } }
+static void fmSndClose() { if (s_fm_snd_root) { lv_obj_del_async(s_fm_snd_root); s_fm_snd_root = nullptr; } }
 static void fmSndCloseCb(lv_event_t* e) { if (lv_event_get_code(e) == LV_EVENT_CLICKED) fmSndClose(); }
 static void fmSndBuildPref(char* pref, int cap) {
   if (s_fm_snd_on_sd) snprintf(pref, cap, "sd:%s", s_fm_snd_path);
@@ -15298,11 +15312,9 @@ static void fmSndSetCb(lv_event_t* e) {
   if (!wavIsSupported(pref)) { if (g_lv.task) g_lv.task->showAlert(TR("Unsupported WAV (need 16-bit PCM)"), 2200); return; }
   int slot = s_snd_pending_slot; if (slot < 0 || slot > 2) slot = TOUCH_SND_MSG;
   touchPrefsSetSoundFile(slot, pref);
-  if (s_snd_btn_lbl[slot] && lv_obj_is_valid(s_snd_btn_lbl[slot])) {
-    char disp[48]; soundDisplayName(pref, disp, sizeof disp);
-    lv_label_set_text(s_snd_btn_lbl[slot], disp);
-  }
   fmSndClose();
+  closeFullscreenView();             // tear down the File Manager so closing Sound won't reveal it
+  openSettingsCategory(CAT_SOUND);   // back to Settings -> Sound, fresh (shows the new file)
   if (g_lv.task) g_lv.task->showAlert(TR("Notification sound set"), 1300);
 }
 static void fmOpenAudio(const char* name) {
@@ -33329,7 +33341,8 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
     const uint8_t cmute = channel ? touchPrefsGetChannelMute(thread) : 0;
     if (!isBuzzerQuiet()) {   // master Sound switch: off = silent, overrules everything
       if (is_mention && touchPrefsGetSoundMentions() && !(cmute & TOUCH_CHMUTE_MEN)) uiPlaySlot(TOUCH_SND_MEN);
-      else if (touchPrefsGetSoundMessages() && !(cmute & TOUCH_CHMUTE_MSG))          uiPlaySlot(is_dm ? TOUCH_SND_DM : TOUCH_SND_MSG);
+      else if (is_dm) { if (touchPrefsGetSoundDirect()) uiPlaySlot(TOUCH_SND_DM); }
+      else if (touchPrefsGetSoundMessages() && !(cmute & TOUCH_CHMUTE_MSG))          uiPlaySlot(TOUCH_SND_MSG);
     }
   }
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -492,7 +492,8 @@ extern volatile uint16_t s_tile_fetch_pending;
 // Holding the driver resident permanently kept ~2 KB of internal DMA RAM, which
 // shrank the margin the tile-fetch worker relies on and made tile downloads
 // OOM-reboot. Transient install keeps steady-state internal RAM untouched.
-static bool tdeckAudioInstall() {
+static bool fmSdTryMount();   // defined far below (microSD mount, T-Deck)
+static bool tdeckAudioInstallRate(int rate) {
   // Heap pre-flight. i2s_driver_install ESP_ERROR_CHECKs its internal DMA + timer
   // allocations and abort()s the firmware on NO_MEM — this is the "esp_timer_create
   // ESP_ERR_NO_MEM" crash testers hit toggling sound while BLE + Wi-Fi are both up
@@ -501,7 +502,7 @@ static bool tdeckAudioInstall() {
   if (heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT) < 16 * 1024) return false;
   i2s_config_t cfg = {};
   cfg.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
-  cfg.sample_rate = kI2sSampleRate;
+  cfg.sample_rate = rate;
   cfg.bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT;
   cfg.channel_format = I2S_CHANNEL_FMT_ONLY_LEFT;   // MAX98357A is mono
   cfg.communication_format = I2S_COMM_FORMAT_STAND_I2S;
@@ -520,6 +521,7 @@ static bool tdeckAudioInstall() {
   if (i2s_set_pin(kI2sPort, &pins) != ESP_OK) { i2s_driver_uninstall(kI2sPort); return false; }
   return true;
 }
+static bool tdeckAudioInstall() { return tdeckAudioInstallRate(kI2sSampleRate); }
 
 // Render `freq` Hz for `ms` ms into the already-installed I2S as a 16-bit sine
 // with a short fade-in/out so it doesn't click.
@@ -546,22 +548,104 @@ static void tdeckPlayToneRaw(int freq, int ms, int vol = 9000) {
   i2s_zero_dma_buffer(kI2sPort);
 }
 
+// ---- Custom WAV notification playback (T-Deck I2S) -------------------------
+// Stream a small PCM WAV (internal SPIFFS or "sd:"-prefixed SD) straight to the
+// amp. Supports PCM 16-bit, mono or stereo (downmixed to the mono amp), sample
+// rate read from the header; capped to ~6 s so a stray big file can't hold the
+// notify task. Any problem -> false, and the caller falls back to the chime.
+static uint32_t wavRd32(File& f){ uint8_t b[4]; if(f.read(b,4)!=4) return 0; return (uint32_t)b[0]|((uint32_t)b[1]<<8)|((uint32_t)b[2]<<16)|((uint32_t)b[3]<<24); }
+static uint16_t wavRd16(File& f){ uint8_t b[2]; if(f.read(b,2)!=2) return 0; return (uint16_t)(b[0]|(b[1]<<8)); }
+static bool wavParse(File& f, uint16_t* pch, uint32_t* prate, uint32_t* pdata) {
+  char tag[4];
+  if (f.read((uint8_t*)tag,4)!=4 || memcmp(tag,"RIFF",4)) return false;
+  wavRd32(f);
+  if (f.read((uint8_t*)tag,4)!=4 || memcmp(tag,"WAVE",4)) return false;
+  uint16_t fmt=0, ch=0, bits=0; uint32_t rate=0, dlen=0; bool hf=false, hd=false;
+  while (f.available() >= 8) {
+    if (f.read((uint8_t*)tag,4)!=4) break;
+    uint32_t csz = wavRd32(f);
+    if (!memcmp(tag,"fmt ",4)) {
+      fmt = wavRd16(f); ch = wavRd16(f); rate = wavRd32(f); wavRd32(f); wavRd16(f); bits = wavRd16(f);
+      if (csz > 16) f.seek(f.position() + (csz - 16));
+      hf = true;
+    } else if (!memcmp(tag,"data",4)) { dlen = csz; hd = true; break; }
+    else f.seek(f.position() + csz + (csz & 1));
+  }
+  if (!hf || !hd || fmt != 1 || bits != 16 || (ch != 1 && ch != 2) || rate < 8000 || rate > 48000)
+    return false;
+  if (pch) *pch = ch; if (prate) *prate = rate; if (pdata) *pdata = dlen;
+  return true;
+}
+static bool wavOpen(const char* prefpath, File& f) {
+  if (!prefpath || !prefpath[0]) return false;
+  fs::FS* fsp = &SPIFFS; const char* fp = prefpath;
+  if (!strncmp(prefpath, "sd:", 3)) { fsp = &SD; fp = prefpath + 3; fmSdTryMount(); }
+  f = fsp->open(fp, FILE_READ);
+  if (!f || f.isDirectory()) { if (f) f.close(); return false; }
+  return true;
+}
+static bool wavIsSupported(const char* prefpath) {
+  File f; if (!wavOpen(prefpath, f)) return false;
+  bool ok = wavParse(f, nullptr, nullptr, nullptr);
+  f.close();
+  return ok;
+}
+static bool tdeckPlayWavFile(const char* prefpath, int vol) {
+  File f; if (!wavOpen(prefpath, f)) return false;
+  uint16_t ch=0; uint32_t rate=0, dlen=0;
+  if (!wavParse(f, &ch, &rate, &dlen)) { f.close(); return false; }
+  const uint32_t frameBytes = (uint32_t)ch * 2u;
+  const uint32_t maxBytes = rate * frameBytes * 6u;   // ~6 s cap
+  if (dlen > maxBytes) dlen = maxBytes;
+  if (!tdeckAudioInstallRate((int)rate)) { f.close(); return false; }
+  const float gain = (float)vol / 13000.0f;
+  int16_t in[256], out[256];
+  uint32_t remaining = dlen;
+  while (remaining >= frameBytes) {
+    size_t want = sizeof(in);
+    if (want > remaining) want = remaining - (remaining % frameBytes);
+    int got = f.read((uint8_t*)in, want);
+    if (got <= 0) break;
+    int frames = got / (int)frameBytes;
+    for (int i = 0; i < frames; ++i) {
+      int32_t smp = (ch == 2) ? (((int32_t)in[2*i] + in[2*i+1]) / 2) : in[i];
+      smp = (int32_t)(smp * gain);
+      if (smp > 32767) smp = 32767; else if (smp < -32768) smp = -32768;
+      out[i] = (int16_t)smp;
+    }
+    size_t bw = 0;
+    i2s_write(kI2sPort, out, (size_t)frames * sizeof(int16_t), &bw, pdMS_TO_TICKS(300));
+    remaining -= (uint32_t)got;
+  }
+  i2s_zero_dma_buffer(kI2sPort);
+  i2s_driver_uninstall(kI2sPort);
+  f.close();
+  return true;
+}
+
 static volatile bool s_notify_playing = false;
-static volatile bool s_notify_mention = false;   // play the @-mention pattern this round
+static volatile int  s_notify_slot    = TOUCH_SND_MSG;   // which per-event sound to play this round
 static volatile int  s_notify_vol     = 9000;    // amplitude, scaled from the volume pref
 // The chime body: install I2S, play the notes, uninstall. ~300 ms of blocking
 // i2s_write + driver setup/teardown — run on its own throwaway task (below).
 static void tdeckNotifyTaskFn(void* arg) {
   (void)arg;
-  if (tdeckAudioInstall()) {
-    const int v = s_notify_vol;
-    if (s_notify_mention) {              // @-mention: a brighter 3-note rising arpeggio
-      tdeckPlayToneRaw(1318, 70,  v);    // E6
-      tdeckPlayToneRaw(1760, 70,  v);    // A6
-      tdeckPlayToneRaw(2349, 130, v);    // D7
-    } else {                            // message: the two-note chime
-      tdeckPlayToneRaw(880,  90,  v);    // A5
-      tdeckPlayToneRaw(1318, 110, v);    // E6
+  const int v = s_notify_vol;
+  // Custom WAV for this slot (if set + valid) — installs/uninstalls I2S itself.
+  char path[TOUCH_SOUND_PATH_MAXLEN];
+  touchPrefsGetSoundFile(s_notify_slot, path, sizeof path);
+  bool played = (path[0] && tdeckPlayWavFile(path, v));
+  if (!played && tdeckAudioInstall()) {         // built-in chime fallback (distinct per slot)
+    if (s_notify_slot == TOUCH_SND_MEN) {        // @-mention: bright 3-note rising arpeggio
+      tdeckPlayToneRaw(1318, 70,  v);            // E6
+      tdeckPlayToneRaw(1760, 70,  v);            // A6
+      tdeckPlayToneRaw(2349, 130, v);            // D7
+    } else if (s_notify_slot == TOUCH_SND_DM) {  // direct message: distinct rising fifth
+      tdeckPlayToneRaw(1047, 90,  v);            // C6
+      tdeckPlayToneRaw(1568, 120, v);            // G6
+    } else {                                     // message: the original two-note chime
+      tdeckPlayToneRaw(880,  90,  v);            // A5
+      tdeckPlayToneRaw(1318, 110, v);            // E6
     }
     i2s_driver_uninstall(kI2sPort);
   }
@@ -574,13 +658,14 @@ static void tdeckNotifyTaskFn(void* arg) {
 // playing synchronously locked the screen for the whole chime. Skips while tiles
 // download (DMA-RAM contention → reboot) and won't stack itself. Caller checks the
 // sound pref.
-static void tdeckPlayNotify(bool mention) {
+static void tdeckPlayNotifySlot(int slot) {
   if (s_tile_fetch_pending > 0) return;   // don't fight the Wi-Fi/tile DMA buffers
   if (s_notify_playing) return;           // already chiming — don't stack tasks/I2S
-  s_notify_mention = mention;
+  s_notify_slot = slot;
   s_notify_vol = (int)touchPrefsGetSoundVolume() * 130;   // 0..100 -> 0..13000 amplitude
   s_notify_playing = true;
-  if (xTaskCreate(tdeckNotifyTaskFn, "notify", 4096, nullptr, 3, nullptr) != pdPASS) {
+  // bigger stack than the tone-only chime: WAV path uses a File handle + buffers.
+  if (xTaskCreate(tdeckNotifyTaskFn, "notify", 8192, nullptr, 3, nullptr) != pdPASS) {
     s_notify_playing = false;             // couldn't spawn (low DRAM) — skip the chime
   }
 }
@@ -630,25 +715,19 @@ static void v4BuzzerBeep(bool mention) {
 static void tanBeep();   // I2S notification tick; defined far below (with the CC volume slider)
 #endif
 // Play the platform's notification chime. Caller checks the buzzer/sound pref.
-static inline void uiPlayNotify() {
+static inline void uiPlaySlot(int slot) {
 #if defined(HAS_TDECK_GT911)
-  tdeckPlayNotify(false);
+  tdeckPlayNotifySlot(slot);
 #elif defined(HELTEC_V4_BUZZER_PIN)
-  v4BuzzerBeep(false);
+  v4BuzzerBeep(slot == TOUCH_SND_MEN);   // mention = higher trill; msg/DM = the lower chime
 #elif defined(HAS_TANMATSU)
-  tanBeep();   // I2S codec tick (same path as the volume-preview beep the user confirmed works)
+  tanBeep();   // single codec tick on these boards (no per-slot sounds)
 #endif
+  (void)slot;
 }
-// Play the distinct @-mention chime.
-static inline void uiPlayMention() {
-#if defined(HAS_TDECK_GT911)
-  tdeckPlayNotify(true);
-#elif defined(HELTEC_V4_BUZZER_PIN)
-  v4BuzzerBeep(true);
-#elif defined(HAS_TANMATSU)
-  tanBeep();   // no distinct mention chime on the Tanmatsu yet — same tick
-#endif
-}
+// Notification chimes. uiPlayNotify = generic message slot; uiPlayMention = @-mention slot.
+static inline void uiPlayNotify()  { uiPlaySlot(TOUCH_SND_MSG); }
+static inline void uiPlayMention() { uiPlaySlot(TOUCH_SND_MEN); }
 
 #if defined(HAS_TANMATSU)
 // Defined in the HAS_TANMATSU apply block far below; forward-declared so the

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -33117,10 +33117,11 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
   // sounds but still hear @-mentions. Each respects the per-channel mute flags.
   {
     const bool is_mention = channel && text && textMentionsMe(text);
+    const bool is_dm = (g_last_event == UIEventType::contactMessage);   // private/direct message
     const uint8_t cmute = channel ? touchPrefsGetChannelMute(thread) : 0;
     if (!isBuzzerQuiet()) {   // master Sound switch: off = silent, overrules everything
-      if (is_mention && touchPrefsGetSoundMentions() && !(cmute & TOUCH_CHMUTE_MEN)) uiPlayMention();
-      else if (touchPrefsGetSoundMessages() && !(cmute & TOUCH_CHMUTE_MSG))          uiPlayNotify();
+      if (is_mention && touchPrefsGetSoundMentions() && !(cmute & TOUCH_CHMUTE_MEN)) uiPlaySlot(TOUCH_SND_MEN);
+      else if (touchPrefsGetSoundMessages() && !(cmute & TOUCH_CHMUTE_MSG))          uiPlaySlot(is_dm ? TOUCH_SND_DM : TOUCH_SND_MSG);
     }
   }
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -625,6 +625,7 @@ static bool tdeckPlayWavFile(const char* prefpath, int vol) {
 
 static volatile bool s_notify_playing = false;
 static volatile int  s_notify_slot    = TOUCH_SND_MSG;   // which per-event sound to play this round
+static char          s_notify_path[TOUCH_SOUND_PATH_MAXLEN] = {0};   // caller-resolved WAV path (avoid NVS in the task)
 static volatile int  s_notify_vol     = 9000;    // amplitude, scaled from the volume pref
 // The chime body: install I2S, play the notes, uninstall. ~300 ms of blocking
 // i2s_write + driver setup/teardown — run on its own throwaway task (below).
@@ -632,9 +633,9 @@ static void tdeckNotifyTaskFn(void* arg) {
   (void)arg;
   const int v = s_notify_vol;
   // Custom WAV for this slot (if set + valid) — installs/uninstalls I2S itself.
-  char path[TOUCH_SOUND_PATH_MAXLEN];
-  touchPrefsGetSoundFile(s_notify_slot, path, sizeof path);
-  bool played = (path[0] && tdeckPlayWavFile(path, v));
+  // Path was resolved on the caller thread (s_notify_path) to keep NVS access
+  // off this short-lived task.
+  bool played = (s_notify_path[0] && tdeckPlayWavFile(s_notify_path, v));
   if (!played && tdeckAudioInstall()) {         // built-in chime fallback (distinct per slot)
     if (s_notify_slot == TOUCH_SND_MEN) {        // @-mention: bright 3-note rising arpeggio
       tdeckPlayToneRaw(1318, 70,  v);            // E6
@@ -663,11 +664,23 @@ static void tdeckPlayNotifySlot(int slot) {
   if (s_notify_playing) return;           // already chiming — don't stack tasks/I2S
   s_notify_slot = slot;
   s_notify_vol = (int)touchPrefsGetSoundVolume() * 130;   // 0..100 -> 0..13000 amplitude
+  touchPrefsGetSoundFile(slot, s_notify_path, sizeof s_notify_path);   // resolve here, not in the task
   s_notify_playing = true;
   // bigger stack than the tone-only chime: WAV path uses a File handle + buffers.
   if (xTaskCreate(tdeckNotifyTaskFn, "notify", 8192, nullptr, 3, nullptr) != pdPASS) {
     s_notify_playing = false;             // couldn't spawn (low DRAM) — skip the chime
   }
+}
+// Preview an arbitrary WAV (not yet saved to a slot) on the notify task.
+static void tdeckPreviewWavFile(const char* prefpath) {
+  if (s_tile_fetch_pending > 0 || s_notify_playing) return;
+  strncpy(s_notify_path, prefpath, sizeof s_notify_path - 1);
+  s_notify_path[sizeof s_notify_path - 1] = '\0';
+  s_notify_slot = TOUCH_SND_MSG;          // if the file fails, the task plays the msg chime
+  s_notify_vol  = (int)touchPrefsGetSoundVolume() * 130;
+  s_notify_playing = true;
+  if (xTaskCreate(tdeckNotifyTaskFn, "notify", 8192, nullptr, 3, nullptr) != pdPASS)
+    s_notify_playing = false;
 }
 #endif  // HAS_TDECK_GT911
 
@@ -8658,6 +8671,13 @@ static void lockwallDisplayName(const char* path, char* out, int cap) {
   snprintf(out, cap, "%s%s", sd ? "SD: " : "", base);
 }
 static void openLockWallPickerCb(lv_event_t* e);   // defined with the picker, below
+#if defined(HAS_TDECK_GT911)
+// Per-event notification-sound picker (Settings -> Sound). Mirrors the wallpaper picker.
+static lv_obj_t* s_snd_btn_lbl[3] = { nullptr, nullptr, nullptr };
+static int  s_snd_pending_slot = TOUCH_SND_MSG;    // slot we're choosing a sound for
+static void soundDisplayName(const char* path, char* out, int cap);
+static void openSoundPickerCb(lv_event_t* e);      // defined with the chooser, below
+#endif
 static void lockColorChosenCb(lv_event_t* e);
 #endif
 
@@ -8785,6 +8805,33 @@ static void buildDeviceSettings(int sec) {
     lv_obj_add_event_cb(sw, toggleMentionSoundCb, LV_EVENT_VALUE_CHANGED, nullptr);
     y += LV_MAX(34, rh + 12);
   }
+#if defined(HAS_TDECK_GT911)
+  // Per-event notification sound files. Each slot: built-in chime, or a 16-bit
+  // PCM WAV from /sounds/ (internal) or the SD card. Empty = built-in.
+  {
+    static const char* const kSndRowLbl[3] = { "Message sound", "Direct (DM) sound", "@ mention sound" };
+    for (int slot = 0; slot < 3; ++slot) {
+      y += settingsRowLabel(body, y, 0, kSndRowLbl[slot], COLOR_SUB, &g_font_12, 0) + 2;
+      lv_obj_t* b = lv_btn_create(body);
+      lv_obj_set_size(b, lv_pct(100), SC(34));
+      lv_obj_set_pos(b, 2, y);
+      styleButton(b);
+      lv_obj_add_event_cb(b, openSoundPickerCb, LV_EVENT_CLICKED, (void*)(intptr_t)slot);
+      s_snd_btn_lbl[slot] = lv_label_create(b);
+      {
+        char cur[TOUCH_SOUND_PATH_MAXLEN], disp[48];
+        touchPrefsGetSoundFile(slot, cur, sizeof cur);
+        soundDisplayName(cur, disp, sizeof disp);
+        lv_label_set_text(s_snd_btn_lbl[slot], disp);
+      }
+      lv_label_set_long_mode(s_snd_btn_lbl[slot], LV_LABEL_LONG_DOT);
+      lv_obj_set_width(s_snd_btn_lbl[slot], lv_pct(92));
+      lv_obj_set_style_text_align(s_snd_btn_lbl[slot], LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+      lv_obj_center(s_snd_btn_lbl[slot]);
+      y += SC(40);
+    }
+  }
+#endif
 #if defined(HAS_TDECK_GT911) || defined(HAS_TANMATSU)
   // Volume with - / + step buttons (T-Deck I2S + Tanmatsu codec; the V4 piezo can't vary volume).
   {
@@ -15065,6 +15112,13 @@ static bool fmIsImage(const char* name) {
          !strcasecmp(dot, ".jpeg") || !strcasecmp(dot, ".sjpg") ||
          !strcasecmp(dot, ".bmp");
 }
+#if defined(HAS_TDECK_GT911)
+static bool fmIsAudio(const char* name) {
+  if (!name) return false;
+  const char* dot = strrchr(name, '.');
+  return dot && !strcasecmp(dot, ".wav");
+}
+#endif
 
 // Defined further down (with the map tile code); used here by the image viewer.
 static uint8_t* decodeJpegToRgb565(const uint8_t* jpeg, size_t jpeg_len,
@@ -15220,6 +15274,85 @@ static void fmSetWallpaperCb(lv_event_t* e) {
   fmImageClose();
   if (g_lv.task) g_lv.task->showAlert(TR("Lock wallpaper set"), 1300);
 }
+
+#if defined(HAS_TDECK_GT911)
+// ---- .wav -> notification-sound chooser (opened from the File Manager) ------
+static char      s_fm_snd_path[208] = {0};
+static bool      s_fm_snd_on_sd     = false;
+static lv_obj_t* s_fm_snd_root      = nullptr;
+static void fmSndClose() { if (s_fm_snd_root) { lv_obj_del(s_fm_snd_root); s_fm_snd_root = nullptr; } }
+static void fmSndCloseCb(lv_event_t* e) { if (lv_event_get_code(e) == LV_EVENT_CLICKED) fmSndClose(); }
+static void fmSndBuildPref(char* pref, int cap) {
+  if (s_fm_snd_on_sd) snprintf(pref, cap, "sd:%s", s_fm_snd_path);
+  else                snprintf(pref, cap, "%s", s_fm_snd_path);
+}
+static void fmSndPlayCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED || !s_fm_snd_path[0]) return;
+  char pref[TOUCH_SOUND_PATH_MAXLEN]; fmSndBuildPref(pref, sizeof pref);
+  if (!wavIsSupported(pref)) { if (g_lv.task) g_lv.task->showAlert(TR("Unsupported WAV (need 16-bit PCM)"), 2200); return; }
+  tdeckPreviewWavFile(pref);
+}
+static void fmSndSetCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED || !s_fm_snd_path[0]) return;
+  char pref[TOUCH_SOUND_PATH_MAXLEN]; fmSndBuildPref(pref, sizeof pref);
+  if (!wavIsSupported(pref)) { if (g_lv.task) g_lv.task->showAlert(TR("Unsupported WAV (need 16-bit PCM)"), 2200); return; }
+  int slot = s_snd_pending_slot; if (slot < 0 || slot > 2) slot = TOUCH_SND_MSG;
+  touchPrefsSetSoundFile(slot, pref);
+  if (s_snd_btn_lbl[slot] && lv_obj_is_valid(s_snd_btn_lbl[slot])) {
+    char disp[48]; soundDisplayName(pref, disp, sizeof disp);
+    lv_label_set_text(s_snd_btn_lbl[slot], disp);
+  }
+  fmSndClose();
+  if (g_lv.task) g_lv.task->showAlert(TR("Notification sound set"), 1300);
+}
+static void fmOpenAudio(const char* name) {
+  if (!s_fm_fs || !name || !name[0]) return;
+  fmMarkSdIo();
+  char path[208]; fmFullPath(name, path, sizeof path);
+  strncpy(s_fm_snd_path, path, sizeof s_fm_snd_path - 1);
+  s_fm_snd_path[sizeof s_fm_snd_path - 1] = '\0';
+  s_fm_snd_on_sd = fmIsSd(s_fm_fs);
+  fmSndClose();
+  const lv_coord_t sw = lv_disp_get_hor_res(nullptr);
+  const lv_coord_t sh = lv_disp_get_ver_res(nullptr);
+  s_fm_snd_root = lv_obj_create(lv_layer_top());
+  lv_obj_remove_style_all(s_fm_snd_root);
+  lv_obj_set_size(s_fm_snd_root, sw, sh - STATUSBAR_H);
+  lv_obj_set_pos(s_fm_snd_root, 0, STATUSBAR_H);
+  lv_obj_set_style_bg_color(s_fm_snd_root, lv_color_hex(COLOR_BG), LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(s_fm_snd_root, LV_OPA_COVER, LV_PART_MAIN);
+  lv_obj_clear_flag(s_fm_snd_root, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_t* fn = lv_label_create(s_fm_snd_root);
+  lv_label_set_long_mode(fn, LV_LABEL_LONG_DOT);
+  lv_obj_set_pos(fn, 8, 10); lv_obj_set_width(fn, sw - 16);
+  lv_label_set_text(fn, name);
+  lv_obj_set_style_text_font(fn, &g_font_16, LV_PART_MAIN);
+  lv_obj_set_style_text_color(fn, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
+  static const char* const kSlot[3] = { "Message", "Direct (DM)", "@ mention" };
+  lv_obj_t* sub = lv_label_create(s_fm_snd_root);
+  char subt[56]; snprintf(subt, sizeof subt, "Target: %s sound",
+                          kSlot[(s_snd_pending_slot >= 0 && s_snd_pending_slot < 3) ? s_snd_pending_slot : 0]);
+  lv_label_set_text(sub, subt);
+  lv_obj_set_pos(sub, 8, 40);
+  lv_obj_set_style_text_font(sub, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_style_text_color(sub, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_t* play = lv_btn_create(s_fm_snd_root);
+  lv_obj_set_size(play, sw - 16, 40); lv_obj_set_pos(play, 8, 76); styleButton(play);
+  lv_obj_add_event_cb(play, fmSndPlayCb, LV_EVENT_CLICKED, nullptr);
+  lv_obj_t* pl = lv_label_create(play); lv_label_set_text(pl, LV_SYMBOL_PLAY "  Play"); lv_obj_center(pl);
+  lv_obj_t* setb = lv_btn_create(s_fm_snd_root);
+  lv_obj_set_size(setb, sw - 16, 44); lv_obj_set_pos(setb, 8, 124); styleButton(setb);
+  lv_obj_set_style_bg_color(setb, lv_color_hex(0x35C9C9), LV_PART_MAIN);
+  lv_obj_add_event_cb(setb, fmSndSetCb, LV_EVENT_CLICKED, nullptr);
+  lv_obj_t* sl = lv_label_create(setb); lv_label_set_text(sl, LV_SYMBOL_OK "  Set as notification sound");
+  lv_obj_set_style_text_color(sl, lv_color_black(), LV_PART_MAIN); lv_obj_center(sl);
+  lv_obj_t* close = lv_btn_create(s_fm_snd_root);
+  lv_obj_set_size(close, 30, 26); lv_obj_align(close, LV_ALIGN_TOP_RIGHT, -6, 6); styleButton(close);
+  lv_obj_add_event_cb(close, fmSndCloseCb, LV_EVENT_CLICKED, nullptr);
+  lv_obj_t* cl = lv_label_create(close); lv_label_set_text(cl, LV_SYMBOL_CLOSE); tanCloseRed(cl);
+  lv_obj_set_style_text_font(cl, &g_font_12, LV_PART_MAIN); lv_obj_center(cl);
+}
+#endif  // HAS_TDECK_GT911 (.wav notification-sound chooser)
 
 static void fmOpenImage(const char* name) {
   if (!s_fm_fs || !name || !name[0]) return;
@@ -15377,6 +15510,9 @@ static void fmRowClickCb(lv_event_t* e) {
   FmRowData* rd = (FmRowData*)lv_obj_get_user_data(lv_event_get_target(e));
   if (!rd) return;
   if (rd->isdir)                fmEnterDir(rd->name);
+#if defined(HAS_TDECK_GT911)
+  else if (fmIsAudio(rd->name)) fmOpenAudio(rd->name);   // .wav -> notification-sound chooser
+#endif
   else if (fmIsImage(rd->name)) fmOpenImage(rd->name);   // images -> read-only viewer
   else                          fmOpenEditor(rd->name);  // text -> editor; long-press -> manage
 }
@@ -24333,6 +24469,78 @@ static void serviceLockscreen() {
 #if defined(HAS_TDECK_KEYBOARD)   // re-enter the keyboard block the lock screen was carved out of
 #if defined(HAS_TDECK_GT911)   // wallpaper picker is SD/SPIFFS-backed -> T-Deck only
 // ---- Lock-screen wallpaper picker (lists JPEGs in internal /lock/ + SD) ----
+// ---- Notification-sound chooser (Settings -> Sound) ------------------------
+// Tapping a slot button opens a small menu: "Choose .wav from files" (opens the
+// File Manager, exactly like the wallpaper picker; opening a .wav there offers
+// "Set as notification sound"), or "Built-in (default)" to reset to the chime.
+static void soundDisplayName(const char* path, char* out, int cap) {
+  if (!out || cap <= 0) return;
+  if (!path || !path[0]) { snprintf(out, cap, "Built-in"); return; }
+  const bool sd = !strncmp(path, "sd:", 3);
+  const char* p = sd ? path + 3 : path;
+  const char* base = strrchr(p, '/'); base = base ? base + 1 : p;
+  snprintf(out, cap, sd ? "SD: %s" : "%s", base);
+}
+static lv_obj_t* s_snd_menu = nullptr;
+static void sndMenuClose() { if (s_snd_menu) { lv_obj_del(s_snd_menu); s_snd_menu = nullptr; } }
+static void sndMenuCloseCb(lv_event_t* e) { if (lv_event_get_code(e) == LV_EVENT_CLICKED) sndMenuClose(); }
+static void sndMenuBuiltinCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
+  int slot = s_snd_pending_slot; if (slot < 0 || slot > 2) slot = TOUCH_SND_MSG;
+  touchPrefsSetSoundFile(slot, "");
+  if (s_snd_btn_lbl[slot] && lv_obj_is_valid(s_snd_btn_lbl[slot]))
+    lv_label_set_text(s_snd_btn_lbl[slot], TR("Built-in"));
+  sndMenuClose();
+  tdeckPlayNotifySlot(slot);     // preview the built-in chime
+}
+static void sndMenuFilesCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
+  sndMenuClose();
+  lv_obj_t* body = openFullscreenView("Files");
+  buildFileManager(body);
+  if (g_lv.task) g_lv.task->showAlert(TR("Open a .wav, then tap 'Set as notification sound'"), 2800);
+}
+static void openSoundMenu(int slot) {
+  s_snd_pending_slot = slot;
+  sndMenuClose();
+  const lv_coord_t sw = lv_disp_get_hor_res(nullptr);
+  const lv_coord_t sh = lv_disp_get_ver_res(nullptr);
+  const lv_coord_t pw = (sw * 82) / 100, ph = 168;
+  s_snd_menu = lv_obj_create(lv_layer_top());
+  lv_obj_remove_style_all(s_snd_menu);
+  lv_obj_set_size(s_snd_menu, pw, ph);
+  lv_obj_set_pos(s_snd_menu, (sw - pw) / 2, STATUSBAR_H + (sh - STATUSBAR_H - ph) / 2);
+  lv_obj_set_style_bg_color(s_snd_menu, lv_color_hex(COLOR_BG), LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(s_snd_menu, LV_OPA_COVER, LV_PART_MAIN);
+  lv_obj_set_style_radius(s_snd_menu, 8, LV_PART_MAIN);
+  lv_obj_set_style_border_width(s_snd_menu, 1, LV_PART_MAIN);
+  lv_obj_set_style_border_color(s_snd_menu, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_clear_flag(s_snd_menu, LV_OBJ_FLAG_SCROLLABLE);
+  static const char* const kSlot[3] = { "Message", "Direct (DM)", "@ mention" };
+  lv_obj_t* title = lv_label_create(s_snd_menu);
+  char tt[40]; snprintf(tt, sizeof tt, "%s sound", kSlot[(slot >= 0 && slot < 3) ? slot : 0]);
+  lv_label_set_text(title, tt);
+  lv_obj_set_style_text_font(title, &g_font_16, LV_PART_MAIN);
+  lv_obj_set_style_text_color(title, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
+  lv_obj_set_pos(title, 12, 12);
+  lv_obj_t* bf = lv_btn_create(s_snd_menu);
+  lv_obj_set_size(bf, pw - 24, 40); lv_obj_set_pos(bf, 12, 44); styleButton(bf);
+  lv_obj_add_event_cb(bf, sndMenuFilesCb, LV_EVENT_CLICKED, nullptr);
+  lv_obj_t* lf = lv_label_create(bf); lv_label_set_text(lf, LV_SYMBOL_DIRECTORY "  Choose .wav from files"); lv_obj_center(lf);
+  lv_obj_t* bb = lv_btn_create(s_snd_menu);
+  lv_obj_set_size(bb, pw - 24, 40); lv_obj_set_pos(bb, 12, 92); styleButton(bb);
+  lv_obj_add_event_cb(bb, sndMenuBuiltinCb, LV_EVENT_CLICKED, nullptr);
+  lv_obj_t* lb = lv_label_create(bb); lv_label_set_text(lb, TR("Built-in (default)")); lv_obj_center(lb);
+  lv_obj_t* close = lv_btn_create(s_snd_menu);
+  lv_obj_set_size(close, 30, 26); lv_obj_align(close, LV_ALIGN_TOP_RIGHT, -6, 6); styleButton(close);
+  lv_obj_add_event_cb(close, sndMenuCloseCb, LV_EVENT_CLICKED, nullptr);
+  lv_obj_t* cl = lv_label_create(close); lv_label_set_text(cl, LV_SYMBOL_CLOSE); tanCloseRed(cl);
+  lv_obj_set_style_text_font(cl, &g_font_12, LV_PART_MAIN); lv_obj_center(cl);
+}
+static void openSoundPickerCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
+  openSoundMenu((int)(intptr_t)lv_event_get_user_data(e));
+}
 static lv_obj_t* s_lockwall_picker = nullptr;
 static char s_lockwall_paths[24][TOUCH_LOCK_WALLPAPER_MAXLEN];
 static int  s_lockwall_count = 0;


### PR DESCRIPTION
### What
Adds custom notification sounds on the T-Deck, configured in Settings → Sound.
Each event — **message**, **direct (DM)**, **@-mention** — can use the built-in
chime or a user-supplied **WAV** picked from the File Manager.

### Settings → Sound
- Master **Sound** switch, then independent on/off for **Message**, **DM**, and
  **@ mention** (DM previously rode the Messages switch; it now has its own).
- Three sound-file rows. Tapping one offers **Choose .wav from files** (opens the
  File Manager — opening a `.wav` shows **Play** + **Set as notification sound**,
  mirroring the wallpaper picker) or **Built-in (default)**.
- After setting from the File Manager, it returns to Settings → Sound.

### Playback
- New `tdeckPlayWavFile`: streams a PCM **16-bit**, mono/stereo (downmixed) WAV
  from internal flash or the SD card straight to the I2S amp; sample rate is read
  from the header; capped to ~6 s. Unsupported files are rejected at selection,
  and any failure falls back to the built-in chime.
- Built-in chimes are distinct per event (message, DM, @-mention).
- Routing distinguishes DM (`contactMessage`) from channel/room messages.

### Storage
Per-event file paths and the new DM on/off are stored as their own prefs
(`sndf_*` for files — kept separate from the `snd_*` on/off keys).

### Safety
File browsing reuses the File Manager (one directory at a time) rather than a
recursive SD walk — nested directory handles on the shared LoRa SPI bus would
deadlock the UI. V4 (piezo) and Tanmatsu keep the built-in chimes; the WAV
picker is T-Deck only.

### Testing
Based on current `main` (`1e00ac3`, beta_19), built for
`LilyGo_TDeck_companion_radio_touch` and flashed on a T-Deck Plus. Verified:
picking/playing WAVs per event from the SD card, return to Settings → Sound and
clean exit afterwards, the four independent on/off switches, DM vs channel vs
@-mention routing, built-in fallback, and rejection of non-16-bit-PCM files.