### PR TITLE
ui-touch: invalidate LVGL img cache before freeing lock wallpaper buf.  Fixes #127

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -32931,7 +32931,18 @@ static void lockscreenShow() {
   // Wallpaper, scaled to cover the screen (crop overflow, never letterbox).
   int ww = 0, wh = 0;
   const uint8_t* wall_data = nullptr;
-  if (s_lock_wall) { lvglPsramFree(s_lock_wall); s_lock_wall = nullptr; }
+  if (s_lock_wall) {
+    // Invalidate LVGL's image cache entry for s_lock_wall_dsc BEFORE freeing the
+    // buffer it points at. s_lock_wall_dsc is a static var (stable address), and
+    // LVGL's img cache is keyed by that src pointer -- without this, the next
+    // lockscreenShow() can hit a stale cache entry pointing at freed PSRAM that
+    // has since been reused elsewhere (e.g. the map's 128 KB tile buffers),
+    // rendering as RGB565 noise on wake. Same bug class already fixed for map
+    // tiles in freeMapTileSlot() -- see the comment there (issue #127).
+    lv_img_cache_invalidate_src(&s_lock_wall_dsc);
+    lvglPsramFree(s_lock_wall);
+    s_lock_wall = nullptr;
+  }
   char wpath[TOUCH_LOCK_WALLPAPER_MAXLEN];
   touchPrefsGetLockWallpaper(wpath, sizeof wpath);
   if (!strcmp(wpath, "/lock/placeholder.jpg")) {
@@ -33075,7 +33086,7 @@ static void lockscreenHide() {
     s_lock_status = nullptr; s_lock_hint = nullptr;
 #endif
   }
-  if (s_lock_wall) { lvglPsramFree(s_lock_wall); s_lock_wall = nullptr; }
+  if (s_lock_wall) { lv_img_cache_invalidate_src(&s_lock_wall_dsc); lvglPsramFree(s_lock_wall); s_lock_wall = nullptr; }
   s_lock_clock_min = -1;
   s_lock_unread_n  = -1;
   // Restore the status bar's normal opaque background + accent border.


### PR DESCRIPTION
Fixes #127

## Root cause

`s_lock_wall_dsc` (the lock screen's `lv_img_dsc_t`) is a `static` variable, so
its address never changes across lock/unlock cycles. LVGL's image cache is
keyed by that *source pointer*, not by the `data` it points at.

`lockscreenShow()` re-decodes a custom wallpaper into a **fresh** PSRAM buffer
every time the screen locks, and frees the previous buffer — but never
invalidated the LVGL image cache entry for `&s_lock_wall_dsc` before doing so.
So the next `lv_img_set_src(img, &s_lock_wall_dsc)` can hit a stale cache
entry that still points at the just-freed buffer.

That freed PSRAM is commonly reclaimed almost immediately by the map's
128 KB tile buffers (`kTileBufBytes` in `renderMapTiles`), so the stale draw
comes out as colorful RGB565 noise instead of the wallpaper — exactly the
symptom in #127 ("black lockscreen jpg wallpaper going crazy", correlated
with visiting the map). Only a reboot "fixed" it, since the stale cache entry
otherwise persists indefinitely.

This is the same bug class already fixed for map tiles in
`freeMapTileSlot()` (see its comment) — that fix was just never applied to
the lock screen's wallpaper buffer.

The built-in default wallpaper never shows this because it's a `static
const` RGB565 array baked into flash and is never re-allocated — only
custom (JPEG-decoded) wallpapers are affected.

## Fix

Call `lv_img_cache_invalidate_src(&s_lock_wall_dsc)` immediately before
freeing `s_lock_wall`, in both places that free it:
- `lockscreenShow()` — before re-decoding on the next lock
- `lockscreenHide()` — on teardown

## Testing

Reproduced on-device (LilyGo T-Deck) with a custom JPG lockscreen wallpaper:
repeatedly opening the map, backing out, and locking/waking reliably
corrupted the wallpaper into RGB565 noise before this fix, matching the
screenshot in #127. After the fix, the same repro (many map → lock → wake
cycles) no longer reproduces the corruption.