### PR TITLE
fix(esp32): honor use_sd from touch prefs at boot

### DIFF
--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -6,6 +6,8 @@
 
 #include "SdNvsPrefs.h"   // NVS, or SD /meshcomod fallback when NVS is unusable (Launcher)
 
+#include <Preferences.h>
+#include <SPIFFS.h>
 #include <stddef.h>   // offsetof
 #include <string.h>   // memcpy
 
@@ -24,8 +26,8 @@ static bool s_begun = false;
 // packed into ONE versioned blob keyed "cfg". Strings (tile_srv, rgn_scope,
 // lk_wall, channel-scopes, quick-replies), the byte blobs (fav / ign / rpw) and
 // the Wi-Fi slots keep their own keys — and "use_sd" / "setup_ok" stay standalone
-// keys too, because main.cpp reads (and for use_sd, writes) them directly via a
-// raw Preferences open at boot, BEFORE the touch prefs load.
+// keys too. "use_sd" is mirrored to NVS on every UI toggle (main.cpp reads it at
+// boot via touchPrefsReadUseSdAtBoot); "setup_ok" is still NVS-only.
 //
 // On first run with the blob absent we read every legacy per-key into s_cfg, write
 // "cfg" ONCE, and only after that durable write do we remove() the legacy keys to
@@ -1113,8 +1115,55 @@ bool touchPrefsSetHomeIsDrawer(bool on) {
 // Store ALL device data (identity, prefs, contacts, channels) on the SD card
 // under /meshcomod instead of internal SPIFFS. Read at boot (main.cpp) BEFORE
 // the data loads, so changing it needs a reboot. Key "use_sd" in the "touch"
-// namespace — main.cpp reads the same key directly.
+// namespace — main.cpp must see the same value the UI toggle writes.
 static const char* KEY_USE_SD_STORAGE = "use_sd";
+static const char* TOUCH_KV_BOOT_PATH = "/prefs/touch.kv";
+
+// SdNvsPrefs file mode writes touch.kv only — parse a bool for boot migration.
+static bool readBoolFromTouchKvFile(const char* want_key) {
+  if (!SPIFFS.exists(TOUCH_KV_BOOT_PATH)) return false;
+  File f = SPIFFS.open(TOUCH_KV_BOOT_PATH, FILE_READ);
+  if (!f) return false;
+  while (f.available() > 0) {
+    int kl = f.read();
+    if (kl <= 0 || kl > 15) break;
+    char k[16] = {0};
+    if (f.read((uint8_t*)k, kl) != kl) break;
+    int lo = f.read(), hi = f.read();
+    if (lo < 0 || hi < 0) break;
+    size_t vl = (size_t)lo | ((size_t)hi << 8);
+    if (vl > 2048) break;
+    if (strncmp(k, want_key, sizeof k) == 0) {
+      const bool on = (vl >= 1) && (f.read() != 0);
+      f.close();
+      return on;
+    }
+    for (size_t i = 0; i < vl; ++i) {
+      if (f.read() < 0) { f.close(); return false; }
+    }
+  }
+  f.close();
+  return false;
+}
+
+bool touchPrefsReadUseSdAtBoot() {
+  bool nvs_val = false;
+  Preferences p;
+  if (p.begin(TOUCH_NS, true)) {
+    nvs_val = p.getBool(KEY_USE_SD_STORAGE, false);
+    p.end();
+  }
+  if (nvs_val) return true;
+  const bool file_val = readBoolFromTouchKvFile(KEY_USE_SD_STORAGE);
+  if (file_val) {
+    Serial.println("[BOOT] use_sd read from /prefs/touch.kv (syncing to NVS)");
+    if (p.begin(TOUCH_NS, false)) {
+      p.putBool(KEY_USE_SD_STORAGE, true);
+      p.end();
+    }
+  }
+  return file_val;
+}
 
 bool touchPrefsGetUseSdStorage() {
   if (!s_begun) touchPrefsBegin();
@@ -1128,6 +1177,15 @@ bool touchPrefsSetUseSdStorage(bool use_sd) {
   bool ok = s_prefs.putBool(KEY_USE_SD_STORAGE, use_sd);
   s_prefs.end();
   s_begun = s_prefs.begin(TOUCH_NS, true);
+  // main.cpp reads use_sd from NVS before SdNvsPrefs::useFile() — mirror every
+  // UI toggle there so the boot storage decision matches the switch.
+  Preferences nvs;
+  if (nvs.begin(TOUCH_NS, false)) {
+    if (!nvs.putBool(KEY_USE_SD_STORAGE, use_sd)) ok = false;
+    nvs.end();
+  } else {
+    ok = false;
+  }
   return ok;
 }
 

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -223,6 +223,9 @@ bool touchPrefsSetShowSensorsTab(bool on);
  *  loads, so changing it requires a reboot. Default false (SPIFFS). */
 bool touchPrefsGetUseSdStorage();
 bool touchPrefsSetUseSdStorage(bool use_sd);
+/** Boot-time read for main.cpp's storage decision (before SdNvsPrefs::useFile).
+ *  Checks NVS, then SPIFFS /prefs/touch.kv for a file-only write. */
+bool touchPrefsReadUseSdAtBoot();
 
 /** Global UI orientation, applied at boot before the screens are built so the
  *  whole layout reflows to the rotated resolution. Stored as the raw LVGL

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -358,12 +358,12 @@ void setup() {
 #if defined(HAS_TDECK_GT911)
   {
     extern SPIClass* tdeckSharedSPI();
-    bool use_sd_pref = false, setup_done = false;
+    bool setup_done = false;
     { Preferences _p; if (_p.begin("touch", true)) {
-        use_sd_pref = _p.getBool("use_sd", false);    // explicit user choice
-        setup_done  = _p.getBool("setup_ok", false);  // finished first-run setup
+        setup_done = _p.getBool("setup_ok", false);  // finished first-run setup
         _p.end();
     } }
+    const bool use_sd_pref = touchPrefsReadUseSdAtBoot();   // NVS + /prefs/touch.kv
 
     // First-run SD default: the very first time meshcomod boots on a brand-new
     // device — the user hasn't finished setup yet AND nothing is stored on


### PR DESCRIPTION
## What

Fixes the **Store data on SD** toggle being ignored after reboot on ESP32 touch builds.

The Settings UI persists `use_sd` via `SdNvsPrefs` (written to `/prefs/touch.kv` when NVS is unavailable or when using SD-backed prefs), but `main.cpp` only read the raw NVS `Preferences` key at boot. After enabling SD storage in the UI, a reboot could still show `[BOOT] storage: SPIFFS` and keep contacts on SPIFFS.

## Why

On a large mesh, full `contacts3` rewrites on SPIFFS can block for several seconds and contribute to UI freezes. SD storage is much faster for these writes, but only when boot actually selects SD. This bug meant users could enable **Store data on SD** and still boot into SPIFFS after reboot — so the performance benefit of SD never applied even when the toggle appeared set.

## Fix

- `touchPrefsSetUseSdStorage()` now dual-writes: existing `SdNvsPrefs` path **and** raw NVS `use_sd`.
- New `touchPrefsReadUseSdAtBoot()` reads NVS first, falls back to parsing `/prefs/touch.kv`, and syncs NVS when the file has the authoritative value.
- Boot path in `main.cpp` uses `touchPrefsReadUseSdAtBoot()` instead of `Preferences.getBool("use_sd")`.

## Scope / not touched

- Chat UI, contacts save performance, storage write tracing — separate work.
- No TouchCfg version bump; `use_sd` remains a standalone pref key as before.

## Testing

- [x] Built `LilyGo_TDeck_companion_radio_touch`
- [x] Built `heltec_v4_tft_companion_radio_usb_tcp_touch`
- [x] T-Deck: enable **Store data on SD** in Settings → reboot → boot log shows SD storage selected
- [x] Toggle off/on + reboot: preference survives

Single DCO-signed commit.