### PR TITLE
Attaky mesh series

### DIFF
--- a/boards/attaky_mesh_series.json
+++ b/boards/attaky_mesh_series.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv",
+      "memory_type": "qio_opi"
+      },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=0",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "opi",
+    "hwids": [["0x303A", "0x1001"]],
+    "mcu": "esp32s3",
+    "variant": "attaky_mesh_series"
+  },
+  "connectivity": ["wifi", "bluetooth", "lora"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "Attaky Core (ESP32-S3-WROOM-1U-N16R8, 16 MB FLASH, 8 MB OCTAL PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 8388608,
+    "maximum_size": 16777216,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://attaky.com/",
+  "vendor": "attaky"
+}

--- a/boards/attaky_mesh_series.json
+++ b/boards/attaky_mesh_series.json
@@ -36,7 +36,7 @@
     "use_1200bps_touch": true,
     "wait_for_upload_port": true,
     "require_upload_port": true,
-    "speed": 921600
+    "speed": 115200
   },
   "url": "https://attaky.com/",
   "vendor": "attaky"

--- a/platformio.ini
+++ b/platformio.ini
@@ -279,6 +279,177 @@ lib_deps =
   lovyan03/LovyanGFX@1.2.21
 
 ; ======================================================================
+; Attaky Mesh Series: `pio run -e attaky_mesh_series`.
+; ======================================================================
+[env:attaky_mesh_series]
+platform = platformio/espressif32@6.11.0
+framework = arduino
+board = attaky_mesh_series
+monitor_speed = 115200
+board_build.partitions = partitions_tft_touch.csv
+extra_scripts = pre:scripts/inject_wifi_env.py, merge-bin.py
+
+build_flags =
+  -Wno-deprecated-declarations -Wno-unused-parameter -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
+  -D MC_VENDORED_TOUCH_APP
+  -D LORA_FREQ=910.525
+  -D LORA_BW=250
+  -D LORA_SF=7
+  -D ENABLE_PRIVATE_KEY_IMPORT=1
+  -D ENABLE_PRIVATE_KEY_EXPORT=1
+  -D RADIOLIB_EXCLUDE_CC1101=1
+  -D RADIOLIB_EXCLUDE_RF69=1
+  -D RADIOLIB_EXCLUDE_SX1231=1
+  -D RADIOLIB_EXCLUDE_SI443X=1
+  -D RADIOLIB_EXCLUDE_RFM2X=1
+  -D RADIOLIB_EXCLUDE_SX128X=1
+  -D RADIOLIB_EXCLUDE_AFSK=1
+  -D RADIOLIB_EXCLUDE_AX25=1
+  -D RADIOLIB_EXCLUDE_HELLSCHREIBER=1
+  -D RADIOLIB_EXCLUDE_MORSE=1
+  -D RADIOLIB_EXCLUDE_APRS=1
+  -D RADIOLIB_EXCLUDE_BELL=1
+  -D RADIOLIB_EXCLUDE_RTTY=1
+  -D RADIOLIB_EXCLUDE_SSTV=1
+  -D ESP32_PLATFORM
+  -D ENV_INCLUDE_GPS=1
+  -D ENV_INCLUDE_AHTX0=1
+  -D ENV_INCLUDE_BME280=1
+  -D ENV_INCLUDE_BMP280=1
+  -D ENV_INCLUDE_SHTC3=1
+  -D ENV_INCLUDE_SHT4X=1
+  -D ENV_INCLUDE_LPS22HB=1
+  -D ENV_INCLUDE_INA3221=1
+  -D ENV_INCLUDE_INA219=1
+  -D ENV_INCLUDE_INA226=1
+  -D ENV_INCLUDE_INA260=1
+  -D ENV_INCLUDE_MLX90614=1
+  -D ENV_INCLUDE_VL53L0X=1
+  -D ENV_INCLUDE_BME680=1
+  -D ENV_INCLUDE_BMP085=1
+  -I variants/attaky_mesh_series
+  -D ATTAKY_MESH_SERIES
+  -D USE_SX1262
+  -D ESP32_CPU_FREQ=80
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D P_LORA_DIO_1=21
+  -D P_LORA_NSS=8
+  -D P_LORA_RESET=9
+  -D P_LORA_BUSY=16
+  -D P_LORA_SCLK=5
+  -D P_LORA_MISO=7
+  -D P_LORA_MOSI=6
+  -D PIN_USER_BTN=0
+  -D LORA_TX_POWER=10
+  -D MAX_LORA_TX_POWER=22
+  -D SX126X_REGISTER_PATCH=1
+  -D SX126X_DIO2_AS_RF_SWITCH=true
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D SX126X_RX_BOOSTED_GAIN=1
+  -D PIN_GPS_RX=18
+  -D PIN_GPS_TX=17
+  -D GPS_BAUD=9600
+  ; Keep the base rotation portrait; UITask applies the landscape transform.
+  -D PIN_BOARD_SDA=2
+  -D PIN_BOARD_SCL=1
+  -D DISPLAY_ROTATION=2
+  -D DISPLAY_SCALE_X=1.0
+  -D DISPLAY_SCALE_Y=1.0
+  -D PIN_TFT_RST=10
+  -D PIN_TFT_VDD_CTL=-1
+  -D PIN_TFT_LEDA_CTL=14
+  -D PIN_TFT_LEDA_CTL_ACTIVE=HIGH
+  -D PIN_TFT_CS=45
+  -D PIN_TFT_DC=12
+  -D PIN_TFT_SCL=11
+  -D PIN_TFT_SDA=13
+  -I include
+  -I src
+  -I src/ui-touch
+  -D UI_LVGL=1
+  -D HAS_TOUCH_UI=1
+  -D FIRMWARE_OTA_ENV='"attaky_mesh_series"'
+  -D ENABLE_ADVERT_ON_BOOT=0
+  -D LV_CONF_PATH=lv_conf.h
+  -D LV_CONF_INCLUDE_SIMPLE=1
+  -D LV_INDEV_DEF_SCROLL_THROW=7
+  -D USER_SETUP_LOADED=1
+  -D ST7789_DRIVER=1
+  -D TFT_WIDTH=240
+  -D TFT_HEIGHT=320
+  -D TFT_MOSI=13
+  -D TFT_SCLK=11
+  -D TFT_CS=45
+  -D TFT_DC=12
+  -D TFT_RST=10
+  -D TFT_MISO=-1
+  -D SPI_FREQUENCY=80000000
+  -D TFT_RGB_ORDER=TFT_RGB
+  -D TFT_INVERSION_ON=1
+  -D TFT_BL=14
+  -D TFT_BACKLIGHT_ON=1
+  -D MAX_CONTACTS=2000
+  -D MAX_GROUP_CHANNELS=40
+  -D DISPLAY_CLASS=ST7789LCDDisplay
+  -D ADMIN_PASSWORD='"password"'
+  -D MULTI_TRANSPORT_COMPANION=1
+  -D WADAMESH_FORK_BUILD=1
+  -D TCP_PORT=5000
+  -D WS_PORT=8765
+  -D BLE_PIN_CODE=123456
+  -D CONFIG_MBEDTLS_ASYMMETRIC_CONTENT_LEN=1
+  -D CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN=16384
+  -D CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN=4096
+
+build_src_filter =
+  +<*.cpp>
+  +<*.c>
+  +<helpers/*.cpp>
+  +<helpers/esp32/*.cpp>
+  +<helpers/input/*.cpp>
+  ; The Attaky driver provides the shared touch API.
+  -<helpers/input/TDeckTouch.cpp>
+  +<ui-touch/*.cpp>
+  +<ui-touch/*.c>
+  +<../variants/attaky_mesh_series/*.cpp>
+
+lib_deps =
+  https://github.com/ALLFATHER-BV/meshcomod.git#core-v1.16.5
+  SPI
+  Wire
+  jgromes/RadioLib @ ^7.6.0
+  rweather/Crypto @ ^0.4.0
+  adafruit/RTClib @ ^2.1.3
+  melopero/Melopero RV3028 @ ^1.1.0
+  electroniccats/CayenneLPP @ 1.6.1
+  h2zero/NimBLE-Arduino @ 1.4.3
+  adafruit/Adafruit INA3221 Library @ ^1.0.1
+  adafruit/Adafruit INA219 @ ^1.2.3
+  robtillaart/INA226 @ ^0.6.4
+  adafruit/Adafruit INA260 Library @ ^1.5.3
+  adafruit/Adafruit AHTX0 @ ^2.0.5
+  adafruit/Adafruit BME280 Library @ ^2.3.0
+  adafruit/Adafruit BMP280 Library @ ^2.6.8
+  adafruit/Adafruit SHTC3 Library @ ^1.0.1
+  sensirion/Sensirion I2C SHT4x @ ^1.1.2
+  arduino-libraries/Arduino_LPS22HB @ ^1.0.2
+  adafruit/Adafruit MLX90614 Library @ ^2.1.5
+  adafruit/Adafruit_VL53L0X @ ^1.2.4
+  stevemarple/MicroNMEA @ ^2.0.6
+  adafruit/Adafruit BME680 Library @ ^2.0.4
+  adafruit/Adafruit BMP085 Library @ ^1.2.4
+  adafruit/Adafruit ST7735 and ST7789 Library @ ^1.11.0
+  https://github.com/Quency-D/chsc6x/archive/5cbead829d6b432a8d621ed1aafd4eb474fd4f27.zip
+  ESP32Async/ESPAsyncWebServer @ 3.10.3
+  file://arch/esp32/AsyncElegantOTA
+  lvgl/lvgl @ ^8.3.11
+  bodmer/TFT_eSPI @ ^2.5.43
+  densaugeo/base64 @ ~1.4.0
+  knolleary/PubSubClient @ ^2.8.0
+
+; ======================================================================
 ; LilyGo T-Deck / T-Deck Plus — flattened equivalent of meshcomod's
 ; LilyGo_TDeck_companion_radio_touch. ST7789 via Adafruit (not TFT_eSPI);
 ; GT911 touch + matrix keyboard + trackball; sensors off except GPS.

--- a/platformio.ini
+++ b/platformio.ini
@@ -279,9 +279,9 @@ lib_deps =
   lovyan03/LovyanGFX@1.2.21
 
 ; ======================================================================
-; Attaky Mesh Series: `pio run -e attaky_mesh_series`.
+; Attaky Mesh Series: `pio run -e attaky_mesh_series_companion_radio_touch`.
 ; ======================================================================
-[env:attaky_mesh_series]
+[env:attaky_mesh_series_companion_radio_touch]
 platform = platformio/espressif32@6.11.0
 framework = arduino
 board = attaky_mesh_series
@@ -371,7 +371,7 @@ build_flags =
   -I src/ui-touch
   -D UI_LVGL=1
   -D HAS_TOUCH_UI=1
-  -D FIRMWARE_OTA_ENV='"attaky_mesh_series"'
+  -D FIRMWARE_OTA_ENV='"attaky_mesh_series_companion_radio_touch"'
   -D ENABLE_ADVERT_ON_BOOT=0
   -D LV_CONF_PATH=lv_conf.h
   -D LV_CONF_INCLUDE_SIMPLE=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -348,9 +348,10 @@ build_flags =
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
+  ; MeshCore GPS pin names are module-centric.
   -D PIN_GPS_RX=18
   -D PIN_GPS_TX=17
-  -D GPS_BAUD=9600
+  -D GPS_BAUD_RATE=9600
   ; Keep the base rotation portrait; UITask applies the landscape transform.
   -D PIN_BOARD_SDA=2
   -D PIN_BOARD_SCL=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -349,10 +349,8 @@ build_flags =
   -D SX126X_DIO3_TCXO_VOLTAGE=1.8
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
-  ; MeshCore GPS pin names are module-centric.
   -D PIN_GPS_RX=18
   -D PIN_GPS_TX=17
-  -D GPS_BAUD_RATE=9600
   ; Keep the base rotation portrait; UITask applies the landscape transform.
   -D PIN_BOARD_SDA=2
   -D PIN_BOARD_SCL=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -351,6 +351,7 @@ build_flags =
   -D SX126X_RX_BOOSTED_GAIN=1
   -D PIN_GPS_RX=18
   -D PIN_GPS_TX=17
+  -D GPS_BAUD=9600
   ; Keep the base rotation portrait; UITask applies the landscape transform.
   -D PIN_BOARD_SDA=2
   -D PIN_BOARD_SCL=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -329,6 +329,7 @@ build_flags =
   -D ENV_INCLUDE_BMP085=1
   -I variants/attaky_mesh_series
   -D ATTAKY_MESH_SERIES
+  -D HAS_ATTAKY_MESH_KEYBOARD=1
   -D USE_SX1262
   -D ESP32_CPU_FREQ=80
   -D RADIO_CLASS=CustomSX1262

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -120,6 +120,9 @@
   #if defined(HAS_PAGER_ENCODER)
     #include <helpers/input/PagerEncoder.h>
   #endif
+  #if defined(HAS_ATTAKY_MESH_KEYBOARD)
+    #include <AttakyMeshSeriesKeyboard.h>
+  #endif
   #include "KeyboardLayouts.h"
   #include "i18n.h"
   #include "emoji_data.h"     // baked Noto colour-emoji glyphs (emojiGlyphLookup)
@@ -43377,6 +43380,20 @@ void UITask::loop() {
   }
   serviceLockscreen();
   serviceLockingCountdown(now);
+#endif
+#if defined(HAS_ATTAKY_MESH_KEYBOARD)
+  {
+    lv_obj_t* akb_ta = g_lv.keyboard ? lv_keyboard_get_textarea(g_lv.keyboard) : nullptr;
+    attakyKeyboardPoll(akb_ta != nullptr);
+    for (int kbi = 0; akb_ta && kbi < 16; ++kbi) {
+      int key = attakyKeyboardReadKey();
+      if (key <= 0) break;
+      if (!_screen_off) noteUserInput();
+      if (key == 0x0D || key == 0x0A)      lv_event_send(g_lv.keyboard, LV_EVENT_READY, nullptr);
+      else if (key == 0x08 || key == 0x7F) lv_textarea_del_char(akb_ta);
+      else if (key >= 0x20)                lv_textarea_add_char(akb_ta, (uint32_t)key);
+    }
+  }
 #endif
 #if !defined(HAS_TANMATSU)
   // While a web-mirror browser is connected, count it as activity so the device screen

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -41305,6 +41305,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     // must match so LVGL renders the full 320x240 landscape surface.
     s_ui_rotation = LV_DISP_ROT_270;
 #endif
+#if defined(ATTAKY_MESH_SERIES)
+    // Display and touch share this landscape transform.
+    s_ui_rotation = LV_DISP_ROT_90;
+#endif
 #if !defined(HAS_TANMATSU)
     // REMOTE mode: render the UI to a virtual 480x800 PORTRAIT display for the web
     // (headless/browser use). No physical-panel rotation — the panel is a placeholder.

--- a/src/ui-touch/device_caps.h
+++ b/src/ui-touch/device_caps.h
@@ -118,6 +118,16 @@
   #define CAP_OTA          1   // standalone dual-OTA app
   #define CAP_LOCK_SCREEN  1
 
+#elif defined(ATTAKY_MESH_SERIES)
+  #define CAP_TOUCH        1
+  #define CAP_ROTATABLE    0
+  #define CAP_LARGE_SCREEN 0
+  #define CAP_SD           0
+  #define CAP_FILESYSTEM   0
+  #define CAP_GPS          1
+  #define CAP_OTA          1
+  #define CAP_LOCK_SCREEN  0
+
 #else                                    // ===== Heltec V4 TFT (default) =====
   #define CAP_TOUCH        1   // capacitive touch panel
   #define CAP_ROTATABLE    1   // user can flip portrait/landscape

--- a/variants/attaky_mesh_series/AttakyMeshSeriesBoard.cpp
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesBoard.cpp
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "AttakyMeshSeriesBoard.h"
+#include "AttakySharedI2C.h"
 #include <SPI.h>
+#include <Wire.h>
+
+#define MAX17048_ADDR        0x36
+#define MAX17048_REG_VCELL   0x02
 
 void AttakyMeshSeriesBoard::begin() {
     ESP32Board::begin();
+
+    attakyI2cInit();
 
     esp_reset_reason_t reason = esp_reset_reason();
     if (reason == ESP_RST_DEEPSLEEP) {
@@ -54,9 +61,25 @@ void AttakyMeshSeriesBoard::begin() {
     enterDeepSleep(0);
   }
 
-  // Replaced by the MAX17048 implementation in the peripheral commit.
+  // MAX17048 VCELL is 78.125 uV/LSB.
   uint16_t AttakyMeshSeriesBoard::getBattMilliVolts()  {
-    return 4000;
+    uint32_t now = millis();
+    if (batt_cache_mv != 0 && (uint32_t)(now - batt_last_ms) < 2000) return batt_cache_mv;
+    if (!attakyI2cLock(30)) return batt_cache_mv ? batt_cache_mv : 4000;
+    uint16_t raw = 0;
+    bool ok = false;
+    Wire.beginTransmission(MAX17048_ADDR);
+    Wire.write(MAX17048_REG_VCELL);
+    if (Wire.endTransmission(false) == 0 && Wire.requestFrom((int)MAX17048_ADDR, 2) == 2) {
+      raw = ((uint16_t)Wire.read() << 8) | Wire.read();
+      ok = true;
+    }
+    attakyI2cUnlock();
+    if (ok) {
+      batt_cache_mv = (uint16_t)(((uint32_t)raw * 5) / 64);
+      batt_last_ms  = now;
+    }
+    return batt_cache_mv ? batt_cache_mv : 4000;
   }
 
   const char* AttakyMeshSeriesBoard::getManufacturerName() const {

--- a/variants/attaky_mesh_series/AttakyMeshSeriesBoard.cpp
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesBoard.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "AttakyMeshSeriesBoard.h"
+#include <SPI.h>
+
+void AttakyMeshSeriesBoard::begin() {
+    ESP32Board::begin();
+
+    esp_reset_reason_t reason = esp_reset_reason();
+    if (reason == ESP_RST_DEEPSLEEP) {
+      long wakeup_source = esp_sleep_get_ext1_wakeup_status();
+      if (wakeup_source & (1 << P_LORA_DIO_1)) {
+        startup_reason = BD_STARTUP_RX_PACKET;
+      }
+
+      rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
+      rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
+    }
+
+    // The global-SPI display path does not initialize the bus.
+#if defined(PIN_TFT_LEDA_CTL) && (PIN_TFT_LEDA_CTL >= 0)
+    pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
+    digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
+#endif
+    SPI.begin(PIN_TFT_SCL, -1, PIN_TFT_SDA, PIN_TFT_CS);
+  }
+
+  void AttakyMeshSeriesBoard::onBeforeTransmit(void) { }
+
+  void AttakyMeshSeriesBoard::onAfterTransmit(void) { }
+
+  void AttakyMeshSeriesBoard::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+
+    rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
+    rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
+
+    rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
+
+    if (pin_wake_btn < 0) {
+      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1), ESP_EXT1_WAKEUP_ANY_HIGH);
+    } else {
+      esp_sleep_enable_ext1_wakeup( (1L << P_LORA_DIO_1) | (1L << pin_wake_btn), ESP_EXT1_WAKEUP_ANY_HIGH);
+    }
+
+    if (secs > 0) {
+      esp_sleep_enable_timer_wakeup(secs * 1000000);
+    }
+
+    esp_deep_sleep_start();
+  }
+
+  void AttakyMeshSeriesBoard::powerOff()  {
+    enterDeepSleep(0);
+  }
+
+  // Replaced by the MAX17048 implementation in the peripheral commit.
+  uint16_t AttakyMeshSeriesBoard::getBattMilliVolts()  {
+    return 4000;
+  }
+
+  const char* AttakyMeshSeriesBoard::getManufacturerName() const {
+    return "Attaky Core";
+  }

--- a/variants/attaky_mesh_series/AttakyMeshSeriesBoard.h
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesBoard.h
@@ -14,6 +14,11 @@ class AttakyMeshSeriesBoard : public ESP32Board {
 
 protected:
   float adc_mult = ADC_MULTIPLIER;
+  // MAX17048 fuel-gauge readout cache: getBattMilliVolts() is polled from the UI
+  // render / mesh-telemetry path, so the actual I2C read is throttled to ~2 s and
+  // the last value is served in between (0 = not yet read).
+  uint16_t batt_cache_mv = 0;
+  uint32_t batt_last_ms  = 0;
 
 public:
   AttakyMeshSeriesBoard() { }

--- a/variants/attaky_mesh_series/AttakyMeshSeriesBoard.h
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesBoard.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+#include <driver/rtc_io.h>
+
+#ifndef ADC_MULTIPLIER
+  #define ADC_MULTIPLIER 1.0
+#endif
+
+class AttakyMeshSeriesBoard : public ESP32Board {
+
+protected:
+  float adc_mult = ADC_MULTIPLIER;
+
+public:
+  AttakyMeshSeriesBoard() { }
+
+  void begin();
+  void onBeforeTransmit(void) override;
+  void onAfterTransmit(void) override;
+  void enterDeepSleep(uint32_t secs, int pin_wake_btn = -1);
+  void powerOff() override;
+  uint16_t getBattMilliVolts() override;
+  bool setAdcMultiplier(float multiplier) override {
+    if (multiplier == 0.0f) {
+      adc_mult = ADC_MULTIPLIER;
+    } else {
+      adc_mult = multiplier;
+    }
+    return true;
+  }
+  float getAdcMultiplier() const override { return adc_mult; }
+  const char* getManufacturerName() const override;
+};

--- a/variants/attaky_mesh_series/AttakyMeshSeriesKeyboard.cpp
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesKeyboard.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "AttakyMeshSeriesKeyboard.h"
+
+#if defined(HAS_ATTAKY_MESH_KEYBOARD) && defined(ESP32)
+
+#include <Arduino.h>
+#include <Wire.h>
+#include "AttakySharedI2C.h"
+
+static const uint8_t AW_REG_IN_P0   = 0x00;
+static const uint8_t AW_REG_OUT_P1  = 0x03;
+static const uint8_t AW_REG_CFG_P0  = 0x04;
+static const uint8_t AW_REG_CFG_P1  = 0x05;
+static const uint8_t AW_REG_OUT_P0  = 0x02;
+static const uint8_t AW_REG_MODE_P0 = 0x12;
+static const uint8_t AW_REG_MODE_P1 = 0x13;
+static const uint8_t AW_REG_SWRST   = 0x7F;
+
+static const uint8_t KB_ADDR[2] = { 0x5A, 0x5B };
+
+static const uint8_t P1_IDLE = 0xE0;
+static const uint8_t ROW_DRIVE[5] = { 0xFE, 0xFD, 0xFB, 0xF7, 0xEF };
+
+#define K_NOP  0x00
+#define K_SFT  0x01
+#define K_BSP  0x08
+#define K_TAB  0x09
+#define K_ENT  0x0D
+#define K_SPC  0x20
+
+static const uint8_t KEYMAP_L[5][5] = {
+  { '1', '2', '3',  '4',  '5' },
+  { 'q', 'w', 'e',  'r',  't' },
+  { 'a', 's', 'd',  'f',  'g' },
+  { K_SFT, 'z', 'x', 'c', 'v' },
+  { K_NOP, K_TAB, K_NOP, ',', K_SPC },
+};
+static const uint8_t KEYMAP_R[5][5] = {
+  { '6', '7', '8', '9', '0' },
+  { 'y', 'u', 'i', 'o', 'p' },
+  { 'h', 'j', 'k', 'l', K_BSP },
+  { 'b', 'n', 'm', K_NOP, K_ENT },
+  { K_NOP, '.', K_NOP, '#', K_NOP },
+};
+static const uint8_t SHIFT_HALF = 0, SHIFT_ROW = 3, SHIFT_COL = 0;
+
+static bool     s_inited      = false;
+static bool     s_present[2]  = { false, false };
+static uint8_t  s_prev[2][5]  = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+                                  { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
+
+static volatile uint8_t s_ring[16];
+static volatile uint8_t s_head = 0, s_tail = 0;
+
+static void ringPush(uint8_t b) {
+  uint8_t nh = (uint8_t)((s_head + 1) & 15);
+  if (nh != s_tail) { s_ring[s_head] = b; s_head = nh; }
+}
+static void ringClear() { s_head = s_tail = 0; }
+
+static bool awWrite(uint8_t addr, uint8_t reg, uint8_t val) {
+  Wire.beginTransmission(addr);
+  Wire.write(reg);
+  Wire.write(val);
+  return Wire.endTransmission() == 0;
+}
+static uint8_t awRead(uint8_t addr, uint8_t reg) {
+  Wire.beginTransmission(addr);
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) return 0xFF;
+  if (Wire.requestFrom((int)addr, 1) != 1) return 0xFF;
+  return (uint8_t)Wire.read();
+}
+
+static bool initHalf(uint8_t addr) {
+  bool ok = true;
+  ok &= awWrite(addr, AW_REG_SWRST,   0x00);
+  delay(2);
+  ok &= awWrite(addr, AW_REG_MODE_P0, 0xFF);
+  ok &= awWrite(addr, AW_REG_MODE_P1, 0xFF);
+  ok &= awWrite(addr, AW_REG_CFG_P0,  0xFF);
+  ok &= awWrite(addr, AW_REG_CFG_P1,  0x00);
+  ok &= awWrite(addr, AW_REG_OUT_P0,  0x00);
+  ok &= awWrite(addr, AW_REG_OUT_P1,  P1_IDLE);
+  return ok;
+}
+
+static void ensureInit() {
+  if (s_inited) return;
+  s_inited = true;
+  for (int h = 0; h < 2; h++) {
+    if (!attakyI2cLock(30)) continue;
+    s_present[h] = initHalf(KB_ADDR[h]);
+    attakyI2cUnlock();
+  }
+}
+
+static void scanHalf(uint8_t addr, uint8_t cols[5]) {
+  for (uint8_t row = 0; row < 5; row++) {
+    awWrite(addr, AW_REG_OUT_P1, (uint8_t)(ROW_DRIVE[row] | 0xE0));
+    delayMicroseconds(50);
+    cols[row] = (uint8_t)(awRead(addr, AW_REG_IN_P0) & 0x1F);
+  }
+  awWrite(addr, AW_REG_OUT_P1, P1_IDLE);
+}
+
+void attakyKeyboardPoll(bool active) {
+  ensureInit();
+
+  if (!active) {
+    for (int h = 0; h < 2; h++)
+      for (int r = 0; r < 5; r++) s_prev[h][r] = 0xFF;
+    ringClear();
+    return;
+  }
+
+  uint8_t cur[2][5] = { { 0x1F,0x1F,0x1F,0x1F,0x1F }, { 0x1F,0x1F,0x1F,0x1F,0x1F } };
+  for (int h = 0; h < 2; h++) {
+    if (!s_present[h]) continue;
+    if (!attakyI2cLock(20)) continue;
+    scanHalf(KB_ADDR[h], cur[h]);
+    attakyI2cUnlock();
+  }
+
+  const bool shift_down =
+      s_present[SHIFT_HALF] && !(cur[SHIFT_HALF][SHIFT_ROW] & (1u << SHIFT_COL));
+
+  for (int h = 0; h < 2; h++) {
+    if (!s_present[h]) continue;
+    for (int row = 0; row < 5; row++) {
+      uint8_t now_bits  = cur[h][row];
+      uint8_t prev_bits = s_prev[h][row];
+      for (int col = 0; col < 5; col++) {
+        const uint8_t mask = (uint8_t)(1u << col);
+        const bool down_now  = !(now_bits  & mask);
+        const bool down_prev = !(prev_bits & mask);
+        if (down_now && !down_prev) {
+          uint8_t k = (h == 0) ? KEYMAP_L[row][col] : KEYMAP_R[row][col];
+          if (k == K_NOP || k == K_SFT) continue;
+          if (shift_down && k >= 'a' && k <= 'z') k = (uint8_t)(k - 0x20);
+          ringPush(k);
+        }
+      }
+      s_prev[h][row] = now_bits;
+    }
+  }
+}
+
+int attakyKeyboardReadKey() {
+  if (s_tail == s_head) return 0;
+  uint8_t b = s_ring[s_tail];
+  s_tail = (uint8_t)((s_tail + 1) & 15);
+  return b;
+}
+
+bool attakyKeyboardPresent() { return s_present[0] || s_present[1]; }
+
+#endif

--- a/variants/attaky_mesh_series/AttakyMeshSeriesKeyboard.h
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesKeyboard.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#if defined(HAS_ATTAKY_MESH_KEYBOARD) && defined(ESP32)
+
+#include <stdint.h>
+
+void attakyKeyboardPoll(bool active);
+int attakyKeyboardReadKey();
+bool attakyKeyboardPresent();
+
+#endif

--- a/variants/attaky_mesh_series/AttakyMeshSeriesTouch.cpp
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesTouch.cpp
@@ -6,6 +6,7 @@
 
 #include <Arduino.h>
 #include <Wire.h>
+#include "AttakySharedI2C.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <helpers/ui/MomentaryButton.h>
@@ -140,12 +141,14 @@ static void mapTouchToDisplay(uint16_t in_x, uint16_t in_y, uint16_t* out_x, uin
 }
 
 static bool i2c_read_reg(uint8_t addr, uint8_t reg, uint8_t* buf, uint8_t n) {
+  if (!attakyI2cLock(20)) return false;
   Wire.beginTransmission(addr);
   Wire.write(reg);
-  if (Wire.endTransmission(false) != 0) return false;
+  if (Wire.endTransmission(false) != 0) { attakyI2cUnlock(); return false; }
   uint8_t got = Wire.requestFrom((int)addr, (int)n);
-  if (got != n) return false;
+  if (got != n) { attakyI2cUnlock(); return false; }
   for (uint8_t i = 0; i < n; i++) buf[i] = Wire.read();
+  attakyI2cUnlock();
   return true;
 }
 
@@ -154,10 +157,13 @@ static bool aw9523_read(uint8_t reg, uint8_t* val) {
 }
 
 static bool aw9523_write(uint8_t reg, uint8_t val) {
+  if (!attakyI2cLock(20)) return false;
   Wire.beginTransmission(AW9523_ADDR);
   Wire.write(reg);
   Wire.write(val);
-  return Wire.endTransmission() == 0;
+  bool ok = (Wire.endTransmission() == 0);
+  attakyI2cUnlock();
+  return ok;
 }
 
 static bool aw9523_set_bit(uint8_t reg, uint8_t bitmask, bool set) {
@@ -206,11 +212,7 @@ bool heltecV4CapTouchBegin() {
   s_init_attempted = true;
   s_last_init_try_ms = now;
 
-  // Bound the shared bus so a missing peripheral cannot stall startup.
-  Wire.begin(PIN_BOARD_SDA, PIN_BOARD_SCL, 400000);
-#if defined(ESP32)
-  Wire.setTimeOut(20);
-#endif
+  attakyI2cInit();
 
   ft6636_hw_reset();
 
@@ -225,10 +227,13 @@ bool heltecV4CapTouchBegin() {
   s_vendor_id = vid;
   s_present = true;
 
-  Wire.beginTransmission(FT6636_ADDR);
-  Wire.write(FT6636_REG_MODE);
-  Wire.write((uint8_t)0x00);
-  Wire.endTransmission();
+  if (attakyI2cLock(20)) {
+    Wire.beginTransmission(FT6636_ADDR);
+    Wire.write(FT6636_REG_MODE);
+    Wire.write((uint8_t)0x00);
+    Wire.endTransmission();
+    attakyI2cUnlock();
+  }
 
   snprintf(s_debug, sizeof(s_debug), "FT6636 ok (vid=0x%02X)", vid);
   s_init_ok = true;

--- a/variants/attaky_mesh_series/AttakyMeshSeriesTouch.cpp
+++ b/variants/attaky_mesh_series/AttakyMeshSeriesTouch.cpp
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../../src/helpers/input/HeltecV4CapTouch.h"
+
+#if (defined(HAS_HELTEC_V4_CAP_TOUCH) || defined(HAS_TOUCH_UI)) && defined(ESP32)
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <helpers/ui/MomentaryButton.h>
+
+#ifndef PIN_BOARD_SDA
+  #define PIN_BOARD_SDA 2
+#endif
+#ifndef PIN_BOARD_SCL
+  #define PIN_BOARD_SCL 1
+#endif
+
+static const uint8_t FT6636_ADDR        = 0x38;
+static const uint8_t FT6636_REG_MODE    = 0x00;
+static const uint8_t FT6636_REG_TD_ST   = 0x02;
+static const uint8_t FT6636_REG_VENDOR  = 0xA8;
+
+static const uint8_t AW9523_ADDR        = 0x59;
+static const uint8_t AW9523_REG_OUT_P1  = 0x03;
+static const uint8_t AW9523_REG_CFG_P1  = 0x05;
+static const uint8_t AW9523_REG_LEDM_P1 = 0x13;
+static const uint8_t AW9523_P13_BIT     = (1u << 3);
+
+#ifndef HELTEC_V4_TOUCH_LONG_MS
+  #define HELTEC_V4_TOUCH_LONG_MS 1000
+#endif
+#ifndef HELTEC_V4_TOUCH_LONG_MOVE_MAX
+  #define HELTEC_V4_TOUCH_LONG_MOVE_MAX 18
+#endif
+#ifndef HELTEC_V4_TOUCH_SWIPE_MIN
+  #define HELTEC_V4_TOUCH_SWIPE_MIN 36
+#endif
+#ifndef HELTEC_V4_TOUCH_SWIPE_INVERT
+  #define HELTEC_V4_TOUCH_SWIPE_INVERT 0
+#endif
+
+static bool s_present = false;
+static bool s_init_attempted = false;
+static bool s_init_ok = false;
+static unsigned long s_last_init_try_ms = 0;
+static bool s_tap_pending = false;
+static uint16_t s_tap_x = 0, s_tap_y = 0;
+static bool s_swipe_pending = false;
+static int8_t s_swipe_x = 0, s_swipe_y = 0;
+static bool s_live = false;
+static uint16_t s_live_x = 0, s_live_y = 0;
+static uint16_t s_raw_x = 0, s_raw_y = 0;
+static uint8_t s_vendor_id = 0;
+static char s_debug[48] = "";
+static bool s_swiping_now = false;
+
+static uint8_t s_ui_rotation = 0;
+void heltecV4CapTouchSetRotation(uint8_t lvgl_rot) { s_ui_rotation = lvgl_rot & 3; }
+
+static void rotateSwipeDelta(int dx, int dy, int* odx, int* ody) {
+  switch (s_ui_rotation) {
+    case 1:  *odx = -dy; *ody =  dx; break;
+    case 2:  *odx = -dx; *ody = -dy; break;
+    case 3:  *odx =  dy; *ody = -dx; break;
+    default: *odx =  dx; *ody =  dy; break;
+  }
+}
+
+static uint8_t s_point_rotation = 0;
+void heltecV4CapTouchSetPointRotation(uint8_t r) { s_point_rotation = r & 3; }
+
+static void applyPointRotation(uint16_t* x, uint16_t* y) {
+  if (s_point_rotation == 0) return;
+  const int W = 240;
+  const int H = 320;
+  const int px = *x, py = *y;
+  int lx, ly;
+  switch (s_point_rotation) {
+    case 1:  lx = (H - 1) - py;  ly = px;           break;
+    case 2:  lx = (W - 1) - px;  ly = (H - 1) - py; break;
+    case 3:  lx = py;            ly = (W - 1) - px; break;
+    default: lx = px;            ly = py;           break;
+  }
+  if (lx < 0) lx = 0;
+  if (ly < 0) ly = 0;
+  *x = (uint16_t)lx;
+  *y = (uint16_t)ly;
+}
+
+static void mapTouchToDisplay(uint16_t in_x, uint16_t in_y, uint16_t* out_x, uint16_t* out_y) {
+#ifndef DISPLAY_WIDTH
+  #define DISPLAY_WIDTH 240
+#endif
+#ifndef DISPLAY_HEIGHT
+  #define DISPLAY_HEIGHT 320
+#endif
+#ifndef DISPLAY_ROTATION
+  #define DISPLAY_ROTATION 0
+#endif
+
+  int x = in_x;
+  int y = in_y;
+  int w = DISPLAY_WIDTH;
+  int h = DISPLAY_HEIGHT;
+  switch (DISPLAY_ROTATION & 3) {
+    case 1: {
+      int nx = h - 1 - y;
+      int ny = x;
+      x = nx;
+      y = ny;
+    } break;
+    case 2:
+#if defined(UI_LVGL)
+      break;
+#else
+      x = w - 1 - x;
+      y = h - 1 - y;
+      break;
+#endif
+    case 3: {
+      int nx = y;
+      int ny = w - 1 - x;
+      x = nx;
+      y = ny;
+    } break;
+    default:
+      break;
+  }
+  // Landscape rotations swap output dimensions.
+  int w_out = w, h_out = h;
+  if ((DISPLAY_ROTATION & 3) == 1 || (DISPLAY_ROTATION & 3) == 3) { w_out = h; h_out = w; }
+  if (x < 0) x = 0;
+  if (y < 0) y = 0;
+  if (x >= w_out) x = w_out - 1;
+  if (y >= h_out) y = h_out - 1;
+  if (out_x) *out_x = (uint16_t)x;
+  if (out_y) *out_y = (uint16_t)y;
+}
+
+static bool i2c_read_reg(uint8_t addr, uint8_t reg, uint8_t* buf, uint8_t n) {
+  Wire.beginTransmission(addr);
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) return false;
+  uint8_t got = Wire.requestFrom((int)addr, (int)n);
+  if (got != n) return false;
+  for (uint8_t i = 0; i < n; i++) buf[i] = Wire.read();
+  return true;
+}
+
+static bool aw9523_read(uint8_t reg, uint8_t* val) {
+  return i2c_read_reg(AW9523_ADDR, reg, val, 1);
+}
+
+static bool aw9523_write(uint8_t reg, uint8_t val) {
+  Wire.beginTransmission(AW9523_ADDR);
+  Wire.write(reg);
+  Wire.write(val);
+  return Wire.endTransmission() == 0;
+}
+
+static bool aw9523_set_bit(uint8_t reg, uint8_t bitmask, bool set) {
+  uint8_t v = 0;
+  if (!aw9523_read(reg, &v)) return false;
+  uint8_t nv = set ? (uint8_t)(v | bitmask) : (uint8_t)(v & ~bitmask);
+  if (nv == v) return true;
+  return aw9523_write(reg, nv);
+}
+
+static void ft6636_hw_reset() {
+  bool ok = true;
+  ok &= aw9523_set_bit(AW9523_REG_LEDM_P1, AW9523_P13_BIT, true);
+  ok &= aw9523_set_bit(AW9523_REG_CFG_P1,  AW9523_P13_BIT, false);
+  ok &= aw9523_set_bit(AW9523_REG_OUT_P1,  AW9523_P13_BIT, false);
+  if (!ok) {
+    delay(300);
+    return;
+  }
+  delay(10);
+  aw9523_set_bit(AW9523_REG_OUT_P1, AW9523_P13_BIT, true);
+  delay(300);
+}
+
+static int ft6636_read_touch(uint16_t* x, uint16_t* y) {
+  uint8_t buf[7];
+  if (!i2c_read_reg(FT6636_ADDR, FT6636_REG_TD_ST, buf, 7)) {
+    static uint32_t ec = 0; if ((ec++ & 0x3F) == 0) Serial.printf("[TCH] i2c read FAIL\n");
+    return -1;
+  }
+  uint8_t touch_count = buf[0] & 0x0F;
+  uint8_t event_flag  = (buf[1] >> 6) & 0x03;
+  uint16_t px = (uint16_t)(((buf[1] & 0x0F) << 8) | buf[2]);
+  uint16_t py = (uint16_t)(((buf[3] & 0x0F) << 8) | buf[4]);
+  bool down = (touch_count >= 1) && (event_flag != 1);
+  if (!down) return -1;
+  if (x) *x = px;
+  if (y) *y = py;
+  return 0;
+}
+
+bool heltecV4CapTouchBegin() {
+  if (s_init_ok) return true;
+  unsigned long now = millis();
+  if (s_init_attempted && (unsigned long)(now - s_last_init_try_ms) < 400) return false;
+  s_init_attempted = true;
+  s_last_init_try_ms = now;
+
+  // Bound the shared bus so a missing peripheral cannot stall startup.
+  Wire.begin(PIN_BOARD_SDA, PIN_BOARD_SCL, 400000);
+#if defined(ESP32)
+  Wire.setTimeOut(20);
+#endif
+
+  ft6636_hw_reset();
+
+  uint8_t vid = 0;
+  if (!i2c_read_reg(FT6636_ADDR, FT6636_REG_VENDOR, &vid, 1) || vid == 0) {
+    s_vendor_id = vid;
+    s_present = false;
+    s_init_ok = false;
+    snprintf(s_debug, sizeof(s_debug), "FT6636 absent (vid=0x%02X)", vid);
+    return false;
+  }
+  s_vendor_id = vid;
+  s_present = true;
+
+  Wire.beginTransmission(FT6636_ADDR);
+  Wire.write(FT6636_REG_MODE);
+  Wire.write((uint8_t)0x00);
+  Wire.endTransmission();
+
+  snprintf(s_debug, sizeof(s_debug), "FT6636 ok (vid=0x%02X)", vid);
+  s_init_ok = true;
+  return true;
+}
+
+int heltecV4CapTouchCheck() {
+  if (!s_init_ok || !s_present) {
+    s_live = false;
+    return BUTTON_EVENT_NONE;
+  }
+
+  static bool down = false;
+  static unsigned long down_at = 0;
+  static bool long_dispatched = false;
+  static uint16_t start_x = 0, start_y = 0;
+  static uint16_t last_x = 0, last_y = 0;
+  // Ignore one transient miss before ending a gesture.
+  static uint8_t release_misses = 0;
+  constexpr uint8_t RELEASE_DEBOUNCE = 2;
+
+  uint16_t x = 0, y = 0;
+  int r = ft6636_read_touch(&x, &y);
+  bool now = (r == 0);
+  if (now) { s_raw_x = x; s_raw_y = y; }
+
+  if (!now && down && release_misses < RELEASE_DEBOUNCE) {
+    ++release_misses;
+    return BUTTON_EVENT_NONE;
+  }
+  if (now) release_misses = 0;
+
+  if (now && !down) {
+    down = true;
+    down_at = millis();
+    long_dispatched = false;
+    start_x = last_x = x;
+    start_y = last_y = y;
+    s_swiping_now = false;
+    mapTouchToDisplay(start_x, start_y, &s_live_x, &s_live_y);
+    applyPointRotation(&s_live_x, &s_live_y);
+    s_live = true;
+  } else if (now && down) {
+    last_x = x;
+    last_y = y;
+    mapTouchToDisplay(last_x, last_y, &s_live_x, &s_live_y);
+    applyPointRotation(&s_live_x, &s_live_y);
+    s_live = true;
+    // Only horizontal swipes suppress LVGL clicks.
+    if (!s_swiping_now) {
+      int rdx = static_cast<int>(last_x) - static_cast<int>(start_x);
+      int rdy = static_cast<int>(last_y) - static_cast<int>(start_y);
+      int dx, dy;
+      rotateSwipeDelta(rdx, rdy, &dx, &dy);
+      int adx = dx < 0 ? -dx : dx;
+      int ady = dy < 0 ? -dy : dy;
+      if (adx >= HELTEC_V4_TOUCH_SWIPE_MIN && adx > ady) {
+        s_swiping_now = true;
+      }
+    }
+  } else if (!now && down) {
+    s_live = false;
+    down = false;
+    s_swiping_now = false;
+    unsigned long dur = (down_at > 0) ? (unsigned long)(millis() - down_at) : 0;
+    down_at = 0;
+    uint16_t sx = 0, sy = 0, ex = 0, ey = 0;
+    mapTouchToDisplay(start_x, start_y, &sx, &sy);
+    mapTouchToDisplay(last_x, last_y, &ex, &ey);
+    int rdx = (int)ex - (int)sx;
+    int rdy = (int)ey - (int)sy;
+    int dx, dy;
+    rotateSwipeDelta(rdx, rdy, &dx, &dy);
+    int adx = dx < 0 ? -dx : dx;
+    int ady = dy < 0 ? -dy : dy;
+    if (!long_dispatched && adx >= HELTEC_V4_TOUCH_SWIPE_MIN && adx > (ady + 8)) {
+      bool swipe_left = dx < 0;
+#if HELTEC_V4_TOUCH_SWIPE_INVERT
+      swipe_left = !swipe_left;
+#endif
+      s_swipe_x = swipe_left ? -1 : 1;
+      s_swipe_y = 0;
+      s_swipe_pending = true;
+      // Button events carry horizontal swipe direction.
+      return swipe_left ? BUTTON_EVENT_DOUBLE_CLICK : BUTTON_EVENT_TRIPLE_CLICK;
+    }
+    if (!long_dispatched && ady >= HELTEC_V4_TOUCH_SWIPE_MIN && ady > (adx + 8)) {
+      s_swipe_x = 0;
+      s_swipe_y = (dy < 0) ? -1 : 1;
+      s_swipe_pending = true;
+      return BUTTON_EVENT_NONE;
+    }
+    if (!long_dispatched && dur >= 12 && dur < (unsigned long)HELTEC_V4_TOUCH_LONG_MS) {
+      s_tap_x = ex;
+      s_tap_y = ey;
+      applyPointRotation(&s_tap_x, &s_tap_y);
+      s_tap_pending = true;
+      return BUTTON_EVENT_CLICK;
+    }
+    long_dispatched = false;
+  } else if (down && !long_dispatched && down_at > 0 &&
+             (unsigned long)(millis() - down_at) >= (unsigned long)HELTEC_V4_TOUCH_LONG_MS) {
+    int dx = (int)last_x - (int)start_x;
+    int dy = (int)last_y - (int)start_y;
+    int adx = dx < 0 ? -dx : dx;
+    int ady = dy < 0 ? -dy : dy;
+    if (adx > HELTEC_V4_TOUCH_LONG_MOVE_MAX || ady > HELTEC_V4_TOUCH_LONG_MOVE_MAX) {
+      return BUTTON_EVENT_NONE;
+    }
+    long_dispatched = true;
+    return BUTTON_EVENT_LONG_PRESS;
+  }
+
+  return BUTTON_EVENT_NONE;
+}
+
+bool heltecV4CapTouchPopTap(uint16_t* x, uint16_t* y) {
+  if (!s_tap_pending) return false;
+  s_tap_pending = false;
+  if (x) *x = s_tap_x;
+  if (y) *y = s_tap_y;
+  return true;
+}
+
+bool heltecV4CapTouchGetLive(uint16_t* x, uint16_t* y) {
+  if (!s_live) return false;
+  if (x) *x = s_live_x;
+  if (y) *y = s_live_y;
+  return true;
+}
+
+bool heltecV4CapTouchPopSwipe(int8_t* x_dir, int8_t* y_dir) {
+  if (!s_swipe_pending) return false;
+  s_swipe_pending = false;
+  if (x_dir) *x_dir = s_swipe_x;
+  if (y_dir) *y_dir = s_swipe_y;
+  s_swipe_x = 0;
+  s_swipe_y = 0;
+  return true;
+}
+
+// Poll touch independently from LVGL rendering.
+static TaskHandle_t s_poll_task = nullptr;
+static uint32_t     s_poll_period_ms = 8;
+static volatile bool s_async_active = false;
+
+static void touchPollTaskFn(void* /*arg*/) {
+  s_async_active = true;
+  const TickType_t period = pdMS_TO_TICKS(s_poll_period_ms ? s_poll_period_ms : 8);
+  TickType_t last_wake = xTaskGetTickCount();
+  for (;;) {
+    (void)heltecV4CapTouchCheck();
+    vTaskDelayUntil(&last_wake, period);
+  }
+}
+
+bool heltecV4CapTouchStartBackgroundPoll(uint32_t period_ms) {
+  if (s_poll_task != nullptr) return false;
+  if (!s_init_ok) return false;
+  if (period_ms < 4) period_ms = 4;
+  if (period_ms > 100) period_ms = 100;
+  s_poll_period_ms = period_ms;
+  BaseType_t ok = xTaskCreatePinnedToCore(
+      touchPollTaskFn,
+      "touch_poll",
+      4096,
+      nullptr,
+      1,
+      &s_poll_task,
+      0);
+  if (ok != pdPASS) {
+    s_poll_task = nullptr;
+    return false;
+  }
+  return true;
+}
+
+bool heltecV4CapTouchIsAsyncPolling() {
+  return s_async_active;
+}
+
+bool heltecV4CapTouchIsSwiping() {
+  return s_swiping_now;
+}
+
+const char* heltecV4CapTouchDebug() { return s_debug; }
+
+void heltecV4CapTouchGetRaw(uint16_t* rx, uint16_t* ry) {
+  if (rx) *rx = s_raw_x;
+  if (ry) *ry = s_raw_y;
+}
+
+#endif

--- a/variants/attaky_mesh_series/AttakySharedI2C.cpp
+++ b/variants/attaky_mesh_series/AttakySharedI2C.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "AttakySharedI2C.h"
+#include <Wire.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+static SemaphoreHandle_t s_i2c_mtx = nullptr;
+static bool              s_inited  = false;
+
+void attakyI2cInit() {
+  if (s_inited) return;
+  Wire.begin(PIN_BOARD_SDA, PIN_BOARD_SCL, 400000);
+#if defined(ESP32)
+  Wire.setTimeOut(20);
+#endif
+  s_i2c_mtx = xSemaphoreCreateMutex();
+  s_inited  = true;
+}
+
+bool attakyI2cLock(uint32_t timeout_ms) {
+  if (!s_i2c_mtx) return true;
+  return xSemaphoreTake(s_i2c_mtx, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
+}
+
+void attakyI2cUnlock() {
+  if (s_i2c_mtx) xSemaphoreGive(s_i2c_mtx);
+}

--- a/variants/attaky_mesh_series/AttakySharedI2C.h
+++ b/variants/attaky_mesh_series/AttakySharedI2C.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <Arduino.h>
+
+void attakyI2cInit();
+
+bool attakyI2cLock(uint32_t timeout_ms = 50);
+void attakyI2cUnlock();

--- a/variants/attaky_mesh_series/pins_arduino.h
+++ b/variants/attaky_mesh_series/pins_arduino.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 2;
+static const uint8_t SCL = 1;
+
+static const uint8_t SS    = 8;
+static const uint8_t MOSI  = 6;
+static const uint8_t MISO  = 7;
+static const uint8_t SCK   = 5;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+#endif /* Pins_Arduino_h */

--- a/variants/attaky_mesh_series/target.cpp
+++ b/variants/attaky_mesh_series/target.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <Arduino.h>
+#include "target.h"
+
+namespace {
+struct BootTrace {
+  BootTrace() { set_boot_phase(1); }
+} _boot_trace;
+}
+
+AttakyMeshSeriesBoard board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi;
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+ClockFloorRTC        rtc_clock(fallback_clock);
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display(NULL);
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#if defined(P_LORA_SCLK)
+  return radio.std_init(&spi);
+#else
+  return radio.std_init();
+#endif
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);
+}

--- a/variants/attaky_mesh_series/target.h
+++ b/variants/attaky_mesh_series/target.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" void set_boot_phase(int phase);
+#endif
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <AttakyMeshSeriesBoard.h>
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include "../../src/helpers/ClockFloorRTC.h"
+#include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/ST7789LCDDisplay.h>
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+
+extern AttakyMeshSeriesBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern RADIO_CLASS radio;
+extern ClockFloorRTC rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
## Summary

Adds board support for the Attaky Mesh series.

The new `attaky_mesh_series_companion_radio_touch` PlatformIO environment includes:

- Landscape display and capacitive touch support
- Optional physical keyboard module support
- GPS and battery monitoring
- Shared I2C bus coordination
- LoRa radio configuration
- Board-specific pin and target definitions

## Build

```bash
pio run -e attaky_mesh_series_companion_radio_touch
```

## Test plan

- [x] Clean build succeeds
- [x] Firmware flashes and boots on hardware
- [x] Landscape display and touch input verified
- [x] Physical keyboard input verified
- [x] GPS data reception verified
- [x] Battery voltage reading verified
- [x] Radio initialization verified
- [ ] End-to-end LoRa discovery between two devices