### PR TITLE
feat(mqtt): MQTT bridge — publish mesh messages to broker over WiFi

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ board_build.partitions = partitions_tft_touch.csv
 extra_scripts = pre:scripts/inject_wifi_env.py, merge-bin.py
 
 build_flags =
+  -pipe
   -Wno-deprecated-declarations -Wno-unused-parameter -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
   -D MC_VENDORED_TOUCH_APP
   ; NOTE: tried -D ARDUINO_USB_MODE=1 (HW-CDC, drops unused TinyUSB MSC/DFU ≈ 12 KB internal
@@ -209,6 +210,7 @@ lib_deps =
   lvgl/lvgl @ ^8.3.11
   bodmer/TFT_eSPI @ ^2.5.43
   densaugeo/base64 @ ~1.4.0
+  knolleary/PubSubClient @ ^2.8.0
 
 ; ======================================================================
 ; LilyGo T-Deck / T-Deck Plus — flattened equivalent of meshcomod's
@@ -377,3 +379,4 @@ lib_deps =
   file://arch/esp32/AsyncElegantOTA
   lvgl/lvgl @ ^8.3.11
   densaugeo/base64 @ ~1.4.0
+  knolleary/PubSubClient @ ^2.8.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ framework = arduino
 board = heltec_v4
 monitor_speed = 115200
 board_build.partitions = partitions_tft_touch.csv
-extra_scripts = pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/inject_wifi_env.py, pre:scripts/win_spawn_fix.py, merge-bin.py
 
 build_flags =
   -pipe
@@ -223,7 +223,7 @@ framework = arduino
 board = t-deck
 monitor_speed = 115200
 board_build.partitions = variants/lilygo_tdeck/partitions_tdeck_touch.csv
-extra_scripts = pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/inject_wifi_env.py, pre:scripts/win_spawn_fix.py, merge-bin.py
 
 build_flags =
   -Wno-deprecated-declarations -Wno-unused-parameter -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1

--- a/scripts/win_spawn_fix.py
+++ b/scripts/win_spawn_fix.py
@@ -1,0 +1,252 @@
+"""
+SCons SPAWN override for Windows — two-step compilation workaround.
+
+Root cause:
+  xtensa-esp32s3-elf-g++ internally spawns cc1plus via Windows CreateProcess.
+  With the full ESP32 SDK include list, the cc1plus command line approaches or
+  exceeds Windows' 32767-char CreateProcess limit, causing the spawn to fail.
+
+Fix (compile path):
+  When SCons calls SPAWN for a g++/gcc compile command (-c flag), we split the
+  compilation into two explicit subprocess calls so GCC never needs to spawn a
+  grandchild process:
+    1. g++ -S  → produces a .s assembly file in a temp location
+    2. xtensa-esp32s3-elf-as → assembles the .s into a .o object
+
+  The assembler command line is short (no include paths), so it never hits limits.
+  Any other SCons command (link, archive, …) is passed through unchanged.
+
+Only active on Windows; no-ops silently on Linux/macOS.
+"""
+
+import subprocess
+import shutil
+import shlex
+import tempfile
+import sys
+import os
+import datetime
+
+Import("env")
+
+if sys.platform != "win32":
+    Return()
+
+_PIO_BUILD_DIR = os.path.join(env["PROJECT_DIR"], ".pio", "build")
+_SPAWN_LOG = os.path.join(_PIO_BUILD_DIR, "spawn_debug.log")
+os.makedirs(_PIO_BUILD_DIR, exist_ok=True)
+
+# Resolve the assembler path once at load time
+_SCONS_PATH = env.get("PATH", "")
+if isinstance(_SCONS_PATH, (list, tuple)):
+    _SCONS_PATH = os.pathsep.join(str(p) for p in _SCONS_PATH)
+
+
+def _build_env():
+    """subprocess env: real Windows env + toolchain PATH prepended + TEMP redirected."""
+    merged = dict(os.environ)
+    merged["PATH"] = _SCONS_PATH + os.pathsep + os.environ.get("PATH", "")
+    merged["TEMP"] = _PIO_BUILD_DIR
+    merged["TMP"] = _PIO_BUILD_DIR
+    return merged
+
+
+def _resolve(exe):
+    """Return absolute path of *exe* using the full merged PATH."""
+    # Strip surrounding quotes that SCons sometimes leaves in the command
+    exe = exe.strip('"').strip("'")
+    full_path = _SCONS_PATH + os.pathsep + os.environ.get("PATH", "")
+    if os.path.isabs(exe):
+        return exe
+    found = shutil.which(exe, path=full_path)
+    return found if found else exe
+
+
+def _expand_args(args):
+    """Inline-expand any @response-file arguments into a flat list of strings.
+
+    Handles both @path and @"path" (quoted path after @).
+    """
+    result = []
+    for a in args:
+        s = str(a)
+        if s.startswith("@"):
+            path = s[1:].strip('"').strip("'")
+            if os.path.isfile(path):
+                with open(path, "r", encoding="utf-8", errors="replace") as f:
+                    content = f.read()
+                result.extend(shlex.split(content, posix=True))
+                continue
+        result.append(s)
+    return result
+
+
+def _two_step_compile(exe, expanded_args, merged_env):
+    """
+    Replace a single 'g++ -c' invocation with:
+      1. g++ -S  → .s assembly file in _PIO_BUILD_DIR
+      2. xtensa-esp32s3-elf-as → .o object file
+
+    Returns the process return code.
+    """
+    # Find the output (-o) and source file (last .cpp/.c/.S arg)
+    out_obj = None
+    source_file = None
+    args_iter = list(expanded_args)
+    for i, a in enumerate(args_iter):
+        if a == "-o" and i + 1 < len(args_iter):
+            out_obj = args_iter[i + 1]
+        elif (a.endswith(".cpp") or a.endswith(".c") or a.endswith(".S")
+              or a.endswith(".sx") or a.endswith(".cc")):
+            source_file = a
+
+    if out_obj is None or source_file is None:
+        sys.stderr.write(f"win_spawn_fix: cannot parse compile args, falling back to shell\n")
+        return 1  # signal failure — single-step g++ would also fail on this platform
+
+    # Step 1: compile to assembly
+    asm_fd, asm_path = tempfile.mkstemp(suffix=".s", dir=_PIO_BUILD_DIR)
+    os.close(asm_fd)
+    try:
+        step1_args = [exe]
+        skip_next = False
+        for a in expanded_args:
+            if skip_next:
+                skip_next = False
+                step1_args.append(asm_path)  # replace output path
+                continue
+            if a == "-c":
+                step1_args.append("-S")   # compile to assembly, not object
+            elif a == "-o":
+                skip_next = True
+                step1_args.append("-o")
+            elif a == "-pipe":
+                continue  # skip -pipe
+            else:
+                step1_args.append(a)
+
+        has_longcalls = "-mlongcalls" in step1_args
+        _log(f"STEP1 -mlongcalls={'YES' if has_longcalls else 'NO'} src={source_file[-40:]!r}")
+        rc = subprocess.Popen(step1_args, env=merged_env, shell=False).wait()
+        if rc != 0:
+            return rc
+
+        # Save a copy of the last .s file to help diagnose long-call issues.
+        try:
+            import shutil as _sh
+            _sh.copy2(asm_path, os.path.join(_PIO_BUILD_DIR, "debug_last.s"))
+        except OSError:
+            pass
+
+        # Step 2: assemble.
+        # GCC 8.4.0 Xtensa does NOT emit .longcalls in the -S output even when
+        # -mlongcalls is active — it relies on its internal assembler knowing the
+        # mode. We must pass --longcalls explicitly to the external assembler so
+        # it emits callx8 (indirect, 32-bit range) instead of call8 (direct,
+        # ±512 KB), otherwise the linker fails on large firmwares.
+        as_exe = _resolve("xtensa-esp32s3-elf-as")
+        as_flags = ["--longcalls"] if "-mlongcalls" in step1_args else []
+        step2_args = [as_exe] + as_flags + ["-o", out_obj, asm_path]
+        rc = subprocess.Popen(step2_args, env=merged_env, shell=False).wait()
+        return rc
+    finally:
+        try:
+            os.unlink(asm_path)
+        except OSError:
+            pass
+
+
+# Windows cmd.exe built-in commands that cannot be run as external executables.
+_SHELL_BUILTINS = frozenset(["del", "copy", "move", "mkdir", "rmdir", "rd", "md",
+                              "echo", "ren", "rename", "type", "dir", "cls", "set"])
+
+
+def _log(msg):
+    ts = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+    try:
+        with open(_SPAWN_LOG, "a", encoding="utf-8") as f:
+            f.write(f"[{ts}] {msg}\n")
+    except OSError:
+        pass
+
+
+def _run_shell(cmd_str, merged_env):
+    """Run *cmd_str* through cmd.exe (for shell built-ins like del/copy)."""
+    _log(f"SHELL START: {cmd_str[:200]!r}")
+    try:
+        rc = subprocess.Popen(cmd_str, env=merged_env, shell=True).wait()
+        _log(f"SHELL DONE rc={rc}: {cmd_str[:80]!r}")
+        if rc != 0:
+            sys.stderr.write(f"win_spawn_fix: shell rc={rc} cmd={cmd_str[:160]!r}\n")
+        return rc
+    except OSError as exc:
+        _log(f"SHELL EXCEPTION: {exc} cmd={cmd_str[:80]!r}")
+        sys.stderr.write(f"win_spawn_fix: shell failed for {cmd_str[:60]!r}: {exc}\n")
+        return 1
+
+
+def _run_direct(args_list, merged_env):
+    """Run an external executable directly (shell=False, full path resolved).
+
+    Avoids cmd.exe PATH lookup — we resolve the exe ourselves using the SCons
+    PATH so it works even when cmd.exe's PATH doesn't include the toolchain.
+    No pipe capture: we inherit parent stdout/stderr as-is.
+    """
+    _log(f"DIRECT START: {str(args_list[0])[:120]!r} ({len(args_list)} args)")
+    try:
+        rc = subprocess.Popen(args_list, env=merged_env, shell=False).wait()
+        _log(f"DIRECT DONE rc={rc}: {str(args_list[0])[:80]!r}")
+        if rc != 0:
+            sys.stderr.write(f"win_spawn_fix: direct rc={rc} exe={str(args_list[0])[:80]!r}\n")
+        return rc
+    except OSError as exc:
+        _log(f"DIRECT EXCEPTION: {exc} exe={str(args_list[0])[:80]!r}")
+        sys.stderr.write(f"win_spawn_fix: direct failed for {str(args_list[0])[:60]!r}: {exc}\n")
+        return 1
+
+
+def _win_spawn(sh, escape, cmd, args, env_dict):
+    if not args:
+        return 1
+
+    merged = _build_env()
+
+    # Detect C/C++ compile commands: exe is g++/gcc AND has -c flag
+    exe_raw = str(args[0]).strip('"').strip("'")
+    exe_base = os.path.basename(exe_raw).lower().replace(".exe", "")
+    is_cxx_compiler = "g++" in exe_base or "gcc" in exe_base
+    # Expand response file just enough to check for -c
+    expanded_peek = _expand_args(list(args)[1:])
+    is_compile = is_cxx_compiler and any(a == "-c" for a in expanded_peek)
+
+    if is_compile:
+        _log(f"COMPILE: {exe_raw[:60]}")
+        exe = _resolve(exe_raw)
+        rc = _two_step_compile(exe, expanded_peek, merged)
+        _log(f"COMPILE DONE rc={rc}: {exe_raw[:60]}")
+        return rc
+
+    # For all other commands (linker, ar, python scripts, del, copy, …):
+    def _unquote(s):
+        s = str(s)
+        if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+            return s[1:-1]
+        return s
+
+    exe_raw_unq = _unquote(str(args[0]))
+    exe_base_lower = os.path.basename(exe_raw_unq).lower().replace(".exe", "")
+
+    if exe_base_lower in _SHELL_BUILTINS:
+        # cmd.exe built-in — must go through shell
+        cmd_line = subprocess.list2cmdline([_unquote(a) for a in args])
+        return _run_shell(cmd_line, merged)
+
+    # External executable: resolve full path and run directly (shell=False).
+    # Expand any @response-file args — some tools (ar) don't support them.
+    exe_full = _resolve(exe_raw_unq)
+    raw_args = [exe_full] + [_unquote(str(a)) for a in args[1:]]
+    expanded = [raw_args[0]] + _expand_args(raw_args[1:])
+    return _run_direct(expanded, merged)
+
+
+env.Replace(SPAWN=_win_spawn)

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -22,6 +22,7 @@
 #endif
 #ifdef MULTI_TRANSPORT_COMPANION
 #include <helpers/esp32/MultiTransportCompanionInterface.h>
+#include "helpers/esp32/MqttBridge.h"
 #endif
 #endif
 
@@ -2015,6 +2016,9 @@ void MyMesh::onMessageRecv(const ContactInfo &from, mesh::Packet *pkt, uint32_t 
                            const char *text) {
   markConnectionActive(from); // in case this is from a server, and we have a connection
   queueMessage(from, TXT_TYPE_PLAIN, pkt, sender_timestamp, NULL, 0, text);
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  mqtt_bridge.publishDM(from.name, from.id.pub_key, pkt->getSNR(), pkt->path_len, sender_timestamp, text);
+#endif
 }
 
 void MyMesh::onCommandDataRecv(const ContactInfo &from, mesh::Packet *pkt, uint32_t sender_timestamp,
@@ -2029,6 +2033,9 @@ void MyMesh::onSignedMessageRecv(const ContactInfo &from, mesh::Packet *pkt, uin
   // from.sync_since change needs to be persisted
   dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
   queueMessage(from, TXT_TYPE_SIGNED_PLAIN, pkt, sender_timestamp, sender_prefix, 4, text);
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  mqtt_bridge.publishDM(from.name, from.id.pub_key, pkt->getSNR(), pkt->path_len, sender_timestamp, text);
+#endif
 }
 
 void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packet *pkt, uint32_t timestamp,
@@ -2073,6 +2080,16 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
     frame[0] = PUSH_CODE_MSG_WAITING; // send push 'tickle'
     _serial->writeFrameToAll(frame, 1);
   }
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  {
+    const char* _ch_name = "";
+    ChannelDetails _cd{};
+    if (getChannel(channel_idx, _cd)) _ch_name = _cd.name;
+    mqtt_bridge.publishChannel(channel_idx, _ch_name, pkt->getSNR(),
+                               pkt->isRouteFlood() ? pkt->path_len : 0,
+                               timestamp, text);
+  }
+#endif
 #ifdef DISPLAY_CLASS
   // Get the channel name from the channel index
   const char *channel_name = "Unknown";

--- a/src/helpers/esp32/MqttBridge.cpp
+++ b/src/helpers/esp32/MqttBridge.cpp
@@ -18,8 +18,10 @@ void MqttBridge::begin(const char* nodeHex) {
         _port = (uint16_t)p.getUInt("port", 1883);
         p.getString("user", _user, sizeof(_user));
         p.getString("pwd",  _pwd,  sizeof(_pwd));
+        p.getString("topic_pfx", _topic_prefix, sizeof(_topic_prefix));
         p.end();
     }
+    if (_topic_prefix[0] == '\0') strncpy(_topic_prefix, "wadamesh", sizeof(_topic_prefix) - 1);
     if (!_enabled || _host[0] == '\0') {
         _enabled = false;
         return;
@@ -36,7 +38,7 @@ bool MqttBridge::reconnect() {
 
     char clientId[32], lwtTopic[80];
     snprintf(clientId, sizeof(clientId), "wadamesh-%s", _nodeHex);
-    snprintf(lwtTopic, sizeof(lwtTopic), "wadamesh/%s/status", _nodeHex);
+    snprintf(lwtTopic, sizeof(lwtTopic), "%s/%s/status", _topic_prefix, _nodeHex);
 
     bool ok = _user[0]
         ? _mqtt.connect(clientId, _user, _pwd, lwtTopic, 0, true, "offline")
@@ -67,7 +69,7 @@ void MqttBridge::loop() {
 void MqttBridge::pub(const char* subtopic, const char* json) {
     if (!_enabled || !_mqtt.connected()) return;
     char topic[80];
-    snprintf(topic, sizeof(topic), "wadamesh/%s/%s", _nodeHex, subtopic);
+    snprintf(topic, sizeof(topic), "%s/%s/%s", _topic_prefix, _nodeHex, subtopic);
     _mqtt.publish(topic, json);
 }
 
@@ -115,7 +117,8 @@ void MqttBridge::publishChannel(int channelIdx, const char* channelName,
 }
 
 void MqttBridge::saveConfig(const char* host, uint16_t port,
-                             const char* user, const char* pwd, bool enable) {
+                             const char* user, const char* pwd,
+                             const char* topic_prefix, bool enable) {
     Preferences p;
     if (!p.begin("mqtt", false)) return;
     p.putBool("en",    enable);
@@ -123,6 +126,7 @@ void MqttBridge::saveConfig(const char* host, uint16_t port,
     p.putUInt("port",   port);
     p.putString("user", user);
     p.putString("pwd",  pwd);
+    p.putString("topic_pfx", (topic_prefix && topic_prefix[0]) ? topic_prefix : "wadamesh");
     p.end();
 }
 
@@ -135,8 +139,10 @@ void MqttBridge::reloadConfig() {
         _port = (uint16_t)p.getUInt("port", 1883);
         p.getString("user", _user, sizeof(_user));
         p.getString("pwd",  _pwd,  sizeof(_pwd));
+        p.getString("topic_pfx", _topic_prefix, sizeof(_topic_prefix));
         p.end();
     }
+    if (_topic_prefix[0] == '\0') strncpy(_topic_prefix, "wadamesh", sizeof(_topic_prefix) - 1);
     if (!_enabled || _host[0] == '\0') { _enabled = false; return; }
     _mqtt.setServer(_host, _port);
     _lastReconnectMs = 0;   // reconnect on next loop() tick

--- a/src/helpers/esp32/MqttBridge.cpp
+++ b/src/helpers/esp32/MqttBridge.cpp
@@ -1,0 +1,129 @@
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+#include "MqttBridge.h"
+#include <Preferences.h>
+#include <WiFi.h>
+#include <stdio.h>
+#include <string.h>
+
+MqttBridge mqtt_bridge;
+
+void MqttBridge::begin(const char* nodeHex) {
+    strncpy(_nodeHex, nodeHex, sizeof(_nodeHex) - 1);
+    _nodeHex[sizeof(_nodeHex) - 1] = '\0';
+
+    Preferences p;
+    if (p.begin("mqtt", true)) {
+        _enabled = p.getBool("en", false);
+        p.getString("host", _host, sizeof(_host));
+        _port = (uint16_t)p.getUInt("port", 1883);
+        p.getString("user", _user, sizeof(_user));
+        p.getString("pwd",  _pwd,  sizeof(_pwd));
+        p.end();
+    }
+    if (!_enabled || _host[0] == '\0') {
+        _enabled = false;
+        return;
+    }
+
+    _mqtt.setServer(_host, _port);
+    _mqtt.setKeepAlive(60);
+    _mqtt.setBufferSize(512);
+    Serial.printf("[MQTT] configured → %s:%u\n", _host, _port);
+}
+
+bool MqttBridge::reconnect() {
+    if (!_enabled || WiFi.status() != WL_CONNECTED) return false;
+
+    char clientId[32], lwtTopic[80];
+    snprintf(clientId, sizeof(clientId), "wadamesh-%s", _nodeHex);
+    snprintf(lwtTopic, sizeof(lwtTopic), "wadamesh/%s/status", _nodeHex);
+
+    bool ok = _user[0]
+        ? _mqtt.connect(clientId, _user, _pwd, lwtTopic, 0, true, "offline")
+        : _mqtt.connect(clientId, nullptr, nullptr, lwtTopic, 0, true, "offline");
+
+    if (ok) {
+        _mqtt.publish(lwtTopic, "online", true);
+        Serial.printf("[MQTT] connected as %s\n", clientId);
+    } else {
+        Serial.printf("[MQTT] connect failed, rc=%d\n", _mqtt.state());
+    }
+    return ok;
+}
+
+void MqttBridge::loop() {
+    if (!_enabled) return;
+    if (!_mqtt.connected()) {
+        uint32_t now = millis();
+        if ((uint32_t)(now - _lastReconnectMs) >= RECONNECT_INTERVAL_MS) {
+            _lastReconnectMs = now;
+            reconnect();
+        }
+        return;
+    }
+    _mqtt.loop();
+}
+
+void MqttBridge::pub(const char* subtopic, const char* json) {
+    if (!_enabled || !_mqtt.connected()) return;
+    char topic[80];
+    snprintf(topic, sizeof(topic), "wadamesh/%s/%s", _nodeHex, subtopic);
+    _mqtt.publish(topic, json);
+}
+
+void MqttBridge::escapeJson(const char* src, char* dst, size_t dstLen) {
+    size_t j = 0;
+    for (size_t i = 0; src[i] && j + 3 < dstLen; ++i) {
+        char c = src[i];
+        if (c == '"' || c == '\\') { dst[j++] = '\\'; dst[j++] = c; }
+        else if (c == '\n')        { dst[j++] = '\\'; dst[j++] = 'n'; }
+        else if (c == '\r')        { dst[j++] = '\\'; dst[j++] = 'r'; }
+        else                       { dst[j++] = c; }
+    }
+    dst[j] = '\0';
+}
+
+void MqttBridge::publishDM(const char* senderName, const uint8_t* senderKey32,
+                            float snr, uint8_t hops, uint32_t ts, const char* text) {
+    if (!_enabled || !_mqtt.connected()) return;
+    char keyHex[13] = {};
+    for (int i = 0; i < 6; ++i) snprintf(keyHex + i * 2, 3, "%02x", senderKey32[i]);
+
+    char safeName[48], safeText[300];
+    escapeJson(senderName, safeName, sizeof(safeName));
+    escapeJson(text,       safeText, sizeof(safeText));
+
+    char json[480];
+    snprintf(json, sizeof(json),
+        "{\"sender\":\"%s\",\"key\":\"%s\",\"snr\":%.1f,\"hops\":%u,\"ts\":%lu,\"text\":\"%s\"}",
+        safeName, keyHex, snr, (unsigned)hops, (unsigned long)ts, safeText);
+    pub("msg/dm", json);
+}
+
+void MqttBridge::publishChannel(int channelIdx, const char* channelName,
+                                 float snr, uint8_t hops, uint32_t ts, const char* text) {
+    if (!_enabled || !_mqtt.connected()) return;
+    char safeName[48], safeText[300];
+    escapeJson(channelName, safeName, sizeof(safeName));
+    escapeJson(text,        safeText, sizeof(safeText));
+
+    char json[480];
+    snprintf(json, sizeof(json),
+        "{\"channel\":\"%s\",\"ch_idx\":%d,\"snr\":%.1f,\"hops\":%u,\"ts\":%lu,\"text\":\"%s\"}",
+        safeName, channelIdx, snr, (unsigned)hops, (unsigned long)ts, safeText);
+    pub("msg/ch", json);
+}
+
+void MqttBridge::saveConfig(const char* host, uint16_t port,
+                             const char* user, const char* pwd, bool enable) {
+    Preferences p;
+    if (!p.begin("mqtt", false)) return;
+    p.putBool("en",    enable);
+    p.putString("host", host);
+    p.putUInt("port",   port);
+    p.putString("user", user);
+    p.putString("pwd",  pwd);
+    p.end();
+}
+
+#endif // ESP32 && MULTI_TRANSPORT_COMPANION

--- a/src/helpers/esp32/MqttBridge.cpp
+++ b/src/helpers/esp32/MqttBridge.cpp
@@ -126,4 +126,21 @@ void MqttBridge::saveConfig(const char* host, uint16_t port,
     p.end();
 }
 
+void MqttBridge::reloadConfig() {
+    if (_mqtt.connected()) _mqtt.disconnect();
+    Preferences p;
+    if (p.begin("mqtt", true)) {
+        _enabled = p.getBool("en", false);
+        p.getString("host", _host, sizeof(_host));
+        _port = (uint16_t)p.getUInt("port", 1883);
+        p.getString("user", _user, sizeof(_user));
+        p.getString("pwd",  _pwd,  sizeof(_pwd));
+        p.end();
+    }
+    if (!_enabled || _host[0] == '\0') { _enabled = false; return; }
+    _mqtt.setServer(_host, _port);
+    _lastReconnectMs = 0;   // reconnect on next loop() tick
+    Serial.printf("[MQTT] config reloaded → %s:%u en=%d\n", _host, _port, (int)_enabled);
+}
+
 #endif // ESP32 && MULTI_TRANSPORT_COMPANION

--- a/src/helpers/esp32/MqttBridge.h
+++ b/src/helpers/esp32/MqttBridge.h
@@ -1,0 +1,60 @@
+#pragma once
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+
+#include <Arduino.h>
+#include <PubSubClient.h>
+#include <WiFiClient.h>
+
+// Publishes received mesh messages to an MQTT broker over the existing WiFi link.
+//
+// Topics (QoS 0, retained where noted):
+//   wadamesh/{node_hex}/msg/dm   — direct / signed messages received from the mesh
+//   wadamesh/{node_hex}/msg/ch   — channel messages received from the mesh
+//   wadamesh/{node_hex}/status   — LWT: "online" on connect, "offline" on drop (retained)
+//
+// Config persisted in Preferences namespace "mqtt" (file-backed via SdNvsPrefs):
+//   en    bool    master enable (default false — opt-in)
+//   host  string  broker hostname or IP
+//   port  uint16  broker port (default 1883)
+//   user  string  username (optional)
+//   pwd   string  password (optional)
+//
+// Call begin() once after the_mesh.begin() and SdNvsPrefs::useFile().
+// Call loop() every iteration of the Arduino loop().
+class MqttBridge {
+public:
+    void begin(const char* nodeHex);
+    void loop();
+
+    void publishDM(const char* senderName, const uint8_t* senderKey32,
+                   float snr, uint8_t hops, uint32_t ts, const char* text);
+    void publishChannel(int channelIdx, const char* channelName,
+                        float snr, uint8_t hops, uint32_t ts, const char* text);
+
+    bool enabled() const { return _enabled; }
+
+    // Persist config and reconnect if needed (called from Settings UI save).
+    static void saveConfig(const char* host, uint16_t port,
+                           const char* user, const char* pwd, bool enable);
+
+private:
+    WiFiClient   _wc;
+    PubSubClient _mqtt{_wc};
+    char     _nodeHex[13] = {};   // 6-byte key → 12 hex chars + '\0'
+    bool     _enabled     = false;
+    char     _host[64]    = {};
+    char     _user[32]    = {};
+    char     _pwd[32]     = {};
+    uint16_t _port        = 1883;
+    uint32_t _lastReconnectMs = 0;
+
+    static const uint32_t RECONNECT_INTERVAL_MS = 15000;
+
+    bool reconnect();
+    void pub(const char* subtopic, const char* json);
+    static void escapeJson(const char* src, char* dst, size_t dstLen);
+};
+
+extern MqttBridge mqtt_bridge;
+
+#endif // ESP32 && MULTI_TRANSPORT_COMPANION

--- a/src/helpers/esp32/MqttBridge.h
+++ b/src/helpers/esp32/MqttBridge.h
@@ -13,11 +13,12 @@
 //   wadamesh/{node_hex}/status   — LWT: "online" on connect, "offline" on drop (retained)
 //
 // Config persisted in Preferences namespace "mqtt" (file-backed via SdNvsPrefs):
-//   en    bool    master enable (default false — opt-in)
-//   host  string  broker hostname or IP
-//   port  uint16  broker port (default 1883)
-//   user  string  username (optional)
-//   pwd   string  password (optional)
+//   en         bool    master enable (default false — opt-in)
+//   host       string  broker hostname or IP
+//   port       uint16  broker port (default 1883)
+//   user       string  username (optional)
+//   pwd        string  password (optional)
+//   topic_pfx  string  topic prefix (default "wadamesh")
 //
 // Call begin() once after the_mesh.begin() and SdNvsPrefs::useFile().
 // Call loop() every iteration of the Arduino loop().
@@ -35,18 +36,20 @@ public:
 
     // Persist config (called from Settings UI save).
     static void saveConfig(const char* host, uint16_t port,
-                           const char* user, const char* pwd, bool enable);
+                           const char* user, const char* pwd,
+                           const char* topic_prefix, bool enable);
     // Re-read config from Preferences and reconnect (call after saveConfig).
     void reloadConfig();
 
 private:
     WiFiClient   _wc;
     PubSubClient _mqtt{_wc};
-    char     _nodeHex[13] = {};   // 6-byte key → 12 hex chars + '\0'
-    bool     _enabled     = false;
-    char     _host[64]    = {};
-    char     _user[32]    = {};
-    char     _pwd[32]     = {};
+    char     _nodeHex[13]      = {};   // 6-byte key → 12 hex chars + '\0'
+    bool     _enabled          = false;
+    char     _host[64]         = {};
+    char     _user[32]         = {};
+    char     _pwd[32]          = {};
+    char     _topic_prefix[48] = {};   // MQTT topic prefix (default "wadamesh")
     uint16_t _port        = 1883;
     uint32_t _lastReconnectMs = 0;
 

--- a/src/helpers/esp32/MqttBridge.h
+++ b/src/helpers/esp32/MqttBridge.h
@@ -33,9 +33,11 @@ public:
 
     bool enabled() const { return _enabled; }
 
-    // Persist config and reconnect if needed (called from Settings UI save).
+    // Persist config (called from Settings UI save).
     static void saveConfig(const char* host, uint16_t port,
                            const char* user, const char* pwd, bool enable);
+    // Re-read config from Preferences and reconnect (call after saveConfig).
+    void reloadConfig();
 
 private:
     WiFiClient   _wc;

--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -35,7 +35,7 @@ static bool s_begun = false;
 // short read (→ treat as absent → defaults); `ver` lets later builds add fields.
 static const char* KEY_CFG = "cfg";
 static const uint16_t TOUCH_CFG_MAGIC = 0x5743;   // 'WC' (WadaCfg)
-static const uint8_t  TOUCH_CFG_VER   = 25;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab; v20 map_show_links; v21 map_style (0=OSM default, 1=OpenTopoMap); v22 tb_nav; v23 scope_direct (opt-in: scope direct/login floods to the region); v24 tb_nav default OFF (experimental); v25 fem_lna (Heltec V4.3 high-gain FEM LNA, opt-in)
+static const uint8_t  TOUCH_CFG_VER   = 26;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab; v20 map_show_links; v21 map_style (0=OSM default, 1=OpenTopoMap); v22 tb_nav; v23 scope_direct (opt-in: scope direct/login floods to the region); v24 tb_nav default OFF (experimental); v25 fem_lna (Heltec V4.3 high-gain FEM LNA, opt-in); v26 map_type_filter/map_show_rssi_rings/map_node_alerts
 
 // Defaults (kept identical to the historical per-key defaults).
 static const uint16_t DEFAULT_SCREEN_TIMEOUT_S = 20;
@@ -95,6 +95,9 @@ struct __attribute__((packed)) TouchCfg {
   uint8_t  tb_nav;            // T-Deck trackball: 1=D-pad UI navigation (default), 0=soft cursor — v22 (trailing)
   uint8_t  scope_direct;      // 1=tag direct/login/admin floods with the default region scope (opt-in, default 0) — v23 (trailing)
   uint8_t  fem_lna;           // Heltec V4.3 high-gain FEM LNA (~17 dB): 1=on, 0=bypass (default) — v25 (trailing)
+  uint8_t  map_type_filter;   // contact type filter bitmask (0x0F = all shown): bit0=chat,1=rep,2=room,3=sensor — v26 (trailing)
+  uint8_t  map_show_rssi_rings; // show RSSI range rings on contact markers (bool) — v26 (trailing)
+  uint8_t  map_node_alerts;   // toast alert when a GPS contact appears/disappears (bool) — v26 (trailing)
 };
 
 static TouchCfg s_cfg;
@@ -178,6 +181,9 @@ static void cfgSetDefaults(TouchCfg& c) {
   c.show_sensors_tab   = 1;     // default: show the V4 Expansion-Kit Sensors tab + Home env widget
   c.map_show_links     = 1;     // default: show self->contact link lines (PR #61)
   c.map_style          = 0;     // default: OpenStreetMap (OpenTopoMap is opt-in)
+  c.map_type_filter    = 0x0F;  // default: all contact types shown
+  c.map_show_rssi_rings = 0;    // default: rings off
+  c.map_node_alerts    = 0;     // default: alerts off
 }
 
 // Persist the whole blob using the same end()/begin(RW)/put/end()/begin(RO)
@@ -886,6 +892,33 @@ bool touchPrefsGetMapShowLinks() {
 bool touchPrefsSetMapShowLinks(bool on) {
   if (!s_begun) touchPrefsBegin();
   s_cfg.map_show_links = on ? 1 : 0;
+  return cfgFlush();
+}
+uint8_t touchPrefsGetMapTypeFilter() {
+  if (!s_begun) touchPrefsBegin();
+  return s_cfg.map_type_filter ? s_cfg.map_type_filter : 0x0F;  // 0 means unset — treat as all shown
+}
+bool touchPrefsSetMapTypeFilter(uint8_t mask) {
+  if (!s_begun) touchPrefsBegin();
+  s_cfg.map_type_filter = mask ? mask : 0x0F;
+  return cfgFlush();
+}
+bool touchPrefsGetMapShowRssiRings() {
+  if (!s_begun) touchPrefsBegin();
+  return s_cfg.map_show_rssi_rings != 0;
+}
+bool touchPrefsSetMapShowRssiRings(bool on) {
+  if (!s_begun) touchPrefsBegin();
+  s_cfg.map_show_rssi_rings = on ? 1 : 0;
+  return cfgFlush();
+}
+bool touchPrefsGetMapNodeAlerts() {
+  if (!s_begun) touchPrefsBegin();
+  return s_cfg.map_node_alerts != 0;
+}
+bool touchPrefsSetMapNodeAlerts(bool on) {
+  if (!s_begun) touchPrefsBegin();
+  s_cfg.map_node_alerts = on ? 1 : 0;
   return cfgFlush();
 }
 uint8_t touchPrefsGetMapStyle() {

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -101,6 +101,19 @@ bool touchPrefsSetMapShowContacts(bool on);
 bool touchPrefsGetMapShowLinks();
 bool touchPrefsSetMapShowLinks(bool on);
 
+/** Map contact type filter — bitmask: bit 0=chat/mobile, 1=repeater, 2=room, 3=sensor.
+ *  Default 0x0F (all types shown). */
+uint8_t touchPrefsGetMapTypeFilter();
+bool    touchPrefsSetMapTypeFilter(uint8_t mask);
+
+/** Show RSSI-based range rings around contact markers.  Default false. */
+bool touchPrefsGetMapShowRssiRings();
+bool touchPrefsSetMapShowRssiRings(bool on);
+
+/** Toast alert when a GPS-located contact appears or disappears.  Default false. */
+bool touchPrefsGetMapNodeAlerts();
+bool touchPrefsSetMapNodeAlerts(bool on);
+
 /** Map tile style: 0 = OpenStreetMap (default), 1 = OpenTopoMap (topographic, opt-in). */
 uint8_t touchPrefsGetMapStyle();
 bool    touchPrefsSetMapStyle(uint8_t style);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ static uint32_t _atoi(const char* sp) {
 #ifdef ESP32
   #ifdef MULTI_TRANSPORT_COMPANION
     #include <helpers/esp32/MultiTransportCompanionInterface.h>
+    #include "helpers/esp32/MqttBridge.h"
     MultiTransportCompanionInterface serial_interface;
     #ifndef TCP_PORT
       #define TCP_PORT 5000
@@ -410,6 +411,14 @@ void setup() {
   );
   Serial.println("[BOOT] mesh ok");
 
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  {
+    char nodeHex[13] = {};
+    for (int i = 0; i < 6; ++i) snprintf(nodeHex + i * 2, 3, "%02x", the_mesh.self_id.pub_key[i]);
+    mqtt_bridge.begin(nodeHex);
+  }
+#endif
+
 #if defined(WIFI_SSID) || defined(MULTI_TRANSPORT_COMPANION)
   wifiConfigBegin();
   Serial.println("[BOOT] wifiConfig ok");
@@ -688,6 +697,9 @@ void loop() {
   if (!spectrumOwnsRadio())
 #endif
   the_mesh.loop();
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  mqtt_bridge.loop();
+#endif
 #if defined(GPS_BUF_DEBUG)
   // Bench diagnostic (build with -DGPS_BUF_DEBUG only; absent in releases): peak GPS UART
   // backlog accumulated between sensors.loop() drains. A peak above the old 256-byte default

--- a/src/ui-touch/TetrisGame.cpp
+++ b/src/ui-touch/TetrisGame.cpp
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "TetrisGame.h"
+
+#include <Arduino.h>
+#include <LvglPsramAlloc.h>
+#include <string.h>
+
+static constexpr lv_coord_t kTopBar = 22;
+
+static constexpr uint32_t kColBg      = 0x090B0F;
+static constexpr uint32_t kColPanel   = 0x131922;
+static constexpr uint32_t kColText    = 0xE6EAEE;
+static constexpr uint32_t kColSub     = 0x9AA3AD;
+static constexpr uint32_t kColGrid    = 0x24303E;
+static constexpr uint32_t kColBorder  = 0x4E5D71;
+static constexpr uint32_t kColGhost   = 0x141A22;
+static constexpr uint32_t kColPieces[8] = {
+  0x000000, 0x4AC7EA, 0x5C78FF, 0xF1A643, 0xF6D74A,
+  0x58C96B, 0xC06BEA, 0xE65B5B
+};
+
+static constexpr uint8_t kShapes[7][4][4] = {
+  { {0,0,0,0}, {1,1,1,1}, {0,0,0,0}, {0,0,0,0} }, // I
+  { {1,0,0,0}, {1,1,1,0}, {0,0,0,0}, {0,0,0,0} }, // J
+  { {0,0,1,0}, {1,1,1,0}, {0,0,0,0}, {0,0,0,0} }, // L
+  { {1,1,0,0}, {1,1,0,0}, {0,0,0,0}, {0,0,0,0} }, // O
+  { {0,1,1,0}, {1,1,0,0}, {0,0,0,0}, {0,0,0,0} }, // S
+  { {0,1,0,0}, {1,1,1,0}, {0,0,0,0}, {0,0,0,0} }, // T
+  { {1,1,0,0}, {0,1,1,0}, {0,0,0,0}, {0,0,0,0} }, // Z
+};
+
+TetrisGame* TetrisGame::s_active = nullptr;
+
+bool TetrisGame::isOpen() { return s_active != nullptr && s_active->root_ != nullptr; }
+
+void TetrisGame::launch() {
+  if (s_active) return;
+  TetrisGame* g = new TetrisGame();
+  s_active = g;
+  if (!g->open()) {
+    s_active = nullptr;
+    delete g;
+  }
+}
+
+void TetrisGame::steer(int dx, int dy) {
+  if (!s_active || !s_active->started_ || s_active->paused_ || s_active->over_) return;
+  if (dx == 0 && dy == 0) return;
+  const int adx = dx < 0 ? -dx : dx;
+  const int ady = dy < 0 ? -dy : dy;
+  if (adx >= ady) {
+    s_active->movePiece(dx > 0 ? 1 : -1, 0);
+    s_active->render();
+  } else if (dy < 0) {
+    s_active->rotatePiece();
+    s_active->render();
+  } else {
+    s_active->softDrop();
+  }
+}
+
+bool TetrisGame::open() {
+  const lv_coord_t sw = lv_disp_get_hor_res(nullptr);
+  const lv_coord_t sh = lv_disp_get_ver_res(nullptr);
+  const int overlayH = (int)(sh - kTopBar);
+  const int topRowH = 28;
+  const int sidePanelW = (sw >= 300) ? 84 : 74;
+  int cell = (int)(sw - sidePanelW - 20) / kFieldW;
+  const int byH = (overlayH - topRowH - 10) / kFieldH;
+  if (byH < cell) cell = byH;
+  if (cell > kMaxCellPx) cell = kMaxCellPx;
+  if (cell < 8) cell = 8;
+  cellPx_ = cell;
+  boardWpx_ = kFieldW * cellPx_;
+  boardHpx_ = kFieldH * cellPx_;
+  boardX_ = 8;
+  boardY_ = topRowH + 4;
+  previewX_ = boardX_ + boardWpx_ + 10;
+  previewY_ = boardY_ + 18;
+
+  root_ = lv_obj_create(lv_layer_top());
+  lv_obj_remove_style_all(root_);
+  lv_obj_set_size(root_, sw, overlayH);
+  lv_obj_set_pos(root_, 0, kTopBar);
+  lv_obj_set_style_bg_color(root_, lv_color_hex(0x0E1216), LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(root_, LV_OPA_COVER, LV_PART_MAIN);
+  lv_obj_clear_flag(root_, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_add_flag(root_, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_event_cb(root_, tapCb, LV_EVENT_CLICKED, this);
+
+  score_ = lv_label_create(root_);
+  lv_obj_set_style_text_color(score_, lv_color_hex(kColText), LV_PART_MAIN);
+  lv_obj_align(score_, LV_ALIGN_TOP_LEFT, 6, 4);
+
+  lv_obj_t* x = lv_btn_create(root_);
+  lv_obj_set_size(x, 30, 24);
+  lv_obj_align(x, LV_ALIGN_TOP_RIGHT, -4, 0);
+  lv_obj_add_event_cb(x, closeCb, LV_EVENT_CLICKED, this);
+  lv_obj_t* xl = lv_label_create(x);
+  lv_label_set_text(xl, LV_SYMBOL_CLOSE);
+  lv_obj_center(xl);
+
+  pause_btn_ = lv_btn_create(root_);
+  lv_obj_set_size(pause_btn_, 30, 24);
+  lv_obj_align(pause_btn_, LV_ALIGN_TOP_RIGHT, -40, 0);
+  lv_obj_add_event_cb(pause_btn_, pauseCb, LV_EVENT_CLICKED, this);
+  pause_lbl_ = lv_label_create(pause_btn_);
+  lv_label_set_text(pause_lbl_, LV_SYMBOL_PAUSE);
+  lv_obj_center(pause_lbl_);
+  lv_obj_add_flag(pause_btn_, LV_OBJ_FLAG_HIDDEN);
+
+  boardBuf_ = (lv_color_t*)lvglPsramAlloc((size_t)boardWpx_ * boardHpx_ * sizeof(lv_color_t));
+  prevBuf_ = (lv_color_t*)lvglPsramAlloc((size_t)(kPreviewW * cellPx_) * (kPreviewH * cellPx_) * sizeof(lv_color_t));
+  if (!boardBuf_ || !prevBuf_) return false;
+
+  board_ = lv_canvas_create(root_);
+  lv_canvas_set_buffer(board_, boardBuf_, boardWpx_, boardHpx_, LV_IMG_CF_TRUE_COLOR);
+  lv_obj_set_pos(board_, boardX_, boardY_);
+
+  preview_ = lv_canvas_create(root_);
+  lv_canvas_set_buffer(preview_, prevBuf_, kPreviewW * cellPx_, kPreviewH * cellPx_, LV_IMG_CF_TRUE_COLOR);
+  lv_obj_set_pos(preview_, previewX_, previewY_);
+
+  nextLbl_ = lv_label_create(root_);
+  lv_label_set_text(nextLbl_, "NEXT");
+  lv_obj_set_style_text_color(nextLbl_, lv_color_hex(kColSub), LV_PART_MAIN);
+  lv_obj_set_style_text_font(nextLbl_, &lv_font_montserrat_12, LV_PART_MAIN);
+  lv_obj_set_pos(nextLbl_, previewX_, boardY_);
+
+  start_btn_ = lv_btn_create(root_);
+  lv_obj_set_size(start_btn_, 150, 44);
+  lv_obj_align(start_btn_, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_add_event_cb(start_btn_, startCb, LV_EVENT_CLICKED, this);
+  lv_obj_t* sl = lv_label_create(start_btn_);
+  lv_label_set_text(sl, LV_SYMBOL_PLAY "  New game");
+  lv_obj_center(sl);
+
+  beginRound();
+  started_ = false;
+  paused_ = false;
+  over_ = false;
+  updateScoreLabel();
+  render();
+  if (!timer_) timer_ = lv_timer_create(timerCb, kTickMs, this);
+  return true;
+}
+
+void TetrisGame::close() {
+  if (timer_) { lv_timer_del(timer_); timer_ = nullptr; }
+  if (root_)  { lv_obj_del(root_); root_ = nullptr; }
+  if (boardBuf_) { lvglPsramFree(boardBuf_); boardBuf_ = nullptr; }
+  if (prevBuf_)  { lvglPsramFree(prevBuf_);  prevBuf_  = nullptr; }
+  board_ = nullptr;
+  preview_ = nullptr;
+  score_ = nullptr;
+  nextLbl_ = nullptr;
+  start_btn_ = nullptr;
+  pause_btn_ = nullptr;
+  pause_lbl_ = nullptr;
+}
+
+void TetrisGame::beginRound() {
+  memset(field_, 0, sizeof(field_));
+  scoreVal_ = 0;
+  linesCleared_ = 0;
+  dropIntervalMs_ = 500;
+  paused_ = false;
+  over_ = false;
+  nextType_ = (int)random(0, 7);
+  spawnPiece();
+  lastDropMs_ = millis();
+}
+
+void TetrisGame::startGame() {
+  started_ = true;
+  beginRound();
+  if (start_btn_) {
+    lv_obj_del(start_btn_);
+    start_btn_ = nullptr;
+  }
+  if (pause_btn_) {
+    lv_obj_clear_flag(pause_btn_, LV_OBJ_FLAG_HIDDEN);
+    if (pause_lbl_) lv_label_set_text(pause_lbl_, LV_SYMBOL_PAUSE);
+  }
+  updateScoreLabel();
+  render();
+}
+
+void TetrisGame::updateScoreLabel() {
+  if (!score_) return;
+  if (over_) {
+    lv_label_set_text_fmt(score_, "Game over - score %d (tap to restart)", scoreVal_);
+  } else if (paused_) {
+    lv_label_set_text_fmt(score_, "Paused - score %d", scoreVal_);
+  } else if (started_) {
+    lv_label_set_text_fmt(score_, "score %d   lines %d", scoreVal_, linesCleared_);
+  } else {
+    lv_label_set_text(score_, "Tetris - swipe L/R, up rotate, down drop");
+  }
+}
+
+int TetrisGame::getBlock(int type, int rot, int x, int y) const {
+  switch (rot & 3) {
+    case 0: return kShapes[type][y][x];
+    case 1: return kShapes[type][3 - x][y];
+    case 2: return kShapes[type][3 - y][3 - x];
+    case 3: return kShapes[type][x][3 - y];
+  }
+  return 0;
+}
+
+bool TetrisGame::checkCollision(int x, int y, int rot) const {
+  for (int py = 0; py < 4; ++py) {
+    for (int px = 0; px < 4; ++px) {
+      if (!getBlock(currentType_, rot, px, py)) continue;
+      const int fx = x + px;
+      const int fy = y + py;
+      if (fx < 0 || fx >= kFieldW || fy >= kFieldH) return true;
+      if (fy >= 0 && field_[fy][fx] != 0) return true;
+    }
+  }
+  return false;
+}
+
+bool TetrisGame::movePiece(int dx, int dy) {
+  if (checkCollision(currentX_ + dx, currentY_ + dy, currentRot_)) return false;
+  currentX_ += dx;
+  currentY_ += dy;
+  return true;
+}
+
+void TetrisGame::rotatePiece() {
+  const int nextRot = (currentRot_ + 1) & 3;
+  if (!checkCollision(currentX_, currentY_, nextRot)) currentRot_ = nextRot;
+}
+
+void TetrisGame::spawnPiece() {
+  currentType_ = nextType_;
+  nextType_ = (int)random(0, 7);
+  currentRot_ = 0;
+  currentX_ = (kFieldW / 2) - 2;
+  currentY_ = -1;
+}
+
+void TetrisGame::lockPiece() {
+  for (int py = 0; py < 4; ++py) {
+    for (int px = 0; px < 4; ++px) {
+      if (!getBlock(currentType_, currentRot_, px, py)) continue;
+      const int fx = currentX_ + px;
+      const int fy = currentY_ + py;
+      if (fy >= 0 && fy < kFieldH && fx >= 0 && fx < kFieldW)
+        field_[fy][fx] = (uint8_t)(currentType_ + 1);
+    }
+  }
+}
+
+void TetrisGame::clearLines() {
+  int cleared = 0;
+  for (int y = kFieldH - 1; y >= 0; --y) {
+    bool full = true;
+    for (int x = 0; x < kFieldW; ++x) {
+      if (field_[y][x] == 0) { full = false; break; }
+    }
+    if (!full) continue;
+    for (int row = y; row > 0; --row) memcpy(field_[row], field_[row - 1], sizeof(field_[row]));
+    memset(field_[0], 0, sizeof(field_[0]));
+    ++cleared;
+    ++y;
+  }
+  if (cleared > 0) {
+    linesCleared_ += cleared;
+    scoreVal_ += cleared * 100;
+    const int speedStep = (scoreVal_ / 500) * 50;
+    dropIntervalMs_ = 500 - speedStep;
+    if (dropIntervalMs_ < 100) dropIntervalMs_ = 100;
+  }
+}
+
+void TetrisGame::settlePiece() {
+  lockPiece();
+  clearLines();
+  spawnPiece();
+  if (checkCollision(currentX_, currentY_, currentRot_)) over_ = true;
+  updateScoreLabel();
+  render();
+}
+
+void TetrisGame::softDrop() {
+  if (!started_ || paused_ || over_) return;
+  if (!movePiece(0, 1)) settlePiece();
+  else render();
+  lastDropMs_ = millis();
+}
+
+void TetrisGame::step() {
+  if (!started_ || paused_ || over_) return;
+  const uint32_t now = millis();
+  if ((uint32_t)(now - lastDropMs_) < (uint32_t)dropIntervalMs_) return;
+  lastDropMs_ = now;
+  if (!movePiece(0, 1)) settlePiece();
+  else render();
+}
+
+void TetrisGame::render() {
+  if (!board_ || !preview_) return;
+
+  lv_canvas_fill_bg(board_, lv_color_hex(kColBg), LV_OPA_COVER);
+  lv_draw_rect_dsc_t d;
+  lv_draw_rect_dsc_init(&d);
+  d.radius = 1;
+
+  for (int y = 0; y < kFieldH; ++y) {
+    for (int x = 0; x < kFieldW; ++x) {
+      const int px = x * cellPx_;
+      const int py = y * cellPx_;
+      d.bg_color = lv_color_hex(field_[y][x] ? kColPieces[field_[y][x]] : kColGhost);
+      d.bg_opa = field_[y][x] ? LV_OPA_COVER : LV_OPA_50;
+      d.border_width = 1;
+      d.border_color = lv_color_hex(field_[y][x] ? 0xFFFFFF : kColGrid);
+      d.border_opa = field_[y][x] ? LV_OPA_30 : LV_OPA_20;
+      lv_canvas_draw_rect(board_, px, py, cellPx_ - 1, cellPx_ - 1, &d);
+    }
+  }
+
+  if (!over_) {
+    for (int py = 0; py < 4; ++py) {
+      for (int px = 0; px < 4; ++px) {
+        if (!getBlock(currentType_, currentRot_, px, py)) continue;
+        const int fx = currentX_ + px;
+        const int fy = currentY_ + py;
+        if (fy < 0 || fx < 0 || fx >= kFieldW || fy >= kFieldH) continue;
+        d.bg_color = lv_color_hex(kColPieces[currentType_ + 1]);
+        d.bg_opa = LV_OPA_COVER;
+        d.border_width = 1;
+        d.border_color = lv_color_hex(0xFFFFFF);
+        d.border_opa = LV_OPA_40;
+        lv_canvas_draw_rect(board_, fx * cellPx_, fy * cellPx_, cellPx_ - 1, cellPx_ - 1, &d);
+      }
+    }
+  }
+
+  lv_canvas_fill_bg(preview_, lv_color_hex(kColPanel), LV_OPA_COVER);
+  d.bg_opa = LV_OPA_COVER;
+  d.border_width = 1;
+  d.border_color = lv_color_hex(kColBorder);
+  d.border_opa = LV_OPA_30;
+  for (int py = 0; py < 4; ++py) {
+    for (int px = 0; px < 4; ++px) {
+      if (!kShapes[nextType_][py][px]) continue;
+      d.bg_color = lv_color_hex(kColPieces[nextType_ + 1]);
+      lv_canvas_draw_rect(preview_, px * cellPx_, py * cellPx_, cellPx_ - 1, cellPx_ - 1, &d);
+    }
+  }
+}
+
+void TetrisGame::timerCb(lv_timer_t* t) {
+  auto* self = static_cast<TetrisGame*>(t->user_data);
+  if (self) self->step();
+}
+
+void TetrisGame::tapCb(lv_event_t* e) {
+  auto* self = static_cast<TetrisGame*>(lv_event_get_user_data(e));
+  if (!self) return;
+  if (self->over_) {
+    self->beginRound();
+    self->started_ = true;
+    if (self->pause_btn_) {
+      lv_obj_clear_flag(self->pause_btn_, LV_OBJ_FLAG_HIDDEN);
+      if (self->pause_lbl_) lv_label_set_text(self->pause_lbl_, LV_SYMBOL_PAUSE);
+    }
+    self->updateScoreLabel();
+    self->render();
+  } else if (self->started_ && !self->paused_) {
+    self->rotatePiece();
+    self->render();
+  }
+}
+
+void TetrisGame::startCb(lv_event_t* e) {
+  auto* self = static_cast<TetrisGame*>(lv_event_get_user_data(e));
+  if (self) self->startGame();
+}
+
+void TetrisGame::pauseCb(lv_event_t* e) {
+  auto* self = static_cast<TetrisGame*>(lv_event_get_user_data(e));
+  if (!self || !self->started_ || self->over_) return;
+  self->paused_ = !self->paused_;
+  if (self->pause_lbl_) lv_label_set_text(self->pause_lbl_, self->paused_ ? LV_SYMBOL_PLAY : LV_SYMBOL_PAUSE);
+  self->updateScoreLabel();
+}
+
+void TetrisGame::closeCb(lv_event_t* e) {
+  auto* self = static_cast<TetrisGame*>(lv_event_get_user_data(e));
+  if (!self) return;
+  self->close();
+  if (s_active == self) s_active = nullptr;
+  delete self;
+}

--- a/src/ui-touch/TetrisGame.h
+++ b/src/ui-touch/TetrisGame.h
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <lvgl.h>
+
+// Self-contained Tetris mini-game launched from the Apps drawer.
+//
+// Mirrors SnakeGame's integration style: one full-screen overlay on lv_layer_top,
+// its own score / controls row, start gate, pause button, and close button.
+// UITask routes swipe + trackball input here via isOpen()/steer() so the game
+// stays decoupled from the rest of the touch UI internals.
+class TetrisGame {
+public:
+  static void launch();                 // open (no-op if already open)
+  static bool isOpen();                 // UITask: gate background gestures / tab bar
+  static void steer(int dx, int dy);    // UITask: trackball or swipe -> game control
+
+private:
+  static constexpr int kFieldW = 10;
+  static constexpr int kFieldH = 20;
+  static constexpr int kPreviewW = 4;
+  static constexpr int kPreviewH = 4;
+  static constexpr int kMaxCellPx = 14;
+  static constexpr uint32_t kTickMs = 40;
+
+  lv_obj_t*   root_      = nullptr;
+  lv_obj_t*   board_     = nullptr;
+  lv_obj_t*   preview_   = nullptr;
+  lv_color_t* boardBuf_  = nullptr;
+  lv_color_t* prevBuf_   = nullptr;
+  lv_obj_t*   score_     = nullptr;
+  lv_obj_t*   nextLbl_   = nullptr;
+  lv_obj_t*   start_btn_ = nullptr;
+  lv_obj_t*   pause_btn_ = nullptr;
+  lv_obj_t*   pause_lbl_ = nullptr;
+  lv_timer_t* timer_     = nullptr;
+
+  int cellPx_      = 10;
+  int boardWpx_    = 0;
+  int boardHpx_    = 0;
+  int boardX_      = 0;
+  int boardY_      = 0;
+  int previewX_    = 0;
+  int previewY_    = 0;
+
+  uint8_t field_[kFieldH][kFieldW] = {};
+  int currentX_ = 0, currentY_ = 0;
+  int currentType_ = 0, currentRot_ = 0;
+  int nextType_ = 0;
+  int scoreVal_ = 0;
+  int linesCleared_ = 0;
+  int dropIntervalMs_ = 500;
+  uint32_t lastDropMs_ = 0;
+  bool started_ = false;
+  bool paused_  = false;
+  bool over_    = false;
+
+  bool open();
+  void close();
+  void startGame();
+  void beginRound();
+  void updateScoreLabel();
+  void render();
+  void step();
+  void settlePiece();
+  bool movePiece(int dx, int dy);
+  void rotatePiece();
+  void softDrop();
+  void spawnPiece();
+  void lockPiece();
+  void clearLines();
+  bool checkCollision(int x, int y, int rot) const;
+  int  getBlock(int type, int rot, int x, int y) const;
+
+  static TetrisGame* s_active;
+  static void timerCb(lv_timer_t* t);
+  static void tapCb(lv_event_t* e);
+  static void closeCb(lv_event_t* e);
+  static void startCb(lv_event_t* e);
+  static void pauseCb(lv_event_t* e);
+};

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -1490,6 +1490,7 @@ enum class SettingsModalKind : uint8_t {
   SystemInfo,   // Read-only system / firmware diagnostic page
   AddContact,   // Manual add-contact (pubkey + name) modal
   QuickReply,   // Edit the 6 quick-reply preset macros
+  Mqtt,         // MQTT bridge config
 };
 
 struct SettingsModalState {
@@ -1536,6 +1537,11 @@ struct SettingsModalState {
    *  the slot (so the picker shows "(empty)" and a save with text repopulates).
    *  Allocated only while the modal is open. */
   lv_obj_t* qr_tas[TOUCH_QUICK_REPLY_COUNT];
+  lv_obj_t* mqtt_en_sw;
+  lv_obj_t* mqtt_host_ta;
+  lv_obj_t* mqtt_port_ta;
+  lv_obj_t* mqtt_user_ta;
+  lv_obj_t* mqtt_pwd_ta;
 };
 static SettingsModalState g_set_modal = {};
 
@@ -3511,6 +3517,7 @@ enum {
   CAT_GENERAL,       // reboot, run setup, storage/SD, misc device prefs (was "System")
   CAT_BACKUPS,       // list/delete .json backups + factory reset
   CAT_LANGUAGE,      // UI language picker
+  CAT_MQTT,          // MQTT bridge — broker host/port/credentials
   CAT_ABOUT,         // firmware / update / system info / diagnostics
   CAT_COUNT
 };
@@ -3533,6 +3540,7 @@ static const SettingsCatDef kSettingsCats[CAT_COUNT] = {
   { "General",       LV_SYMBOL_SETTINGS },
   { "Backups",       LV_SYMBOL_SAVE },
   { "Language",      LV_SYMBOL_BARS },
+  { "MQTT bridge",   LV_SYMBOL_UPLOAD },
   { "About",         LV_SYMBOL_LIST },
 };
 // Which slice of the (formerly monolithic) Device settings a builder emits. One
@@ -10194,6 +10202,7 @@ static void doApplyWifi() {
 
 // Forward decl so wifiSlotSaveCb can refresh the modal after writing.
 static void buildWifiSettings();
+static void buildMqttSettings();
 
 // Saved Wi-Fi profile slot: tap to load. Fills the SSID/PWD textareas with
 // the stored creds — does NOT auto-apply, so the operator can still tweak
@@ -10881,6 +10890,186 @@ static void wifiRebuildNetworkList() {
   navMarkDirty();
 }
 #endif  // ESP32 && MULTI_TRANSPORT_COMPANION
+
+// ---- MQTT bridge settings callbacks ----------------------------------------
+
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+#include "helpers/esp32/MqttBridge.h"
+
+struct MqttBrokerPreset { const char* label; const char* host; uint16_t port; };
+static const MqttBrokerPreset kMqttPresets[] = {
+  { "Home Assistant",  "homeassistant.local",  1883 },
+  { "HiveMQ public",   "broker.hivemq.com",    1883 },
+  { "Mosquitto test",  "test.mosquitto.org",   1883 },
+  { "EMQX public",     "broker.emqx.io",       1883 },
+};
+
+static void mqttPresetCb(lv_event_t* e) {
+  const int idx = (int)(intptr_t)lv_event_get_user_data(e);
+  if (idx < 0 || idx >= (int)(sizeof(kMqttPresets)/sizeof(kMqttPresets[0]))) return;
+  if (!g_set_modal.mqtt_host_ta || !g_set_modal.mqtt_port_ta) return;
+  lv_textarea_set_text(g_set_modal.mqtt_host_ta, kMqttPresets[idx].host);
+  char portBuf[8]; snprintf(portBuf, sizeof(portBuf), "%u", kMqttPresets[idx].port);
+  lv_textarea_set_text(g_set_modal.mqtt_port_ta, portBuf);
+}
+
+static void mqttSaveCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
+  if (!g_set_modal.mqtt_host_ta) return;
+  const char* host = lv_textarea_get_text(g_set_modal.mqtt_host_ta);
+  const char* portStr = lv_textarea_get_text(g_set_modal.mqtt_port_ta);
+  const char* user = lv_textarea_get_text(g_set_modal.mqtt_user_ta);
+  const char* pwd  = lv_textarea_get_text(g_set_modal.mqtt_pwd_ta);
+  uint16_t port = portStr && portStr[0] ? (uint16_t)atoi(portStr) : 1883;
+  if (!port) port = 1883;
+  bool en = g_set_modal.mqtt_en_sw && lv_obj_has_state(g_set_modal.mqtt_en_sw, LV_STATE_CHECKED);
+  MqttBridge::saveConfig(host, port, user, pwd, en);
+  mqtt_bridge.reloadConfig();
+  closeSettingsModal();
+}
+#endif // ESP32 && MULTI_TRANSPORT_COMPANION
+
+static void buildMqttSettings() {
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  lv_obj_t* body = createSettingsModal("MQTT bridge", SettingsModalKind::Mqtt);
+  const lv_coord_t cw = s_settings_content_w;
+  int y = 0;
+
+  // ---- Enable toggle ----
+  lv_obj_t* en_lbl = lv_label_create(body);
+  lv_label_set_text(en_lbl, TR("Enable MQTT bridge"));
+  lv_obj_set_style_text_color(en_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(en_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(en_lbl, 2, y + 8);
+  g_set_modal.mqtt_en_sw = lv_switch_create(body);
+  lv_obj_align(g_set_modal.mqtt_en_sw, LV_ALIGN_TOP_RIGHT, 0, y);
+  y += SC(38);
+
+  // ---- Preset broker buttons ----
+  lv_obj_t* pre_lbl = lv_label_create(body);
+  lv_label_set_text(pre_lbl, TR("Quick presets"));
+  lv_obj_set_style_text_color(pre_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(pre_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(pre_lbl, 2, y);
+  y += SC(16);
+  const int nPresets = (int)(sizeof(kMqttPresets)/sizeof(kMqttPresets[0]));
+  const lv_coord_t btn_w = (cw - (nPresets - 1) * 4) / nPresets;
+  for (int i = 0; i < nPresets; ++i) {
+    lv_obj_t* pb = lv_btn_create(body);
+    lv_obj_set_size(pb, btn_w, SC(28));
+    lv_obj_set_pos(pb, i * (btn_w + 4), y);
+    styleButton(pb);
+    lv_obj_set_style_bg_color(pb, lv_color_hex(0x1A3A5C), LV_PART_MAIN);
+    lv_obj_add_event_cb(pb, mqttPresetCb, LV_EVENT_CLICKED, (void*)(intptr_t)i);
+    lv_obj_t* pl = lv_label_create(pb);
+    lv_label_set_text(pl, kMqttPresets[i].label);
+    lv_obj_set_style_text_font(pl, &g_font_12, LV_PART_MAIN);
+    lv_label_set_long_mode(pl, LV_LABEL_LONG_DOT);
+    lv_obj_set_width(pl, btn_w - 4);
+    lv_obj_center(pl);
+  }
+  y += SC(34);
+
+  // ---- Broker host ----
+  lv_obj_t* host_lbl = lv_label_create(body);
+  lv_label_set_text(host_lbl, TR("Broker host / IP"));
+  lv_obj_set_style_text_color(host_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(host_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(host_lbl, 2, y);
+  y += SC(16);
+  g_set_modal.mqtt_host_ta = lv_textarea_create(body);
+  lv_obj_set_size(g_set_modal.mqtt_host_ta, cw - 86, SC(30));
+  lv_obj_set_pos(g_set_modal.mqtt_host_ta, 0, y);
+  lv_textarea_set_one_line(g_set_modal.mqtt_host_ta, true);
+  lv_textarea_set_placeholder_text(g_set_modal.mqtt_host_ta, "192.168.1.x");
+  lv_textarea_set_max_length(g_set_modal.mqtt_host_ta, 63);
+  attachSettingsTaEvents(g_set_modal.mqtt_host_ta);
+  // Port field on the same row
+  lv_obj_t* port_lbl = lv_label_create(body);
+  lv_label_set_text(port_lbl, TR("Port"));
+  lv_obj_set_style_text_color(port_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(port_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(port_lbl, cw - 82, y - SC(16));
+  g_set_modal.mqtt_port_ta = lv_textarea_create(body);
+  lv_obj_set_size(g_set_modal.mqtt_port_ta, 80, SC(30));
+  lv_obj_set_pos(g_set_modal.mqtt_port_ta, cw - 80, y);
+  lv_textarea_set_one_line(g_set_modal.mqtt_port_ta, true);
+  lv_textarea_set_placeholder_text(g_set_modal.mqtt_port_ta, "1883");
+  lv_textarea_set_max_length(g_set_modal.mqtt_port_ta, 5);
+  lv_textarea_set_accepted_chars(g_set_modal.mqtt_port_ta, "0123456789");
+  attachSettingsTaEvents(g_set_modal.mqtt_port_ta);
+  y += SC(36);
+
+  // ---- Username (optional) ----
+  lv_obj_t* user_lbl = lv_label_create(body);
+  lv_label_set_text(user_lbl, TR("Username (optional)"));
+  lv_obj_set_style_text_color(user_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(user_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(user_lbl, 2, y);
+  y += SC(16);
+  g_set_modal.mqtt_user_ta = lv_textarea_create(body);
+  lv_obj_set_size(g_set_modal.mqtt_user_ta, lv_pct(100), SC(30));
+  lv_obj_set_pos(g_set_modal.mqtt_user_ta, 0, y);
+  lv_textarea_set_one_line(g_set_modal.mqtt_user_ta, true);
+  lv_textarea_set_placeholder_text(g_set_modal.mqtt_user_ta, TR("Leave empty if not required"));
+  lv_textarea_set_max_length(g_set_modal.mqtt_user_ta, 31);
+  attachSettingsTaEvents(g_set_modal.mqtt_user_ta);
+  y += SC(36);
+
+  // ---- Password (optional) ----
+  lv_obj_t* pwd_lbl = lv_label_create(body);
+  lv_label_set_text(pwd_lbl, TR("Password (optional)"));
+  lv_obj_set_style_text_color(pwd_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(pwd_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(pwd_lbl, 2, y);
+  y += SC(16);
+  g_set_modal.mqtt_pwd_ta = lv_textarea_create(body);
+  lv_obj_set_size(g_set_modal.mqtt_pwd_ta, lv_pct(100), SC(30));
+  lv_obj_set_pos(g_set_modal.mqtt_pwd_ta, 0, y);
+  lv_textarea_set_one_line(g_set_modal.mqtt_pwd_ta, true);
+  lv_textarea_set_password_mode(g_set_modal.mqtt_pwd_ta, true);
+  lv_textarea_set_placeholder_text(g_set_modal.mqtt_pwd_ta, TR("Leave empty if not required"));
+  lv_textarea_set_max_length(g_set_modal.mqtt_pwd_ta, 31);
+  attachSettingsTaEvents(g_set_modal.mqtt_pwd_ta);
+  y += SC(36);
+
+  // ---- Load current config ----
+  {
+    Preferences p;
+    bool cur_en = false;
+    char cur_host[64] = {}, cur_port_s[8] = "1883", cur_user[32] = {}, cur_pwd[32] = {};
+    if (p.begin("mqtt", true)) {
+      cur_en = p.getBool("en", false);
+      p.getString("host", cur_host, sizeof(cur_host));
+      uint16_t port = (uint16_t)p.getUInt("port", 1883);
+      snprintf(cur_port_s, sizeof(cur_port_s), "%u", port);
+      p.getString("user", cur_user, sizeof(cur_user));
+      p.getString("pwd",  cur_pwd,  sizeof(cur_pwd));
+      p.end();
+    }
+    if (cur_en) lv_obj_add_state(g_set_modal.mqtt_en_sw, LV_STATE_CHECKED);
+    lv_textarea_set_text(g_set_modal.mqtt_host_ta, cur_host);
+    lv_textarea_set_text(g_set_modal.mqtt_port_ta, cur_port_s);
+    lv_textarea_set_text(g_set_modal.mqtt_user_ta, cur_user);
+    lv_textarea_set_text(g_set_modal.mqtt_pwd_ta,  cur_pwd);
+  }
+
+  // ---- Save button ----
+  lv_obj_t* b_save = lv_btn_create(body);
+  lv_obj_set_size(b_save, lv_pct(100), SC(36));
+  lv_obj_set_pos(b_save, 0, y);
+  styleButton(b_save);
+  lv_obj_add_event_cb(b_save, mqttSaveCb, LV_EVENT_CLICKED, nullptr);
+  { lv_obj_t* sl = lv_label_create(b_save);
+    lv_label_set_text(sl, LV_SYMBOL_SAVE "  Save");
+    lv_obj_center(sl); }
+  y += SC(44);
+
+  lv_obj_set_height(body, y + SC(8));
+#else
+  (void)0;   // MQTT bridge only active on ESP32 multi-transport builds
+#endif
+}
 
 static void buildWifiSettings() {
   lv_obj_t* body = createSettingsModal("", SettingsModalKind::Wifi);   // no group header — the top bar already says "Wi-Fi"
@@ -22994,6 +23183,7 @@ static void settingsCatBuild(int cat) {
     case CAT_GENERAL:      buildDeviceSettings(DSEC_GENERAL); break;
     case CAT_BACKUPS:      buildBackupsSettings(); break;
     case CAT_LANGUAGE:     buildLanguageSettings(); break;
+    case CAT_MQTT:         buildMqttSettings(); break;
     case CAT_ABOUT: {
       s_settings_inline_parent = nullptr;
       s_update_about_lbl = lv_label_create(page);   // update/firmware status (top)

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -76,6 +76,7 @@
 #include <Utils.h>
 #include <LvglPsramAlloc.h>   // PSRAM-preferred alloc helpers for the map tile cache
 #include "SnakeGame.h"        // Apps → Snake (self-contained game module)
+#include "TetrisGame.h"       // Apps → Tetris (self-contained game module)
 
 #if defined(HAS_TOUCH_UI)
   #include <lvgl.h>
@@ -1543,6 +1544,7 @@ struct SettingsModalState {
   lv_obj_t* mqtt_port_ta;
   lv_obj_t* mqtt_user_ta;
   lv_obj_t* mqtt_pwd_ta;
+  lv_obj_t* mqtt_topic_ta;
 };
 static SettingsModalState g_set_modal = {};
 
@@ -3932,9 +3934,14 @@ static void applySwipeGesture(int8_t swipe_x, int8_t swipe_y) {
   // cap-touch — so this, not SnakeGame's gestureCb, is what makes touch steering
   // actually work. swipe_x<0 == left, swipe_y<0 == up (see the control-center
   // note below for the sign convention).
-  if (SnakeGame::isOpen()) {
-    if (swipe_x != 0)      SnakeGame::steer(swipe_x < 0 ? -1 : 1, 0);
-    else if (swipe_y != 0) SnakeGame::steer(0, swipe_y < 0 ? -1 : 1);
+  if (SnakeGame::isOpen() || TetrisGame::isOpen()) {
+    if (swipe_x != 0) {
+      if (SnakeGame::isOpen()) SnakeGame::steer(swipe_x < 0 ? -1 : 1, 0);
+      else                     TetrisGame::steer(swipe_x < 0 ? -1 : 1, 0);
+    } else if (swipe_y != 0) {
+      if (SnakeGame::isOpen()) SnakeGame::steer(0, swipe_y < 0 ? -1 : 1);
+      else                     TetrisGame::steer(0, swipe_y < 0 ? -1 : 1);
+    }
     return;
   }
   // A slider was just being dragged — its horizontal drag must NOT be read as a
@@ -10919,10 +10926,11 @@ static void mqttSaveCb(lv_event_t* e) {
   const char* portStr = lv_textarea_get_text(g_set_modal.mqtt_port_ta);
   const char* user = lv_textarea_get_text(g_set_modal.mqtt_user_ta);
   const char* pwd  = lv_textarea_get_text(g_set_modal.mqtt_pwd_ta);
+  const char* pfx  = g_set_modal.mqtt_topic_ta ? lv_textarea_get_text(g_set_modal.mqtt_topic_ta) : nullptr;
   uint16_t port = portStr && portStr[0] ? (uint16_t)atoi(portStr) : 1883;
   if (!port) port = 1883;
   bool en = g_set_modal.mqtt_en_sw && lv_obj_has_state(g_set_modal.mqtt_en_sw, LV_STATE_CHECKED);
-  MqttBridge::saveConfig(host, port, user, pwd, en);
+  MqttBridge::saveConfig(host, port, user, pwd, pfx && pfx[0] ? pfx : "wadamesh", en);
   mqtt_bridge.reloadConfig();
   closeSettingsModal();
 }
@@ -11032,11 +11040,28 @@ static void buildMqttSettings() {
   attachSettingsTaEvents(g_set_modal.mqtt_pwd_ta);
   y += SC(36);
 
+  // ---- Topic prefix ----
+  lv_obj_t* topic_lbl = lv_label_create(body);
+  lv_label_set_text(topic_lbl, TR("Topic prefix"));
+  lv_obj_set_style_text_color(topic_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+  lv_obj_set_style_text_font(topic_lbl, &g_font_12, LV_PART_MAIN);
+  lv_obj_set_pos(topic_lbl, 2, y);
+  y += SC(16);
+  g_set_modal.mqtt_topic_ta = lv_textarea_create(body);
+  lv_obj_set_size(g_set_modal.mqtt_topic_ta, lv_pct(100), SC(30));
+  lv_obj_set_pos(g_set_modal.mqtt_topic_ta, 0, y);
+  lv_textarea_set_one_line(g_set_modal.mqtt_topic_ta, true);
+  lv_textarea_set_placeholder_text(g_set_modal.mqtt_topic_ta, "wadamesh");
+  lv_textarea_set_max_length(g_set_modal.mqtt_topic_ta, 47);
+  attachSettingsTaEvents(g_set_modal.mqtt_topic_ta);
+  y += SC(36);
+
   // ---- Load current config ----
   {
     Preferences p;
     bool cur_en = false;
     char cur_host[64] = {}, cur_port_s[8] = "1883", cur_user[32] = {}, cur_pwd[32] = {};
+    char cur_topic_pfx[48] = "wadamesh";
     if (p.begin("mqtt", true)) {
       cur_en = p.getBool("en", false);
       p.getString("host", cur_host, sizeof(cur_host));
@@ -11044,6 +11069,8 @@ static void buildMqttSettings() {
       snprintf(cur_port_s, sizeof(cur_port_s), "%u", port);
       p.getString("user", cur_user, sizeof(cur_user));
       p.getString("pwd",  cur_pwd,  sizeof(cur_pwd));
+      p.getString("topic_pfx", cur_topic_pfx, sizeof(cur_topic_pfx));
+      if (cur_topic_pfx[0] == '\0') strncpy(cur_topic_pfx, "wadamesh", sizeof(cur_topic_pfx) - 1);
       p.end();
     }
     if (cur_en) lv_obj_add_state(g_set_modal.mqtt_en_sw, LV_STATE_CHECKED);
@@ -11051,6 +11078,7 @@ static void buildMqttSettings() {
     lv_textarea_set_text(g_set_modal.mqtt_port_ta, cur_port_s);
     lv_textarea_set_text(g_set_modal.mqtt_user_ta, cur_user);
     lv_textarea_set_text(g_set_modal.mqtt_pwd_ta,  cur_pwd);
+    lv_textarea_set_text(g_set_modal.mqtt_topic_ta, cur_topic_pfx);
   }
 
   // ---- Save button ----
@@ -20556,6 +20584,23 @@ static bool s_map_show_tilexyz   = true;
 static bool s_map_show_contacts  = true;
 static bool s_map_direct_only    = false;  // when true, only 0-hop (directly-heard) contacts appear
 
+// Contact type filter bitmask: bit0=chat/mobile, 1=repeater, 2=room, 3=sensor (0x0F = all shown).
+static uint8_t s_map_type_filter     = 0x0F;
+// Show RSSI-estimated range rings around contact markers.
+static bool    s_map_show_rssi_rings = false;
+// Show RSSI ring objects — tracked separately so freeMapMarkers() can clean them up.
+static lv_obj_t* s_map_ring_objs[k_map_markers_max] = {};
+// Toast alert when a GPS-located contact appears or disappears.
+static bool    s_map_node_alerts     = false;
+
+// Node-alert state: contact IDs (4-byte pub_key prefix) seen on the last check.
+struct MapContactId { uint32_t hash; char name[32]; };
+static constexpr int k_map_alert_max = 64;
+static MapContactId  s_map_known_ids[k_map_alert_max];
+static int           s_map_known_n      = 0;
+static bool          s_map_known_inited = false;
+static uint32_t      s_map_alerts_last_ms = 0;
+
 // Apply the coords/tile-line visibility flags to the two corner labels. Safe to
 // call before the labels exist (null-guarded); invoked at map build + on toggle.
 static void applyMapTextVis() {
@@ -20604,6 +20649,9 @@ static void freeMapMarkers() {
   for (auto& ln : s_map_link_objs) {
     if (ln) { lv_obj_del(ln); ln = nullptr; }
   }
+  for (auto& r : s_map_ring_objs) {
+    if (r) { lv_obj_del(r); r = nullptr; }
+  }
   for (int i = 0; i < s_route_obj_n; ++i) {
     if (s_route_objs[i]) { lv_obj_del(s_route_objs[i]); s_route_objs[i] = nullptr; }
   }
@@ -20616,6 +20664,16 @@ static void openMapPicker(const int* idxs, int n);
 // (onMapMarkerClickedCb removed — marker taps are now dispatched centrally
 // from the canvas's RELEASED handler in mapCanvasEventCb. See the marker
 // scan in the tap branch below.)
+
+// Returns the type-filter bit index (0-3) for a given ADV_TYPE_* value.
+static uint8_t typeFilterBit(uint8_t adv_type) {
+  switch (adv_type) {
+    case ADV_TYPE_REPEATER: return 1;
+    case ADV_TYPE_ROOM:     return 2;
+    case ADV_TYPE_SENSOR:   return 3;
+    default:                return 0;  // ADV_TYPE_CHAT and anything unknown
+  }
+}
 
 // Plot self + contacts onto the canvas at their lat/lon. Called every time
 // tiles are re-rendered (pan, zoom, recenter, tab open) so markers stay
@@ -20661,6 +20719,7 @@ static void renderMapMarkers() {
       if (!the_mesh.getContactByIdx(i, c)) continue;
       if (c.gps_lat == 0 && c.gps_lon == 0) continue;
       if (s_map_direct_only && c.out_path_len != 0) continue;
+      if (!(s_map_type_filter & (1u << typeFilterBit(c.type)))) continue;
       double mwx, mwy;
       latLonToWorldPx((double)c.gps_lat / 1.0e6, (double)c.gps_lon / 1.0e6,
                       s_map_zoom, &mwx, &mwy);
@@ -20709,6 +20768,7 @@ static void renderMapMarkers() {
     if (!the_mesh.getContactByIdx(i, c)) continue;
     if (c.gps_lat == 0 && c.gps_lon == 0) continue;
     if (s_map_direct_only && c.out_path_len != 0) continue;
+    if (!(s_map_type_filter & (1u << typeFilterBit(c.type)))) continue;
 
     const double lat = (double)c.gps_lat / 1.0e6;
     const double lon = (double)c.gps_lon / 1.0e6;
@@ -20744,6 +20804,35 @@ static void renderMapMarkers() {
     // pan handler instead of being swallowed by the marker.
     lv_obj_clear_flag(m.obj, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_clear_flag(m.obj, LV_OBJ_FLAG_SCROLLABLE);
+
+    // RSSI range ring — drawn before the dot would be better, but since we use
+    // LVGL z-order (children rendered in creation order), we draw the ring here
+    // then move it behind the marker using lv_obj_move_to_index().
+    if (s_map_show_rssi_rings && g_lv.task) {
+      const int8_t rssi = g_lv.task->getContactLastRssi(c.name);
+      if (rssi < -20 && rssi > -130) {
+        // Rough free-space estimate: tx_power=20 dBm, FSPL at 1 m ≈ 31.7 dB at 915 MHz.
+        // range_m = 10^((tx - fspl_1m - rssi) / 20)
+        const double m_per_px = 156543.03 * cos(lat * M_PI / 180.0) / (double)(1u << s_map_zoom);
+        const double radius_m = pow(10.0, (20.0 - 31.7 - (double)rssi) / 20.0);
+        int rpx = (int)round(radius_m / m_per_px);
+        if (rpx < 4)   rpx = 4;
+        if (rpx > 120) rpx = 120;
+        lv_obj_t* ring = lv_obj_create(parent);
+        lv_obj_remove_style_all(ring);
+        lv_obj_set_size(ring, rpx * 2, rpx * 2);
+        lv_obj_set_pos(ring, sx - rpx, sy - rpx);
+        lv_obj_set_style_bg_opa(ring, LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_set_style_border_color(ring, lv_color_hex(color), LV_PART_MAIN);
+        lv_obj_set_style_border_width(ring, 1, LV_PART_MAIN);
+        lv_obj_set_style_border_opa(ring, LV_OPA_40, LV_PART_MAIN);
+        lv_obj_set_style_radius(ring, rpx, LV_PART_MAIN);
+        lv_obj_clear_flag(ring, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_move_to_index(ring, 0);   // push behind the dot
+        s_map_ring_objs[slot] = ring;
+      }
+    }
+
     ++slot;
   }
 
@@ -21166,6 +21255,41 @@ static void mapOptDirectOnlyCb(lv_event_t* e) {
   renderMapMarkers();
 }
 
+// Type filter: one callback handles all 4 bits — user_data = bit index (0-3).
+static void mapOptTypeFilterCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  const uint8_t bit = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+  if (lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED))
+    s_map_type_filter |=  (uint8_t)(1u << bit);
+  else
+    s_map_type_filter &= (uint8_t)~(1u << bit);
+  if (!s_map_type_filter) s_map_type_filter = 0x0F;   // guard: never hide everything
+#if defined(ESP32)
+  touchPrefsSetMapTypeFilter(s_map_type_filter);
+#endif
+  renderMapMarkers();
+}
+
+// RSSI range rings toggle.
+static void mapOptRssiRingsCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  s_map_show_rssi_rings = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
+#if defined(ESP32)
+  touchPrefsSetMapShowRssiRings(s_map_show_rssi_rings);
+#endif
+  renderMapMarkers();
+}
+
+// Node appear/disappear alerts toggle.
+static void mapOptNodeAlertsCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  s_map_node_alerts = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
+#if defined(ESP32)
+  touchPrefsSetMapNodeAlerts(s_map_node_alerts);
+#endif
+  if (!s_map_node_alerts) { s_map_known_inited = false; }   // reset tracking when disabled
+}
+
 static void mapZoomControlsApply();   // fwd (defined near the map build) — reposition zoom controls
 // Map zoom-control style toggle (map options popup): ON = +/- buttons, OFF = slider.
 static void mapOptZoomButtonsCb(lv_event_t* e) {
@@ -21459,6 +21583,96 @@ static void openMapOptions() {
       lv_obj_add_event_cb(sw, r.cb, LV_EVENT_VALUE_CHANGED, nullptr);
       y += 40;
     }
+  }
+
+  // Section: filter by contact type.
+  {
+    lv_obj_t* sep2 = lv_obj_create(card);
+    lv_obj_remove_style_all(sep2);
+    lv_obj_set_size(sep2, cardw - 24, 1);
+    lv_obj_set_pos(sep2, 0, y + 4);
+    lv_obj_set_style_bg_color(sep2, lv_color_hex(0x303438), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(sep2, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_t* sl2 = lv_label_create(card);
+    lv_label_set_text(sl2, TR("Filter by type"));
+    lv_obj_set_style_text_color(sl2, lv_color_hex(0x8A929B), LV_PART_MAIN);
+    lv_obj_set_style_text_font(sl2, &g_font_12, LV_PART_MAIN);
+    lv_obj_set_pos(sl2, 2, y + 10);
+    y += 34;
+
+    struct { const char* label; uint8_t bit; } types[] = {
+      { "Mobile / chat",  0 },
+      { "Repeater",       1 },
+      { "Room",           2 },
+      { "Sensor",         3 },
+    };
+    for (auto& t : types) {
+      lv_obj_t* tl = lv_label_create(card);
+      lv_label_set_text(tl, TR(t.label));
+      lv_obj_set_style_text_color(tl, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
+      lv_obj_set_style_text_font(tl, &g_font_14, LV_PART_MAIN);
+      lv_obj_set_pos(tl, 2, y + 4);
+      lv_obj_t* tsw = lv_switch_create(card);
+      lv_obj_align(tsw, LV_ALIGN_TOP_RIGHT, 0, y);
+      if (s_map_type_filter & (1u << t.bit)) lv_obj_add_state(tsw, LV_STATE_CHECKED);
+      lv_obj_add_event_cb(tsw, mapOptTypeFilterCb, LV_EVENT_VALUE_CHANGED,
+                          (void*)(uintptr_t)t.bit);
+      y += 40;
+    }
+  }
+
+  // Section: overlays.
+  {
+    lv_obj_t* sep3 = lv_obj_create(card);
+    lv_obj_remove_style_all(sep3);
+    lv_obj_set_size(sep3, cardw - 24, 1);
+    lv_obj_set_pos(sep3, 0, y + 4);
+    lv_obj_set_style_bg_color(sep3, lv_color_hex(0x303438), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(sep3, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_t* sl3 = lv_label_create(card);
+    lv_label_set_text(sl3, TR("Overlays"));
+    lv_obj_set_style_text_color(sl3, lv_color_hex(0x8A929B), LV_PART_MAIN);
+    lv_obj_set_style_text_font(sl3, &g_font_12, LV_PART_MAIN);
+    lv_obj_set_pos(sl3, 2, y + 10);
+    y += 34;
+
+    lv_obj_t* rl = lv_label_create(card);
+    lv_label_set_text(rl, TR("RSSI range rings"));
+    lv_obj_set_style_text_color(rl, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
+    lv_obj_set_style_text_font(rl, &g_font_14, LV_PART_MAIN);
+    lv_obj_set_pos(rl, 2, y + 4);
+    lv_obj_t* rsw = lv_switch_create(card);
+    lv_obj_align(rsw, LV_ALIGN_TOP_RIGHT, 0, y);
+    if (s_map_show_rssi_rings) lv_obj_add_state(rsw, LV_STATE_CHECKED);
+    lv_obj_add_event_cb(rsw, mapOptRssiRingsCb, LV_EVENT_VALUE_CHANGED, nullptr);
+    y += 40;
+  }
+
+  // Section: alerts.
+  {
+    lv_obj_t* sep4 = lv_obj_create(card);
+    lv_obj_remove_style_all(sep4);
+    lv_obj_set_size(sep4, cardw - 24, 1);
+    lv_obj_set_pos(sep4, 0, y + 4);
+    lv_obj_set_style_bg_color(sep4, lv_color_hex(0x303438), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(sep4, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_t* sl4 = lv_label_create(card);
+    lv_label_set_text(sl4, TR("Alerts"));
+    lv_obj_set_style_text_color(sl4, lv_color_hex(0x8A929B), LV_PART_MAIN);
+    lv_obj_set_style_text_font(sl4, &g_font_12, LV_PART_MAIN);
+    lv_obj_set_pos(sl4, 2, y + 10);
+    y += 34;
+
+    lv_obj_t* al = lv_label_create(card);
+    lv_label_set_text(al, TR("Node appear / leave"));
+    lv_obj_set_style_text_color(al, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
+    lv_obj_set_style_text_font(al, &g_font_14, LV_PART_MAIN);
+    lv_obj_set_pos(al, 2, y + 4);
+    lv_obj_t* asw = lv_switch_create(card);
+    lv_obj_align(asw, LV_ALIGN_TOP_RIGHT, 0, y);
+    if (s_map_node_alerts) lv_obj_add_state(asw, LV_STATE_CHECKED);
+    lv_obj_add_event_cb(asw, mapOptNodeAlertsCb, LV_EVENT_VALUE_CHANGED, nullptr);
+    y += 40;
   }
 
   auto mk_row_btn = [&](const char* txt, lv_event_cb_t cb) {
@@ -22199,6 +22413,70 @@ static void mapRecenterCb(lv_event_t* e) {
   renderMapTiles();
   renderMapMarkers();
   refreshMapInfoLabel();
+}
+
+// Alert tick: detect contacts appearing / disappearing. Throttled to once per 5 s.
+// Only watches contacts that have GPS coordinates — contacts without a position
+// would cause noisy false-positives whenever the contact list is rebuilt.
+static void mapAlertsTick() {
+  if (!s_map_node_alerts || !g_lv.task) return;
+  const uint32_t now_ms = millis();
+  if (s_map_known_inited && (uint32_t)(now_ms - s_map_alerts_last_ms) < 5000) return;
+  s_map_alerts_last_ms = now_ms;
+
+  // Build the current set of GPS-located contacts.
+  struct { uint32_t hash; char name[32]; } cur[k_map_alert_max];
+  int cur_n = 0;
+  const uint32_t total = the_mesh.getNumContacts();
+  for (uint32_t i = 0; i < total && cur_n < k_map_alert_max; ++i) {
+    ContactInfo c;
+    if (!the_mesh.getContactByIdx(i, c)) continue;
+    if (c.gps_lat == 0 && c.gps_lon == 0) continue;
+    uint32_t hash = 0; memcpy(&hash, c.id.pub_key, sizeof(hash));
+    cur[cur_n].hash = hash;
+    strncpy(cur[cur_n].name, c.name, 31); cur[cur_n].name[31] = '\0';
+    ++cur_n;
+  }
+
+  if (!s_map_known_inited) {
+    // Seed without alerting on the first run.
+    for (int i = 0; i < cur_n; ++i) {
+      s_map_known_ids[i].hash = cur[i].hash;
+      strncpy(s_map_known_ids[i].name, cur[i].name, 31);
+    }
+    s_map_known_n = cur_n;
+    s_map_known_inited = true;
+    return;
+  }
+
+  // New contacts (in cur but not in known).
+  for (int i = 0; i < cur_n; ++i) {
+    bool found = false;
+    for (int j = 0; j < s_map_known_n; ++j)
+      if (s_map_known_ids[j].hash == cur[i].hash) { found = true; break; }
+    if (!found) {
+      char msg[48]; snprintf(msg, sizeof(msg), "Online: %.28s", cur[i].name);
+      g_lv.task->showAlert(msg, 2500);
+    }
+  }
+  // Lost contacts (in known but not in cur).
+  for (int i = 0; i < s_map_known_n; ++i) {
+    bool found = false;
+    for (int j = 0; j < cur_n; ++j)
+      if (cur[j].hash == s_map_known_ids[i].hash) { found = true; break; }
+    if (!found) {
+      char msg[48]; snprintf(msg, sizeof(msg), "Offline: %.27s", s_map_known_ids[i].name);
+      g_lv.task->showAlert(msg, 2500);
+    }
+  }
+
+  // Update known set.
+  for (int i = 0; i < cur_n; ++i) {
+    s_map_known_ids[i].hash = cur[i].hash;
+    strncpy(s_map_known_ids[i].name, cur[i].name, 31);
+    s_map_known_ids[i].name[31] = '\0';
+  }
+  s_map_known_n = cur_n;
 }
 
 // Auto-follow: while enabled, recenter the map on self whenever the GPS position
@@ -25348,11 +25626,15 @@ static void updateTrackball(unsigned long now) {
 
   // ---- Snake game ----
   // While Snake is open the trackball steers it (no soft cursor on that page).
-  if (SnakeGame::isOpen()) {
+  if (SnakeGame::isOpen() || TetrisGame::isOpen()) {
     if (!lv_obj_has_flag(s_tb_cursor, LV_OBJ_FLAG_HIDDEN))
       lv_obj_add_flag(s_tb_cursor, LV_OBJ_FLAG_HIDDEN);
     s_tb_click_press = false;
-    if (moved && (dx != 0 || dy != 0)) { SnakeGame::steer(dx, dy); if (g_lv.task) g_lv.task->noteUserInput(); }
+    if (moved && (dx != 0 || dy != 0)) {
+      if (SnakeGame::isOpen()) SnakeGame::steer(dx, dy);
+      else                     TetrisGame::steer(dx, dy);
+      if (g_lv.task) g_lv.task->noteUserInput();
+    }
     return;
   }
 
@@ -27945,6 +28227,7 @@ enum AppDrawerAction {
   APPACT_CHATS, APPACT_CONTACTS, APPACT_MAP, APPACT_SETTINGS,
   APPACT_ADVERT, APPACT_POWER, APPACT_MENTIONS, APPACT_CMDCENTER, APPACT_SIGNAL,
   APPACT_TERMINAL, APPACT_FILES, APPACT_MONITOR, APPACT_SPECTRUM, APPACT_SNAKE,
+  APPACT_TETRIS,
 };
 
 static void closeAppDrawer() {
@@ -28192,6 +28475,7 @@ static void appTileCb(lv_event_t* e) {
     case APPACT_ADVERT:    openAdvertModalCb(e);  return;
     case APPACT_POWER:     openPowerMenu();      return;
     case APPACT_SNAKE:     SnakeGame::launch();  return;
+    case APPACT_TETRIS:    TetrisGame::launch(); return;
 #if defined(HAS_TOUCH_UI)
     case APPACT_TERMINAL:  homeTerminalCb(e);    return;
 #endif
@@ -28286,6 +28570,24 @@ static void addAppTile(lv_obj_t* parent, int x, int y, int w, int h,
     lv_obj_set_style_bg_color(eye, lv_color_hex(0x0E1216), LV_PART_MAIN);
     lv_obj_set_style_bg_opa(eye, LV_OPA_COVER, LV_PART_MAIN);
     lv_obj_set_style_radius(eye, 1, LV_PART_MAIN);
+  } else if (act == APPACT_TETRIS) {
+    // Stylized tetromino icon so the tile does not depend on a missing glyph.
+    lv_obj_t* box = lv_obj_create(chip_o);
+    lv_obj_remove_style_all(box);
+    lv_obj_clear_flag(box, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(box, 18, 18);
+    lv_obj_center(box);
+    static const struct { int8_t x, y; } seg[4] = { {0,6}, {6,6}, {12,6}, {6,0} };
+    for (int s = 0; s < 4; s++) {
+      lv_obj_t* cell = lv_obj_create(box);
+      lv_obj_remove_style_all(cell);
+      lv_obj_clear_flag(cell, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_set_size(cell, 6, 6);
+      lv_obj_set_pos(cell, seg[s].x, seg[s].y);
+      lv_obj_set_style_bg_color(cell, lv_color_hex(icon_col), LV_PART_MAIN);
+      lv_obj_set_style_bg_opa(cell, LV_OPA_COVER, LV_PART_MAIN);
+      lv_obj_set_style_radius(cell, 2, LV_PART_MAIN);
+    }
   } else if (icon) {
     lv_obj_t* ic = lv_label_create(chip_o);
     lv_label_set_text(ic, icon);
@@ -28499,6 +28801,7 @@ static void openAppDrawer() {
     { LV_SYMBOL_DIRECTORY, "Files",     APPACT_FILES,    0,         0xE6BE4A },      // folder gold
 #endif
     { nullptr,             "Snake",     APPACT_SNAKE,    0,         0x53C06B },      // snake game (icon drawn from APPACT_SNAKE, not a glyph)
+    { nullptr,             "Tetris",    APPACT_TETRIS,   0,         0x4AC7EA },      // tetris game (icon drawn from APPACT_TETRIS, not a glyph)
     { LV_SYMBOL_POWER,     "Power",     APPACT_POWER,    0,         0xE05544 },      // power red
   };
   const int n = (int)(sizeof(tiles) / sizeof(tiles[0]));
@@ -28584,7 +28887,7 @@ static void statusBarTapCb(lv_event_t* e) {
   // While Snake is up the bar is raised to the FRONT of lv_layer_top (see the
   // edge-trigger in updateGlobalStatusBar), so it stays tappable over the game.
   // Swallow the tap so it can't open the control centre over the game.
-  if (SnakeGame::isOpen()) return;
+  if (SnakeGame::isOpen() || TetrisGame::isOpen()) return;
   if (s_sb_shot_done) { s_sb_shot_done = false; return; }   // this press was a screenshot hold
   // A full-screen tool page (RF Monitor / Spectrum) is up: the bar carries its Back
   // chevron + title, so a tap goes back (closes the page) just like settings.
@@ -29085,7 +29388,7 @@ static void updateGlobalStatusBar() {
     // lv_layer_top and moved foreground, so without this the TALL bar's lower half (back
     // chevron + title) is covered by the page. Settings sheets sit on lv_scr_act so they
     // never need this.
-    const bool want_fg = SnakeGame::isOpen() || (s_apppage_title != nullptr);
+    const bool want_fg = SnakeGame::isOpen() || TetrisGame::isOpen() || (s_apppage_title != nullptr);
     if (want_fg != s_bar_fg) {
       s_bar_fg = want_fg;
       if (want_fg) lv_obj_move_foreground(g_statusbar.root);
@@ -29697,7 +30000,7 @@ static void refreshStatusLabels() {
   // Map tab: refresh the bottom info strip (self GPS + on-map count) only
   // when the tab is actually visible. Cheap, but no point doing it on every
   // tick if the user is somewhere else.
-  if (active_tab == MAP_TAB_INDEX) { mapAutoFollowTick(); refreshMapInfoLabel(); }
+  if (active_tab == MAP_TAB_INDEX) { mapAutoFollowTick(); mapAlertsTick(); refreshMapInfoLabel(); }
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
   // Wi-Fi fetcher arrived a new tile — re-render the map so the freshly
   // downloaded tile appears. Only re-render if we're actually on the
@@ -33579,7 +33882,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   s_map_style         = touchPrefsGetMapStyle();          // 0=OpenStreetMap (default), 1=OpenTopoMap
   { const uint8_t pz = touchPrefsGetMapZoom();    // restore the last user-set map zoom
     if (pz >= k_map_zoom_min && pz <= k_map_zoom_max) s_map_zoom = pz; }
-  s_map_zoom_buttons = touchPrefsGetMapZoomButtons();   // map zoom control: slider (default) vs +/- buttons
+  s_map_zoom_buttons    = touchPrefsGetMapZoomButtons();    // map zoom control: slider (default) vs +/- buttons
+  s_map_type_filter     = touchPrefsGetMapTypeFilter();     // contact type filter (0x0F = all)
+  s_map_show_rssi_rings = touchPrefsGetMapShowRssiRings();  // RSSI range rings
+  s_map_node_alerts     = touchPrefsGetMapNodeAlerts();     // appear/disappear alerts
   s_home_is_drawer   = touchPrefsGetHomeIsDrawer();     // Home tab default: Commander (default) vs app drawer
   // Monitor RX/RAW log rings live in PSRAM (2×28×80 = 4.4 KB) so they don't sit
   // in scarce internal DRAM that Wi-Fi DMA needs. Zero-init; the push/collect
@@ -34627,6 +34933,20 @@ int UITask::getGpsSats() {
   return lp ? (int)lp->satellitesCount() : -1;
 }
 
+int8_t UITask::getContactLastRssi(const char* name) const {
+  if (!name || !name[0] || !_ui_msgs) return 0;
+  int8_t best_rssi = 0;
+  uint32_t best_ts  = 0;
+  for (int i = 0; i < _ui_msg_count; ++i) {
+    const UIMessage& m = _ui_msgs[i];
+    if (m.outgoing || m.rssi == 0) continue;
+    if (strncmp(m.sender, name, MAX_SENDER_NAME) == 0) {
+      if (m.ts > best_ts) { best_ts = m.ts; best_rssi = m.rssi; }
+    }
+  }
+  return best_rssi;
+}
+
 // Keep the node's advertised location synced to GPS once we have a fix, and
 // persist it occasionally so a fix survives reboot ("had a fix at least once").
 // Called every UITask::loop(). No-op on boards without GPS (provider == NULL).
@@ -35544,7 +35864,7 @@ void UITask::loop() {
     }
     // Also hard-lock the tab bar while Snake is open so a swipe/tap near the
     // bottom can't slip through to the app switcher (e.g. into the map).
-    const bool want_lock = (now < s_tabbar_lock_until) || SnakeGame::isOpen();
+    const bool want_lock = (now < s_tabbar_lock_until) || SnakeGame::isOpen() || TetrisGame::isOpen();
     if (want_lock != s_tabbar_locked && g_lv.tabview) {
       lv_obj_t* tab_btns = lv_tabview_get_tab_btns(g_lv.tabview);
       if (tab_btns) {

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -9735,6 +9735,7 @@ static void buildDeviceSettings(int sec) {
   lv_label_set_text(l_reboot, TR("Reboot device"));
   lv_obj_center(l_reboot);
   y += SC(42);
+  }
 
   if (sec == DSEC_BATTERY) {   // --- Battery ---
   // ---- Battery ----
@@ -22057,6 +22058,12 @@ static bool mapZoomReachable(uint8_t z) {
   return false;
 }
 #endif
+// Sync the slider thumb + zoom label to s_map_zoom (called after any zoom step change).
+static void mapSyncSliderIfOpen() {
+  if (!s_map_zoom_slider || lv_obj_has_flag(s_map_zoom_slider, LV_OBJ_FLAG_HIDDEN)) return;
+  lv_slider_set_value(s_map_zoom_slider, s_map_zoom, LV_ANIM_OFF);
+  if (s_map_zoom_val) lv_label_set_text_fmt(s_map_zoom_val, "zoom %d", (int)s_map_zoom);
+}
 static void mapZoomInCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   if (s_map_zoom >= k_map_zoom_max) return;
@@ -22079,6 +22086,7 @@ static void mapZoomInCb(lv_event_t* e) {
   renderMapTiles();
   renderMapMarkers();
   refreshMapInfoLabel();
+  mapSyncSliderIfOpen();
 }
 static void mapZoomOutCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
@@ -22103,6 +22111,7 @@ static void mapZoomOutCb(lv_event_t* e) {
   renderMapTiles();
   renderMapMarkers();
   refreshMapInfoLabel();
+  mapSyncSliderIfOpen();
 }
 // Zoom slider overlay. The zoom button toggles it; dragging updates the live
 // readout, and releasing applies + persists the chosen level.
@@ -22137,9 +22146,18 @@ static void mapZoomToggleCb(lv_event_t* e) {
       lv_obj_clear_flag(s_map_zoom_val, LV_OBJ_FLAG_HIDDEN);
       lv_obj_move_foreground(s_map_zoom_val);
     }
+    // Show the step buttons that flank the zoom label (slider mode only)
+    if (!s_map_zoom_buttons) {
+      if (s_map_btn_zoomin)  { lv_obj_clear_flag(s_map_btn_zoomin,  LV_OBJ_FLAG_HIDDEN); lv_obj_move_foreground(s_map_btn_zoomin); }
+      if (s_map_btn_zoomout) { lv_obj_clear_flag(s_map_btn_zoomout, LV_OBJ_FLAG_HIDDEN); lv_obj_move_foreground(s_map_btn_zoomout); }
+    }
   } else {
     lv_obj_add_flag(s_map_zoom_slider, LV_OBJ_FLAG_HIDDEN);
-    if (s_map_zoom_val) lv_obj_add_flag(s_map_zoom_val, LV_OBJ_FLAG_HIDDEN);
+    if (s_map_zoom_val)    lv_obj_add_flag(s_map_zoom_val,    LV_OBJ_FLAG_HIDDEN);
+    if (!s_map_zoom_buttons) {
+      if (s_map_btn_zoomin)  lv_obj_add_flag(s_map_btn_zoomin,  LV_OBJ_FLAG_HIDDEN);
+      if (s_map_btn_zoomout) lv_obj_add_flag(s_map_btn_zoomout, LV_OBJ_FLAG_HIDDEN);
+    }
   }
 }
 // Position + show/hide the map zoom controls per s_map_zoom_buttons. The right-edge
@@ -22160,8 +22178,14 @@ static void mapZoomControlsApply() {
     if (s_map_zoom_val)    lv_obj_add_flag(s_map_zoom_val, LV_OBJ_FLAG_HIDDEN);
   } else {
     show(s_map_btn_zoomtoggle, y); y += H;
+    // Step buttons: pre-positioned flanking the zoom label above the slider.
+    // Hidden here; mapZoomToggleCb shows/hides them with the slider overlay.
     hide(s_map_btn_zoomin);
     hide(s_map_btn_zoomout);
+    if (s_map_btn_zoomin && s_map_zoom_slider)
+      lv_obj_align_to(s_map_btn_zoomin,  s_map_zoom_slider, LV_ALIGN_OUT_TOP_MID,  55, -6);
+    if (s_map_btn_zoomout && s_map_zoom_slider)
+      lv_obj_align_to(s_map_btn_zoomout, s_map_zoom_slider, LV_ALIGN_OUT_TOP_MID, -55, -6);
   }
   show(s_map_btn_recenter, y); y += H;
   show(s_map_btn_contacts, y); y += H;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -112,6 +112,7 @@
         #include <Update.h>   // Arduino OTA writer (native dual-OTA boards; Tanmatsu is IDF/AppFS, no OTA)
       #endif
       #include "../helpers/esp32/WifiRuntimeStore.h"   // QUOTED: this tree's copy (wifiScan*Active), not the lib's stale one
+      #include "helpers/esp32/MqttBridge.h"
     #endif
   #endif
   #if defined(HAS_TANMATSU)
@@ -9734,7 +9735,6 @@ static void buildDeviceSettings(int sec) {
   lv_label_set_text(l_reboot, TR("Reboot device"));
   lv_obj_center(l_reboot);
   y += SC(42);
-  }
 
   if (sec == DSEC_BATTERY) {   // --- Battery ---
   // ---- Battery ----
@@ -10894,8 +10894,6 @@ static void wifiRebuildNetworkList() {
 // ---- MQTT bridge settings callbacks ----------------------------------------
 
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
-#include "helpers/esp32/MqttBridge.h"
-
 struct MqttBrokerPreset { const char* label; const char* host; uint16_t port; };
 static const MqttBrokerPreset kMqttPresets[] = {
   { "Home Assistant",  "homeassistant.local",  1883 },

--- a/src/ui-touch/UITask.h
+++ b/src/ui-touch/UITask.h
@@ -373,6 +373,9 @@ public:
   bool getGpsHadFix() const { return _gps_had_fix; }
   double getNodeLat() const { return _sensors ? _sensors->node_lat : 0.0; }
   double getNodeLon() const { return _sensors ? _sensors->node_lon : 0.0; }
+  /** RSSI (dBm) of the last inbound message received from the named sender.
+   *  Returns 0 if no inbound message from that sender is in the ring. */
+  int8_t getContactLastRssi(const char* name) const;
   const char* getNodeNameCstr() const { return (_node_prefs && _node_prefs->node_name[0]) ? _node_prefs->node_name : ""; }
 
   /** Settings: persist node display name (max 31 chars + NUL). */


### PR DESCRIPTION
## Summary

- **MQTT bridge** (`MqttBridge.h/.cpp`): publishes incoming mesh messages to a configurable MQTT broker over WiFi. Supports enable/disable, host, port, username, password, and **configurable topic prefix** (default `wadamesh`) stored in ESP32 NVS.
- **Settings UI** (`buildMqttSettings()`): dedicated Settings → MQTT page with broker config, topic prefix field, and one-tap public presets (HiveMQ, EMQX, broker.mqtt.cool).
- **Map contact type filter**: toggles in Map Options to show/hide contacts by type (Mobile/chat, Repeater, Room, Sensor); bitmask persisted in NVS (TouchPrefsStore v26).
- **RSSI range rings**: optional transparent circle drawn around each map marker, radius estimated from the last received RSSI value using a free-space path-loss model.
- **Node appear/disappear alerts**: optional toast notification ("Online: …" / "Offline: …") when a GPS-located contact joins or leaves the map; throttled to 5 s.
- **Tetris mini-game** (`TetrisGame.h/.cpp`): full Tetromino game accessible from the Apps drawer, mirroring SnakeGame's integration style. 7 pieces, rotation, line clear, progressive speed, next-piece preview, score, pause and restart. Swipe left/right = move, swipe up = rotate, swipe down = soft drop; trackball routed via `TetrisGame::steer()`. Custom T-shaped icon in the app drawer.
- **Map zoom step buttons**: `[−]` and `[+]` buttons appear flanking the zoom label above the slider when the toggle is pressed; `mapSyncSliderIfOpen()` keeps the slider in sync with tap-based zooming.
- **Windows build fix** (`scripts/win_spawn_fix.py`): SCons SPAWN override that routes g++/gcc compile commands through a two-step g++ -S → as --longcalls workaround, bypassing the Windows 32767-char CreateProcess limit that prevents cc1plus from being spawned internally.
- Rebased on beta_20; Wi-Fi management UI (known-networks list) preserved intact.
- Both `heltec_v4_tft_companion_radio_usb_tcp_touch` and `LilyGo_TDeck_companion_radio_touch` build successfully.

## Test plan

- [ ] Flash to Heltec V4, open Settings → MQTT, enter broker credentials and topic prefix, save
- [ ] Verify mesh messages appear on broker under the configured prefix (e.g. HiveMQ WebSocket client)
- [ ] Toggle MQTT off — verify no messages published
- [ ] Open map card → Map Options: toggle individual contact types on/off, verify markers filter correctly
- [ ] Enable RSSI rings — verify circles appear around contacts that have sent messages
- [ ] Enable node alerts — move away from a contact until it loses GPS, verify toast appears
- [ ] Open Apps drawer → Tetris: start game, verify pieces fall, rotate, and lines clear; verify pause/restart work
- [ ] Open map card, press +/− toggle, verify step buttons appear around zoom label
- [ ] Tap +/− step buttons, verify zoom changes and slider updates in sync
- [ ] Windows build: `PYTHONUTF8=1 pio run -e heltec_v4_tft_companion_radio_usb_tcp_touch -j 1` should complete without hanging