### PR TITLE
ui-touch: keyboard-backlight brightness control for the T-Deck (issue #84)

### DIFF
--- a/src/helpers/input/TDeckKeyboard.cpp
+++ b/src/helpers/input/TDeckKeyboard.cpp
@@ -34,9 +34,9 @@ void tdeckKeyboardSetBacklight(uint8_t level) {
   if (level != s_bl_desired || !forced) { s_bl_desired = level; s_bl_dirty = true; forced = true; }
 }
 
-void tdeckKeyboardPoll() {
-  if (!s_inited) return;
-  if (s_bl_dirty) {
+void tdeckKeyboardFlushBacklight() {
+  if (!s_inited || !s_bl_dirty) return;
+  {
     s_bl_dirty = false;
     // LilyGo T-Keyboard backlight: 2-byte command [0x01, brightness] (0 = off).
     Wire.beginTransmission(PIN_KB_ADDR);
@@ -44,6 +44,11 @@ void tdeckKeyboardPoll() {
     Wire.write(s_bl_desired);    // 0 = off, 1-255 = brightness
     Wire.endTransmission();
   }
+}
+
+void tdeckKeyboardPoll() {
+  if (!s_inited) return;
+  tdeckKeyboardFlushBacklight();
   if (Wire.requestFrom((int)PIN_KB_ADDR, 1) != 1) return;
   uint8_t key = Wire.read();
   if (key == 0) return;                       // no key this scan

--- a/src/helpers/input/TDeckKeyboard.h
+++ b/src/helpers/input/TDeckKeyboard.h
@@ -28,4 +28,10 @@ int tdeckKeyboardReadKey();
  *  owns the bus. Only re-sent when the value changes. */
 void tdeckKeyboardSetBacklight(uint8_t level);
 
+/** Flush a pending backlight request over I2C NOW. CORE-0 ONLY (touch task).
+ *  Cheap when nothing is pending (one flag check); called every poll tick so a
+ *  brightness change lands within ~one touch-poll period (~8 ms) instead of
+ *  waiting for the next full keyboard scan (~32 ms). */
+void tdeckKeyboardFlushBacklight();
+
 #endif

--- a/src/helpers/input/TDeckTouch.cpp
+++ b/src/helpers/input/TDeckTouch.cpp
@@ -356,6 +356,7 @@ static void touchPollTask(void* arg) {
 #if defined(HAS_TDECK_KEYBOARD)
     // Poll the keyboard from THIS task too (same I2C bus) so the two devices
     // never get hit from two cores at once. ~every 4th tick (~32 ms) is plenty.
+    tdeckKeyboardFlushBacklight();   // backlight requests land within ~one tick (~8 ms); key scan stays /4
     if (++kb_div >= 4) { kb_div = 0; tdeckKeyboardPoll(); }
 #endif
     vTaskDelay(pdMS_TO_TICKS(s_period_ms));

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -1540,6 +1540,8 @@ struct SettingsModalState {
   uint8_t log_mode; // 0 = rx summary, 1 = raw
   /** Device modal: screen-timeout (seconds, 0=never) textarea. */
   lv_obj_t* screen_to_ta;
+  /** Device modal (Keyboard): backlight-brightness slider (issue #84). */
+  lv_obj_t* kbbl_slider;
   /** Device modal: live GPS fix-status line under the GPS toggle. */
   lv_obj_t* gps_status;
   /** Quick replies modal: 6 textareas, one per slot. Empty save clears
@@ -9185,6 +9187,57 @@ static void lockColorChosenCb(lv_event_t* e);
 #endif
 
 static void calibrateBatteryCb(lv_event_t* e);   // defined with the battery helpers below
+#if defined(HAS_TDECK_KEYBOARD)
+// Keyboard-backlight brightness (issue #84). The T-Keyboard's C3 firmware takes a
+// 2-byte I2C command [0x01, level 0-255]; the ON level was hardcoded 0xFF (100%).
+// This percent scales that level; the per-loop tick recomputes it and the I2C layer
+// only writes on change, so adjusting any control gives a live preview for free.
+static uint8_t s_tdeck_kb_bl_pct = 100;
+// Perceived LED brightness is roughly logarithmic in PWM duty, so a linear pct->duty
+// map feels coarse at the bottom (small pct steps = big visible jumps). A squared
+// (gamma-2) curve spends most of the percent range on the dim end, evening it out.
+static inline uint8_t tdeckKbBlLevel() {
+  if (s_tdeck_kb_bl_pct == 0) return 0;
+  uint32_t lvl = ((uint32_t)s_tdeck_kb_bl_pct * s_tdeck_kb_bl_pct * 255 + 5000) / 10000;
+  return (uint8_t)(lvl < 1 ? 1 : lvl);             // any nonzero pct stays visibly lit
+}
+// Apply a new percent: instant visual feedback (the loop tick + I2C layer pick it
+// up within ~2 keyboard polls). Turning the knob while the mode is off flips it to
+// on - mirroring the Tanmatsu control-centre behaviour.
+static void kbBlSetPct(int pct, bool sync_slider) {
+  if (pct < 0) pct = 0; if (pct > 100) pct = 100;
+  s_tdeck_kb_bl_pct = (uint8_t)pct;
+  if (s_kb_bl_mode == 0) s_kb_bl_mode = 1;
+  noteKbActivity();                                // auto mode: light up now so the preview shows
+  tdeckKeyboardSetBacklight(tdeckKbBlLevel());     // request NOW; the touch-poll task flushes it over I2C within ~8 ms
+  if (sync_slider && g_set_modal.kbbl_slider)
+    lv_slider_set_value(g_set_modal.kbbl_slider, pct, LV_ANIM_OFF);
+}
+// Persisting rewrites the whole TouchCfg blob to NVS (cfgFlush), which can block the
+// UI thread for a good fraction of a second - far too slow to run on EVERY -/+ tap.
+// Defer it: one one-shot timer, re-armed on each change, writes ONCE after the user
+// stops clicking. Reads only statics, so it is safe even after the page is closed.
+static lv_timer_t* s_kbbl_save_timer = nullptr;
+static void kbBlSaveTimerCb(lv_timer_t*) {
+  s_kbbl_save_timer = nullptr;                     // repeat-count 1 -> LVGL deletes the timer after this
+  touchPrefsSetKbdBacklight(s_tdeck_kb_bl_pct);
+  touchPrefsSetKbBacklight(s_kb_bl_mode);          // persist the (possibly flipped) mode too
+}
+static void kbBlScheduleSave() {
+  if (s_kbbl_save_timer) { lv_timer_reset(s_kbbl_save_timer); return; }
+  s_kbbl_save_timer = lv_timer_create(kbBlSaveTimerCb, 1200, nullptr);
+  lv_timer_set_repeat_count(s_kbbl_save_timer, 1);
+}
+static void kbBlSliderCb(lv_event_t* e) {          // live while dragging
+  kbBlSetPct(lv_slider_get_value(lv_event_get_target(e)), false);
+}
+static void kbBlSliderReleaseCb(lv_event_t*)   { kbBlScheduleSave(); }
+static void kbBlPresetCb(lv_event_t* e) {          // Off / 25 / 50 / 75 / Max: user_data = the percent
+  kbBlSetPct((int)(intptr_t)lv_event_get_user_data(e), true);
+  kbBlScheduleSave();
+}
+#endif
+
 static void buildDeviceSettings(int sec) {
   // One detail page per section: each block below is gated to its DSEC_* section
   // (skipped blocks don't advance y, so every page lays out from the top).
@@ -9566,6 +9619,39 @@ static void buildDeviceSettings(int sec) {
   }
 
   if (sec == DSEC_KEYBOARD) {   // --- Keyboard ---
+#if defined(HAS_TDECK_KEYBOARD)
+  /* Keyboard backlight brightness (issue #84). A live slider (gamma-2 mapped so the
+     dim end is fine-grained) plus Off / 25 / 50 / 75 / Max one-tap presets; changes
+     apply within ~8 ms, the NVS save is debounced. 0 keeps the backlight dark even
+     in the on/auto modes. */
+  {
+    y += settingsRowLabel(body, y, 0, "Keyboard backlight", COLOR_SUB, &g_font_12, 0) + 4;
+    lv_obj_t* sl = lv_slider_create(body);
+    g_set_modal.kbbl_slider = sl;
+    lv_obj_set_size(sl, lv_pct(96), SC(8));
+    lv_obj_set_pos(sl, 2, y + SC(6));
+    lv_slider_set_range(sl, 0, 100);
+    lv_slider_set_value(sl, s_tdeck_kb_bl_pct, LV_ANIM_OFF);
+    lv_obj_set_style_bg_color(sl, lv_color_hex(0x202428), LV_PART_MAIN);
+    lv_obj_set_style_bg_color(sl, lv_color_hex(COLOR_ACCENT), LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(sl, lv_color_hex(COLOR_ACCENT), LV_PART_KNOB);
+    lv_obj_set_style_pad_all(sl, 6, LV_PART_KNOB);
+    lv_obj_add_event_cb(sl, kbBlSliderCb,        LV_EVENT_VALUE_CHANGED, nullptr);
+    lv_obj_add_event_cb(sl, kbBlSliderReleaseCb, LV_EVENT_RELEASED,      nullptr);
+    y += SC(26);
+
+    static const struct { const char* txt; int pct; } k_presets[] =
+      { { "Off", 0 }, { "25", 25 }, { "50", 50 }, { "75", 75 }, { "Max", 100 } };
+    for (int i = 0; i < 5; ++i) {                       // one-tap presets
+      lv_obj_t* b = lv_btn_create(body);
+      lv_obj_set_size(b, SC(48), SC(30));
+      lv_obj_set_pos(b, 2 + i * SC(54), y);
+      lv_obj_add_event_cb(b, kbBlPresetCb, LV_EVENT_CLICKED, (void*)(intptr_t)k_presets[i].pct);
+      lv_obj_t* l = lv_label_create(b); lv_label_set_text(l, k_presets[i].txt); lv_obj_center(l);
+    }
+    y += SC(38);
+  }
+#endif
   /* Secondary keyboards (multi-select). Switch on any layouts you want in the
      rotation; a double-tap of SPACE on the physical keyboard cycles
      English -> each enabled layout -> back. The active layout is remembered
@@ -34446,6 +34532,9 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 #if CAP_KEYBOARD
     s_kb_bl_mode = touchPrefsGetKbBacklight();
 #endif
+#if defined(HAS_TDECK_KEYBOARD)
+    { uint8_t p = touchPrefsGetKbdBacklight(); s_tdeck_kb_bl_pct = (p > 100) ? 100 : p; }   // shared kbd_bl pref
+#endif
     // Accent-popup picker (both boards: on-screen + physical keyboard). Default on.
     s_accent_popups = touchPrefsGetAccentPopups();
     i18nSetLang(touchPrefsGetUiLang());   // active UI translation language (before the UI builds)
@@ -36021,8 +36110,8 @@ void UITask::loop() {
   }
   // Keyboard backlight: off / on / auto (lit after activity, off after idle).
   uint8_t kb_bl = 0;
-  if (s_kb_bl_mode == 1) kb_bl = 0xFF;
-  else if (s_kb_bl_mode == 2 && (now - s_kb_last_key_ms) < kKbBacklightIdleMs) kb_bl = 0xFF;
+  if (s_kb_bl_mode == 1) kb_bl = tdeckKbBlLevel();
+  else if (s_kb_bl_mode == 2 && (now - s_kb_last_key_ms) < kKbBacklightIdleMs) kb_bl = tdeckKbBlLevel();
   if (_screen_off || _manual_lock) kb_bl = 0;   // dark/locked screen -> keep the keyboard dark too
   // New-message notify flash: light the screen so the user sees a message arrived. When the
   // screen is hard-locked, REVEAL the lock screen (lights the wallpaper, keeps the lock) rather
@@ -36034,7 +36123,7 @@ void UITask::loop() {
     if (_manual_lock)     lockscreenReveal();   // locked: light wallpaper, keep the lock (unlock still works)
     else if (_screen_off) wakeScreen();         // idle-dimmed: normal wake
   }
-  if (!_screen_off && !_manual_lock && s_msgflash_until && (int32_t)(now - s_msgflash_until) < 0) kb_bl = 0xFF;
+  if (!_screen_off && !_manual_lock && s_msgflash_until && (int32_t)(now - s_msgflash_until) < 0) kb_bl = tdeckKbBlLevel();
   tdeckKeyboardSetBacklight(kb_bl);
   serviceLockscreen();            // refresh the lock-screen clock on minute roll-over
   serviceLockingCountdown(now);   // advance / fire the spacebar "Locking…" countdown


### PR DESCRIPTION
## Keyboard-backlight brightness control for the T-Deck

Fixes #84.

The T-Keyboard's C3 firmware accepts a 2-byte I2C command `[0x01, level 0-255]`, but the level the UI drove it at was hardcoded `0xFF` — so the backlight was always 100% when lit. This adds a **Keyboard backlight** control at the top of Settings → Keyboard: a live slider plus Off / 25 / 50 / 75 / Max one-tap presets. The chosen level applies to the *on* and *auto* modes and to the new-message flash; `0` keeps the keyboard dark even when the mode is on.

The percent persists in the existing `kbd_bl` pref (shared with the Tanmatsu Keys slider — no new config fields, no TouchCfg version bump), and adjusting the control while the mode is *off* flips it to *on*, mirroring the Tanmatsu control-centre behaviour.

### Latency notes (why the diff touches the input helpers)

Three things made the first cut of this control feel bad, and each fix is in this PR:

- **Perceptual mapping.** Perceived LED brightness is roughly logarithmic in PWM duty, so a linear pct→duty map felt coarse at the dim end (small steps = big visible jumps). The percent is now gamma-2 mapped (`duty ∝ pct²`), which spends most of the control range on the dim end; any nonzero percent still guarantees a visibly lit level (≥1).
- **NVS writes off the hot path.** The pref setter rewrites the whole TouchCfg blob via `cfgFlush()`, which can block the UI thread for a good fraction of a second — far too slow per tap. The save is now debounced: a one-shot timer re-armed on each change writes once after the user stops adjusting.
- **I2C flush cadence.** The backlight write must stay on the touch-poll task (the keyboard shares the I2C bus with the GT911), but it used to ride the ~32 ms keyboard-scan divider — and the Settings control additionally waited for the next `UITask::loop()` pass to notice the change. Requests are now made directly by the control and flushed by a new `tdeckKeyboardFlushBacklight()` on every poll tick (~8 ms; a single flag check when idle), so the control feels as immediate as the screen-brightness slider, whose `ledcWrite` hits the ESP32's own PWM peripheral synchronously.

### Testing

Built and flashed on a T-Deck Plus (`LilyGo_TDeck_companion_radio_touch`, on top of beta_26). Verified:  live dimming while dragging (the C3 does PWM the intermediate levels); presets jump instantly; the value survives a reboot; the on/off/auto modes and the message flash honour the chosen level; typing latency unaffected (key scan cadence unchanged).

Single DCO-signed commit.