### PR TITLE
fix(esp32): persist preferences safely off the UI task

### DIFF
--- a/src/helpers/esp32/SdNvsPrefs.cpp
+++ b/src/helpers/esp32/SdNvsPrefs.cpp
@@ -4,6 +4,7 @@
 #include <FS.h>
 #include <SD.h>
 #include <SPIFFS.h>
+#include <errno.h>
 #include <string.h>
 
 // ----------------------------- backend selection -----------------------------
@@ -59,23 +60,45 @@ bool SdNvsPrefs::useNvs() {
 // ----------------------------- begin / end -----------------------------
 bool SdNvsPrefs::begin(const char* ns, bool readOnly) {
   _read_only = readOnly;
-  _sd.clear();
-  _sd_loaded = false;
   if (_nvs_open) { _nvs.end(); _nvs_open = false; }
 
   if (fileMode()) {
-    snprintf(_path, sizeof(_path), "%s/%s.kv", s_file_dir, ns);
-    sdLoad();
-    _sd_loaded = true;
+    char path[sizeof(_path)];
+    snprintf(path, sizeof(path), "%s/%s.kv", s_file_dir, ns);
+    if (strncmp(_path, path, sizeof(_path)) != 0) {
+      strncpy(_path, path, sizeof(_path) - 1);
+      _path[sizeof(_path) - 1] = '\0';
+      _sd.clear();
+      _sd_loaded = false;
+    }
+    const bool had_cache = _sd_loaded;
+    const bool loaded = sdLoad();
+    if (loaded) _sd_loaded = true;
     if (nvsHasLegacyData()) _nvs_open = _nvs.begin(ns, true);   // RO migration source
-    return true;
+    // A transient storage outage must not turn a previously-loaded namespace
+    // into an empty one. Readers can keep using the last-known-good mirror;
+    // writers fail so callers do not report a save that never reached disk.
+    return loaded || (readOnly && had_cache);
   }
 
-  if (useNvs()) { _nvs_open = _nvs.begin(ns, readOnly); return _nvs_open; }
-  snprintf(_path, sizeof(_path), "/meshcomod/%s.kv", ns);
-  sdLoad();
-  _sd_loaded = true;
-  return true;
+  if (useNvs()) {
+    _sd.clear();
+    _sd_loaded = false;
+    _nvs_open = _nvs.begin(ns, readOnly);
+    return _nvs_open;
+  }
+  char path[sizeof(_path)];
+  snprintf(path, sizeof(path), "/meshcomod/%s.kv", ns);
+  if (strncmp(_path, path, sizeof(_path)) != 0) {
+    strncpy(_path, path, sizeof(_path) - 1);
+    _path[sizeof(_path) - 1] = '\0';
+    _sd.clear();
+    _sd_loaded = false;
+  }
+  const bool had_cache = _sd_loaded;
+  const bool loaded = sdLoad();
+  if (loaded) _sd_loaded = true;
+  return loaded || (readOnly && had_cache);
 }
 
 void SdNvsPrefs::end() {
@@ -88,48 +111,114 @@ SdNvsPrefs::Kv* SdNvsPrefs::sdFind(const char* key) {
   return nullptr;
 }
 
-void SdNvsPrefs::sdSet(const char* key, const uint8_t* data, size_t len) {
+bool SdNvsPrefs::sdSet(const char* key, const uint8_t* data, size_t len) {
+  if (!key || (len > 0 && !data)) return false;
   Kv* e = sdFind(key);
+  bool added = false;
+  std::vector<uint8_t> old;
   if (!e) {
     _sd.push_back(Kv{});
     e = &_sd.back();
+    added = true;
     strncpy(e->key, key, sizeof(e->key) - 1);
     e->key[sizeof(e->key) - 1] = '\0';
+  } else {
+    old = e->val;
   }
-  e->val.assign(data, data + len);
-  sdSave();
+  if (len == 0) e->val.clear();
+  else          e->val.assign(data, data + len);
+  if (sdSave()) return true;
+  if (added) _sd.pop_back();
+  else       e->val = std::move(old);
+  return false;
 }
 
-void SdNvsPrefs::sdLoad() {
+bool SdNvsPrefs::sdLoad() {
+  fs::FS* fs = activeFs();
+  if (!fs) return false;
+
+  char tmp[sizeof(_path) + 5], bak[sizeof(_path) + 5];
+  if (snprintf(tmp, sizeof(tmp), "%s.tmp", _path) >= (int)sizeof(tmp) ||
+      snprintf(bak, sizeof(bak), "%s.bak", _path) >= (int)sizeof(bak)) return false;
+
+  // No file on the first load is a valid, empty namespace. Once a namespace
+  // has been loaded, however, a missing file means the backing FS disappeared;
+  // retain the RAM mirror instead of silently replacing every key with defaults.
+  const bool have_live = fs->exists(_path);
+  const bool have_tmp  = fs->exists(tmp);
+  const bool have_bak  = fs->exists(bak);
+  if (!have_live && !have_tmp && !have_bak) {
+    if (_sd_loaded) return false;
+    _sd.clear();
+    return true;
+  }
+
+  auto parse = [fs](const char* path, std::vector<Kv>& out) {
+    File f = fs->open(path, FILE_READ);
+    if (!f) return false;
+    bool ok = true;
+    // record = [keylen u8][key bytes][vallen u16 LE][val bytes]. Parse into a
+    // temporary vector so a short/corrupt file cannot destroy the RAM mirror.
+    while (f.available() > 0) {
+      if (out.size() >= 256) { ok = false; break; }
+      int kl = f.read();
+      if (kl <= 0 || kl > 15) { ok = false; break; }
+      char k[16] = {0};
+      if (f.read((uint8_t*)k, kl) != kl) { ok = false; break; }
+      int lo = f.read(), hi = f.read();
+      if (lo < 0 || hi < 0) { ok = false; break; }
+      size_t vl = (size_t)lo | ((size_t)hi << 8);
+      if (vl > 2048) { ok = false; break; }
+      std::vector<uint8_t> v(vl);
+      if (vl && f.read(v.data(), vl) != (int)vl) { ok = false; break; }
+      Kv e; strncpy(e.key, k, sizeof(e.key) - 1); e.key[sizeof(e.key) - 1] = '\0';
+      e.val = std::move(v);
+      out.push_back(std::move(e));
+    }
+    f.close();
+    return ok;
+  };
+
+  // Prefer the live file. If a reset landed between the two renames, validate
+  // the verified temp next, then fall back to the previous complete backup.
+  std::vector<Kv> loaded;
+  if (have_live && parse(_path, loaded)) {
+    if (have_tmp) fs->remove(tmp);
+    if (have_bak) fs->remove(bak);
+    _sd = std::move(loaded);
+    return true;
+  }
+  loaded.clear();
+  if (have_tmp && parse(tmp, loaded)) {
+    if (have_live && !fs->remove(_path)) return false;
+    if (!fs->rename(tmp, _path)) return false;
+    if (have_bak) fs->remove(bak);
+    _sd = std::move(loaded);
+    return true;
+  }
+  loaded.clear();
+  if (have_bak && parse(bak, loaded)) {
+    if (have_live && !fs->remove(_path)) return false;
+    if (have_tmp) fs->remove(tmp);
+    if (!fs->rename(bak, _path)) return false;
+    _sd = std::move(loaded);
+    return true;
+  }
+
+  Serial.printf("[PREFS] refusing partial/corrupt file %s\n", _path);
+  if (_sd_loaded) {
+    // Keep the last-known-good mirror when a mounted filesystem becomes
+    // temporarily unreadable or exposes an incomplete file.
+    return false;
+  }
   _sd.clear();
-  fs::FS* fs = activeFs();
-  if (!fs) return;
-  File f = fs->open(_path, FILE_READ);
-  if (!f) return;
-  // record = [keylen u8][key bytes][vallen u16 LE][val bytes]. Sanity caps stop a
-  // corrupt file from a huge alloc; on any bad record we stop and keep what loaded.
-  while (f.available() > 0 && _sd.size() < 256) {
-    int kl = f.read();
-    if (kl <= 0 || kl > 15) break;
-    char k[16] = {0};
-    if (f.read((uint8_t*)k, kl) != kl) break;
-    int lo = f.read(), hi = f.read();
-    if (lo < 0 || hi < 0) break;
-    size_t vl = (size_t)lo | ((size_t)hi << 8);
-    if (vl > 2048) break;
-    std::vector<uint8_t> v(vl);
-    if (vl && f.read(v.data(), vl) != (int)vl) break;
-    Kv e; strncpy(e.key, k, sizeof(e.key) - 1); e.key[sizeof(e.key) - 1] = '\0';
-    e.val = std::move(v);
-    _sd.push_back(std::move(e));
-  }
-  f.close();
+  return false;
 }
 
-void SdNvsPrefs::sdSave() {
-  if (_read_only) return;
+bool SdNvsPrefs::sdSave() {
+  if (_read_only) return false;
   fs::FS* fs = activeFs();
-  if (!fs) return;
+  if (!fs) return false;
   // Create the parent dir (SD needs it; SPIFFS is flat and treats the whole path
   // as a filename, so mkdir is a harmless no-op there).
   char dir[40];
@@ -139,18 +228,63 @@ void SdNvsPrefs::sdSave() {
 #if defined(TDP4_POKE_TRACE)
   printf("[SDW] %lu core%d kv w %s\n", (unsigned long)millis(), (int)xPortGetCoreID(), _path);
 #endif
-  File f = fs->open(_path, FILE_WRITE);   // truncate + rewrite the whole file
-  if (!f) return;
+
+  char tmp[sizeof(_path) + 5], bak[sizeof(_path) + 5];
+  if (snprintf(tmp, sizeof(tmp), "%s.tmp", _path) >= (int)sizeof(tmp) ||
+      snprintf(bak, sizeof(bak), "%s.bak", _path) >= (int)sizeof(bak)) return false;
+  fs->remove(tmp);   // stale pre-swap temp; the intact live file remains authoritative
+
+  errno = 0;
+  File f = fs->open(tmp, FILE_WRITE);
+  if (!f) {
+    Serial.printf("[PREFS] save open failed %s (e%d)\n", tmp, errno);
+    return false;
+  }
+  bool ok = true;
+  size_t expected = 0;
   for (auto& e : _sd) {
     size_t kl = strnlen(e.key, sizeof(e.key));
     size_t vl = e.val.size();
-    f.write((uint8_t)kl);
-    f.write((const uint8_t*)e.key, kl);
-    f.write((uint8_t)(vl & 0xFF));
-    f.write((uint8_t)((vl >> 8) & 0xFF));
-    if (vl) f.write(e.val.data(), vl);
+    expected += 1 + kl + 2 + vl;
+    ok = ok && (f.write((uint8_t)kl) == 1);
+    ok = ok && (f.write((const uint8_t*)e.key, kl) == kl);
+    ok = ok && (f.write((uint8_t)(vl & 0xFF)) == 1);
+    ok = ok && (f.write((uint8_t)((vl >> 8) & 0xFF)) == 1);
+    if (vl) ok = ok && (f.write(e.val.data(), vl) == vl);
+    if (!ok) break;
   }
   f.close();
+
+  // A short write leaves only the temp damaged. Verify the closed file size too
+  // before touching the live copy (catches buffered close/flush failures).
+  if (ok) {
+    File verify = fs->open(tmp, FILE_READ);
+    ok = verify && verify.size() == expected;
+    if (verify) verify.close();
+  }
+  if (!ok) {
+    Serial.printf("[PREFS] save write failed %s (e%d)\n", tmp, errno);
+    fs->remove(tmp);
+    return false;
+  }
+
+  // Two-step swap with recovery breadcrumbs. At every point either the old
+  // live file, the verified temp, or the backup is complete; sdLoad() resolves
+  // leftovers after a reset between renames.
+  const bool had_live = fs->exists(_path);
+  if (fs->exists(bak)) fs->remove(bak);
+  if (had_live && !fs->rename(_path, bak)) {
+    Serial.printf("[PREFS] save backup rename failed %s (e%d)\n", _path, errno);
+    fs->remove(tmp);
+    return false;
+  }
+  if (!fs->rename(tmp, _path)) {
+    Serial.printf("[PREFS] save commit rename failed %s (e%d)\n", _path, errno);
+    if (had_live) fs->rename(bak, _path);   // best-effort live rollback
+    return false;
+  }
+  if (had_live) fs->remove(bak);
+  return true;
 }
 
 uint64_t SdNvsPrefs::sdGetInt(const char* key, uint64_t def, int width) {
@@ -165,8 +299,7 @@ uint64_t SdNvsPrefs::sdGetInt(const char* key, uint64_t def, int width) {
 size_t SdNvsPrefs::sdPutInt(const char* key, uint64_t v, int width) {
   uint8_t b[8];
   for (int i = 0; i < width; i++) b[i] = (uint8_t)(v >> (8 * i));
-  sdSet(key, b, width);
-  return width;
+  return sdSet(key, b, width) ? width : 0;
 }
 
 // ----------------------------- API -----------------------------
@@ -181,15 +314,22 @@ bool SdNvsPrefs::isKey(const char* key) {
 
 bool SdNvsPrefs::remove(const char* key) {
   if (!fileMode() && useNvs()) return _nvs_open && _nvs.remove(key);
-  for (size_t i = 0; i < _sd.size(); i++)
-    if (strncmp(_sd[i].key, key, sizeof(_sd[i].key)) == 0) { _sd.erase(_sd.begin() + i); sdSave(); return true; }
+  for (size_t i = 0; i < _sd.size(); i++) {
+    if (strncmp(_sd[i].key, key, sizeof(_sd[i].key)) != 0) continue;
+    Kv old = _sd[i];
+    _sd.erase(_sd.begin() + i);
+    if (sdSave()) return true;
+    _sd.insert(_sd.begin() + i, std::move(old));
+    return false;
+  }
   return false;
 }
 
 bool SdNvsPrefs::clear() {
   if (fileMode()) {
+    std::vector<Kv> old = _sd;
     _sd.clear();
-    sdSave();
+    if (!sdSave()) { _sd = std::move(old); return false; }
     // Wipe any legacy NVS copy too, so a factory reset is permanent. Derive the
     // namespace from "<dir>/<ns>.kv".
     if (nvsHasLegacyData()) {
@@ -204,7 +344,11 @@ bool SdNvsPrefs::clear() {
     return true;
   }
   if (useNvs()) return _nvs_open && _nvs.clear();
-  _sd.clear(); sdSave(); return true;
+  std::vector<Kv> old = _sd;
+  _sd.clear();
+  if (sdSave()) return true;
+  _sd = std::move(old);
+  return false;
 }
 
 uint8_t SdNvsPrefs::getUChar(const char* k, uint8_t def) {
@@ -299,9 +443,9 @@ size_t SdNvsPrefs::getString(const char* k, char* buf, size_t maxLen) {
   return n;
 }
 size_t SdNvsPrefs::putString(const char* k, const char* v) {
-  if (fileMode()) { size_t n = v ? strlen(v) : 0; sdSet(k, (const uint8_t*)v, n); return n; }
+  if (fileMode()) { size_t n = v ? strlen(v) : 0; return sdSet(k, (const uint8_t*)v, n) ? n : 0; }
   if (useNvs()) return _nvs.putString(k, v);
-  size_t n = v ? strlen(v) : 0; sdSet(k, (const uint8_t*)v, n); return n;
+  size_t n = v ? strlen(v) : 0; return sdSet(k, (const uint8_t*)v, n) ? n : 0;
 }
 
 size_t SdNvsPrefs::getBytes(const char* k, void* buf, size_t maxLen) {
@@ -319,9 +463,9 @@ size_t SdNvsPrefs::getBytes(const char* k, void* buf, size_t maxLen) {
   return n;
 }
 size_t SdNvsPrefs::putBytes(const char* k, const void* buf, size_t len) {
-  if (fileMode()) { sdSet(k, (const uint8_t*)buf, len); return len; }
+  if (fileMode()) return sdSet(k, (const uint8_t*)buf, len) ? len : 0;
   if (useNvs()) return _nvs.putBytes(k, buf, len);
-  sdSet(k, (const uint8_t*)buf, len); return len;
+  return sdSet(k, (const uint8_t*)buf, len) ? len : 0;
 }
 
 #endif  // ESP32

--- a/src/helpers/esp32/SdNvsPrefs.cpp
+++ b/src/helpers/esp32/SdNvsPrefs.cpp
@@ -4,7 +4,12 @@
 #include <FS.h>
 #include <SD.h>
 #include <SPIFFS.h>
-#include <errno.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+#include <new>
+#include <stddef.h>
 #include <string.h>
 
 // ----------------------------- backend selection -----------------------------
@@ -19,12 +24,248 @@ static bool    s_file_mode = false;
 static int     s_legacy    = -1;   // legacy probe cache: -1 undecided, 0 SD, 1 NVS
 static int     s_migrate   = -1;   // -1 undecided, 0 = no NVS legacy data, 1 = yes
 
+static constexpr uint32_t PREFS_MAGIC       = 0x32504657u;  // "WFP2"
+static constexpr uint16_t PREFS_FORMAT      = 1;
+static constexpr uint32_t PREFS_QUIET_MS    = 750;
+static constexpr uint32_t PREFS_MAX_WAIT_MS = 5000;
+// These are settings namespaces, not a general object store. A hard ceiling
+// bounds the RAM snapshot + worker copy on boards without PSRAM; current touch
+// and discovered payloads are both well below 16 KB.
+static constexpr size_t   PREFS_MAX_PAYLOAD = 64u * 1024u;
+
+struct __attribute__((packed)) SnapshotFooter {
+  uint32_t magic;
+  uint16_t format;
+  uint16_t footer_size;
+  uint32_t generation;
+  uint32_t payload_size;
+  uint32_t payload_crc;
+  uint32_t footer_crc;
+};
+
+struct FileCache {
+  fs::FS* fs = nullptr;
+  char legacy_path[40] = {0};
+  std::vector<SdNvsPrefs::Kv> kv;
+  uint32_t generation = 0;
+  uint32_t revision = 0;
+  uint32_t dirty_first_ms = 0;
+  uint32_t dirty_last_ms = 0;
+  uint32_t retry_after_ms = 0;
+  char active_slot = 0;
+  bool loaded = false;
+  bool dirty = false;
+  bool writing = false;
+  bool legacy_present = false;
+};
+
+struct WriteJob {
+  fs::FS* fs = nullptr;
+  char legacy_path[40] = {0};
+  std::vector<SdNvsPrefs::Kv> kv;
+  uint32_t generation = 0;
+  uint32_t revision = 0;
+  char slot = 'a';
+};
+
+static std::vector<FileCache> s_caches;
+static SemaphoreHandle_t s_cache_mutex = nullptr;
+static QueueHandle_t s_write_queue = nullptr;
+static TaskHandle_t s_write_task = nullptr;
+
+static uint32_t crc32Update(uint32_t crc, const uint8_t* data, size_t len) {
+  crc = ~crc;
+  while (len--) {
+    crc ^= *data++;
+    for (int bit = 0; bit < 8; ++bit)
+      crc = (crc >> 1) ^ (0xEDB88320u & (uint32_t)-(int32_t)(crc & 1u));
+  }
+  return ~crc;
+}
+
+static uint32_t crc32(const void* data, size_t len) {
+  return crc32Update(0, static_cast<const uint8_t*>(data), len);
+}
+
+static bool slotPath(const char* legacy_path, char slot, char* out, size_t cap) {
+  if (!legacy_path || !out || cap == 0) return false;
+  if (slot == 'a') return snprintf(out, cap, "%s", legacy_path) < (int)cap;
+  const size_t n = strlen(legacy_path);
+  if (n >= 3 && strcmp(legacy_path + n - 3, ".kv") == 0)
+    return snprintf(out, cap, "%.*s.alt", (int)(n - 3), legacy_path) < (int)cap;
+  return snprintf(out, cap, "%s.alt", legacy_path) < (int)cap;
+}
+
+static bool serializeKv(const std::vector<SdNvsPrefs::Kv>& kv, std::vector<uint8_t>& out) {
+  size_t total = 0;
+  for (const auto& e : kv) {
+    const size_t kl = strnlen(e.key, sizeof(e.key));
+    if (kl == 0 || kl > 15 || e.val.size() > 2048) return false;
+    total += 1 + kl + 2 + e.val.size();
+    if (total > PREFS_MAX_PAYLOAD) return false;
+  }
+  out.clear();
+  out.reserve(total);
+  for (const auto& e : kv) {
+    const size_t kl = strnlen(e.key, sizeof(e.key));
+    const size_t vl = e.val.size();
+    out.push_back((uint8_t)kl);
+    out.insert(out.end(), e.key, e.key + kl);
+    out.push_back((uint8_t)(vl & 0xFF));
+    out.push_back((uint8_t)((vl >> 8) & 0xFF));
+    out.insert(out.end(), e.val.begin(), e.val.end());
+  }
+  return true;
+}
+
+static bool parsePayload(const uint8_t* data, size_t len, std::vector<SdNvsPrefs::Kv>& out) {
+  out.clear();
+  size_t pos = 0;
+  while (pos < len) {
+    if (out.size() >= 256 || pos + 1 > len) return false;
+    const size_t kl = data[pos++];
+    if (kl == 0 || kl > 15 || pos + kl + 2 > len) return false;
+    SdNvsPrefs::Kv e{};
+    memcpy(e.key, data + pos, kl);
+    e.key[kl] = '\0';
+    pos += kl;
+    const size_t vl = (size_t)data[pos] | ((size_t)data[pos + 1] << 8);
+    pos += 2;
+    if (vl > 2048 || pos + vl > len) return false;
+    e.val.assign(data + pos, data + pos + vl);
+    pos += vl;
+    out.push_back(std::move(e));
+  }
+  return true;
+}
+
+static bool readLegacyFile(fs::FS* fs, const char* path, std::vector<SdNvsPrefs::Kv>& out) {
+  if (!fs || !fs->exists(path)) return false;
+  File f = fs->open(path, FILE_READ);
+  if (!f) return false;
+  const size_t size = f.size();
+  if (size > PREFS_MAX_PAYLOAD) { f.close(); return false; }
+  std::vector<uint8_t> payload(size);
+  const bool ok = (size == 0 || f.read(payload.data(), size) == (int)size);
+  f.close();
+  return ok && parsePayload(payload.data(), payload.size(), out);
+}
+
+static bool readSnapshot(fs::FS* fs, const char* path, std::vector<SdNvsPrefs::Kv>& out,
+                         uint32_t& generation) {
+  if (!fs || !fs->exists(path)) return false;
+  File f = fs->open(path, FILE_READ);
+  if (!f) return false;
+  const size_t size = f.size();
+  if (size < sizeof(SnapshotFooter) || size - sizeof(SnapshotFooter) > PREFS_MAX_PAYLOAD) {
+    f.close();
+    return false;
+  }
+  const size_t payload_size = size - sizeof(SnapshotFooter);
+  std::vector<uint8_t> payload(payload_size);
+  SnapshotFooter footer{};
+  bool ok = (payload_size == 0 || f.read(payload.data(), payload_size) == (int)payload_size) &&
+            f.read((uint8_t*)&footer, sizeof(footer)) == (int)sizeof(footer);
+  f.close();
+  if (!ok || footer.magic != PREFS_MAGIC || footer.format != PREFS_FORMAT ||
+      footer.footer_size != sizeof(footer) || footer.payload_size != payload_size ||
+      footer.payload_crc != crc32(payload.data(), payload.size()) ||
+      footer.footer_crc != crc32(&footer, offsetof(SnapshotFooter, footer_crc))) return false;
+  if (!parsePayload(payload.data(), payload.size(), out)) return false;
+  generation = footer.generation;
+  return true;
+}
+
+static bool writeSnapshot(fs::FS* fs, const char* legacy_path, char slot, uint32_t generation,
+                          const std::vector<SdNvsPrefs::Kv>& kv) {
+  if (!fs) return false;
+  char path[44];
+  if (!slotPath(legacy_path, slot, path, sizeof(path))) return false;
+  char dir[40];
+  strncpy(dir, legacy_path, sizeof(dir) - 1); dir[sizeof(dir) - 1] = '\0';
+  char* slash = strrchr(dir, '/');
+  if (slash && slash != dir) { *slash = '\0'; fs->mkdir(dir); }
+
+  std::vector<uint8_t> payload;
+  if (!serializeKv(kv, payload)) return false;
+  SnapshotFooter footer{PREFS_MAGIC, PREFS_FORMAT, (uint16_t)sizeof(SnapshotFooter),
+                        generation, (uint32_t)payload.size(), crc32(payload.data(), payload.size()), 0};
+  footer.footer_crc = crc32(&footer, offsetof(SnapshotFooter, footer_crc));
+
+#if defined(TDP4_POKE_TRACE)
+  printf("[SDW] %lu core%d prefs %s\n", (unsigned long)millis(), (int)xPortGetCoreID(), path);
+#endif
+  File f = fs->open(path, FILE_WRITE);
+  if (!f) return false;
+  bool ok = (payload.empty() || f.write(payload.data(), payload.size()) == payload.size()) &&
+            f.write((const uint8_t*)&footer, sizeof(footer)) == sizeof(footer);
+  f.flush();
+  f.close();
+  if (!ok) return false;
+
+  std::vector<SdNvsPrefs::Kv> verify;
+  uint32_t verify_generation = 0;
+  return readSnapshot(fs, path, verify, verify_generation) && verify_generation == generation;
+}
+
+static bool newerGeneration(uint32_t lhs, uint32_t rhs) {
+  return (int32_t)(lhs - rhs) > 0;
+}
+
+static FileCache* findCacheLocked(const char* path) {
+  for (auto& cache : s_caches)
+    if (strncmp(cache.legacy_path, path, sizeof(cache.legacy_path)) == 0) return &cache;
+  return nullptr;
+}
+
+static void prefsWriterTask(void*) {
+  for (;;) {
+    WriteJob* job = nullptr;
+    if (xQueueReceive(s_write_queue, &job, portMAX_DELAY) != pdTRUE || !job) continue;
+    const uint32_t started = millis();
+    const bool ok = writeSnapshot(job->fs, job->legacy_path, job->slot, job->generation, job->kv);
+    const uint32_t elapsed = millis() - started;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    if (FileCache* cache = findCacheLocked(job->legacy_path)) {
+      cache->writing = false;
+      if (ok) {
+        cache->generation = job->generation;
+        cache->active_slot = job->slot;
+        if (cache->revision == job->revision) cache->dirty = false;
+        cache->retry_after_ms = 0;
+      } else {
+        cache->dirty = true;
+        cache->dirty_first_ms = cache->dirty_last_ms = millis();
+        cache->retry_after_ms = millis() + 30000;
+        Serial.printf("[PREFS] snapshot write failed %s.%c\n", job->legacy_path, job->slot);
+      }
+    }
+    xSemaphoreGive(s_cache_mutex);
+    if (ok && elapsed >= 200)
+      Serial.printf("[PREFS] slow snapshot %s slot %c: %lums\n", job->legacy_path,
+                    job->slot, (unsigned long)elapsed);
+    delete job;
+  }
+}
+
+static bool ensureWorker() {
+  if (!s_cache_mutex) s_cache_mutex = xSemaphoreCreateMutex();
+  if (!s_write_queue) s_write_queue = xQueueCreate(2, sizeof(WriteJob*));
+  if (!s_cache_mutex || !s_write_queue) return false;
+  if (!s_write_task) {
+    if (xTaskCreatePinnedToCore(prefsWriterTask, "prefs_writer", 6144, nullptr, 2,
+                                &s_write_task, 0) != pdPASS) s_write_task = nullptr;
+  }
+  return s_write_task != nullptr;
+}
+
 void SdNvsPrefs::useFile(fs::FS* fs, const char* dir) {
   if (!fs) return;
   s_file_fs = fs;
   strncpy(s_file_dir, (dir && dir[0]) ? dir : "/prefs", sizeof(s_file_dir) - 1);
   s_file_dir[sizeof(s_file_dir) - 1] = '\0';
   s_file_mode = true;
+  ensureWorker();
   Serial.printf("[PREFS] backend = FILE %s\n", s_file_dir);
 }
 
@@ -63,22 +304,11 @@ bool SdNvsPrefs::begin(const char* ns, bool readOnly) {
   if (_nvs_open) { _nvs.end(); _nvs_open = false; }
 
   if (fileMode()) {
-    char path[sizeof(_path)];
-    snprintf(path, sizeof(path), "%s/%s.kv", s_file_dir, ns);
-    if (strncmp(_path, path, sizeof(_path)) != 0) {
-      strncpy(_path, path, sizeof(_path) - 1);
-      _path[sizeof(_path) - 1] = '\0';
-      _sd.clear();
-      _sd_loaded = false;
-    }
-    const bool had_cache = _sd_loaded;
+    if (!ns || snprintf(_path, sizeof(_path), "%s/%s.kv", s_file_dir, ns) >= (int)sizeof(_path))
+      return false;
     const bool loaded = sdLoad();
-    if (loaded) _sd_loaded = true;
     if (nvsHasLegacyData()) _nvs_open = _nvs.begin(ns, true);   // RO migration source
-    // A transient storage outage must not turn a previously-loaded namespace
-    // into an empty one. Readers can keep using the last-known-good mirror;
-    // writers fail so callers do not report a save that never reached disk.
-    return loaded || (readOnly && had_cache);
+    return loaded;
   }
 
   if (useNvs()) {
@@ -87,14 +317,8 @@ bool SdNvsPrefs::begin(const char* ns, bool readOnly) {
     _nvs_open = _nvs.begin(ns, readOnly);
     return _nvs_open;
   }
-  char path[sizeof(_path)];
-  snprintf(path, sizeof(path), "/meshcomod/%s.kv", ns);
-  if (strncmp(_path, path, sizeof(_path)) != 0) {
-    strncpy(_path, path, sizeof(_path) - 1);
-    _path[sizeof(_path) - 1] = '\0';
-    _sd.clear();
-    _sd_loaded = false;
-  }
+  if (!ns || snprintf(_path, sizeof(_path), "/meshcomod/%s.kv", ns) >= (int)sizeof(_path))
+    return false;
   const bool had_cache = _sd_loaded;
   const bool loaded = sdLoad();
   if (loaded) _sd_loaded = true;
@@ -107,12 +331,49 @@ void SdNvsPrefs::end() {
 
 // ----------------------------- file helpers -----------------------------
 SdNvsPrefs::Kv* SdNvsPrefs::sdFind(const char* key) {
+  if (fileMode()) {
+    if (!s_cache_mutex) return nullptr;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    FileCache* cache = findCacheLocked(_path);
+    Kv* found = nullptr;
+    if (cache) {
+      for (auto& e : cache->kv)
+        if (strncmp(e.key, key, sizeof(e.key)) == 0) { found = &e; break; }
+    }
+    xSemaphoreGive(s_cache_mutex);
+    return found;
+  }
   for (auto& e : _sd) if (strncmp(e.key, key, sizeof(e.key)) == 0) return &e;
   return nullptr;
 }
 
 bool SdNvsPrefs::sdSet(const char* key, const uint8_t* data, size_t len) {
-  if (!key || (len > 0 && !data)) return false;
+  if (_read_only || !key || key[0] == '\0' || strlen(key) > 15 || len > 2048 ||
+      (len > 0 && !data)) return false;
+  if (fileMode()) {
+    if (!s_cache_mutex) return false;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    FileCache* cache = findCacheLocked(_path);
+    if (!cache || !cache->loaded) { xSemaphoreGive(s_cache_mutex); return false; }
+    Kv* e = nullptr;
+    for (auto& item : cache->kv)
+      if (strncmp(item.key, key, sizeof(item.key)) == 0) { e = &item; break; }
+    if (!e) {
+      if (cache->kv.size() >= 256) { xSemaphoreGive(s_cache_mutex); return false; }
+      cache->kv.push_back(Kv{});
+      e = &cache->kv.back();
+      strncpy(e->key, key, sizeof(e->key) - 1);
+    }
+    if (len == 0) e->val.clear(); else e->val.assign(data, data + len);
+    const uint32_t now = millis();
+    if (!cache->dirty) cache->dirty_first_ms = now;
+    cache->dirty = true;
+    cache->dirty_last_ms = now;
+    cache->retry_after_ms = 0;
+    ++cache->revision;
+    xSemaphoreGive(s_cache_mutex);
+    return true;
+  }
   Kv* e = sdFind(key);
   bool added = false;
   std::vector<uint8_t> old;
@@ -136,154 +397,215 @@ bool SdNvsPrefs::sdSet(const char* key, const uint8_t* data, size_t len) {
 bool SdNvsPrefs::sdLoad() {
   fs::FS* fs = activeFs();
   if (!fs) return false;
-
-  char tmp[sizeof(_path) + 5], bak[sizeof(_path) + 5];
-  if (snprintf(tmp, sizeof(tmp), "%s.tmp", _path) >= (int)sizeof(tmp) ||
-      snprintf(bak, sizeof(bak), "%s.bak", _path) >= (int)sizeof(bak)) return false;
-
-  // No file on the first load is a valid, empty namespace. Once a namespace
-  // has been loaded, however, a missing file means the backing FS disappeared;
-  // retain the RAM mirror instead of silently replacing every key with defaults.
-  const bool have_live = fs->exists(_path);
-  const bool have_tmp  = fs->exists(tmp);
-  const bool have_bak  = fs->exists(bak);
-  if (!have_live && !have_tmp && !have_bak) {
-    if (_sd_loaded) return false;
-    _sd.clear();
+  if (!fileMode()) {
+    // Legacy fallback before useFile(): retain the old single-file behaviour.
+    std::vector<Kv> loaded;
+    if (!fs->exists(_path)) { _sd.clear(); return true; }
+    if (!readLegacyFile(fs, _path, loaded)) return false;
+    _sd = std::move(loaded);
     return true;
   }
 
-  auto parse = [fs](const char* path, std::vector<Kv>& out) {
-    File f = fs->open(path, FILE_READ);
-    if (!f) return false;
-    bool ok = true;
-    // record = [keylen u8][key bytes][vallen u16 LE][val bytes]. Parse into a
-    // temporary vector so a short/corrupt file cannot destroy the RAM mirror.
-    while (f.available() > 0) {
-      if (out.size() >= 256) { ok = false; break; }
-      int kl = f.read();
-      if (kl <= 0 || kl > 15) { ok = false; break; }
-      char k[16] = {0};
-      if (f.read((uint8_t*)k, kl) != kl) { ok = false; break; }
-      int lo = f.read(), hi = f.read();
-      if (lo < 0 || hi < 0) { ok = false; break; }
-      size_t vl = (size_t)lo | ((size_t)hi << 8);
-      if (vl > 2048) { ok = false; break; }
-      std::vector<uint8_t> v(vl);
-      if (vl && f.read(v.data(), vl) != (int)vl) { ok = false; break; }
-      Kv e; strncpy(e.key, k, sizeof(e.key) - 1); e.key[sizeof(e.key) - 1] = '\0';
-      e.val = std::move(v);
-      out.push_back(std::move(e));
-    }
-    f.close();
+  if (!ensureWorker()) return false;
+  xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+  if (FileCache* existing = findCacheLocked(_path)) {
+    const bool ok = existing->loaded;
+    xSemaphoreGive(s_cache_mutex);
     return ok;
-  };
+  }
+  xSemaphoreGive(s_cache_mutex);
 
-  // Prefer the live file. If a reset landed between the two renames, validate
-  // the verified temp next, then fall back to the previous complete backup.
-  std::vector<Kv> loaded;
-  if (have_live && parse(_path, loaded)) {
-    if (have_tmp) fs->remove(tmp);
-    if (have_bak) fs->remove(bak);
-    _sd = std::move(loaded);
-    return true;
-  }
-  loaded.clear();
-  if (have_tmp && parse(tmp, loaded)) {
-    if (have_live && !fs->remove(_path)) return false;
-    if (!fs->rename(tmp, _path)) return false;
-    if (have_bak) fs->remove(bak);
-    _sd = std::move(loaded);
-    return true;
-  }
-  loaded.clear();
-  if (have_bak && parse(bak, loaded)) {
-    if (have_live && !fs->remove(_path)) return false;
-    if (have_tmp) fs->remove(tmp);
-    if (!fs->rename(bak, _path)) return false;
-    _sd = std::move(loaded);
-    return true;
+  char path_a[44], path_b[44];
+  if (!slotPath(_path, 'a', path_a, sizeof(path_a)) ||
+      !slotPath(_path, 'b', path_b, sizeof(path_b))) return false;
+  std::vector<Kv> a, b, loaded;
+  uint32_t gen_a = 0, gen_b = 0;
+  const bool ok_a = readSnapshot(fs, path_a, a, gen_a);
+  const bool ok_b = readSnapshot(fs, path_b, b, gen_b);
+  uint32_t generation = 0;
+  char active = 0;
+  bool legacy_present = false;
+  bool migrate = false;
+  if (ok_a && (!ok_b || newerGeneration(gen_a, gen_b))) {
+    loaded = std::move(a); generation = gen_a; active = 'a';
+  } else if (ok_b) {
+    loaded = std::move(b); generation = gen_b; active = 'b';
+  } else {
+    // Migrate the released single-file format. Parsing is all-or-nothing;
+    // defaults never replace a corrupt namespace.
+    if (readLegacyFile(fs, _path, loaded)) {
+      legacy_present = true;
+      migrate = true;
+    } else if (fs->exists(_path) || fs->exists(path_a) || fs->exists(path_b)) {
+      Serial.printf("[PREFS] no valid snapshot for %s\n", _path);
+      return false;
+    }
+    // No file at all is a valid fresh namespace.
   }
 
-  Serial.printf("[PREFS] refusing partial/corrupt file %s\n", _path);
-  if (_sd_loaded) {
-    // Keep the last-known-good mirror when a mounted filesystem becomes
-    // temporarily unreadable or exposes an incomplete file.
-    return false;
+  FileCache cache;
+  cache.fs = fs;
+  strncpy(cache.legacy_path, _path, sizeof(cache.legacy_path) - 1);
+  cache.kv = std::move(loaded);
+  cache.generation = generation;
+  cache.active_slot = active;
+  cache.loaded = true;
+  cache.legacy_present = legacy_present;
+  if (migrate) {
+    cache.dirty = true;
+    cache.dirty_first_ms = cache.dirty_last_ms = millis();
+    ++cache.revision;
   }
-  _sd.clear();
-  return false;
+  xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+  s_caches.push_back(std::move(cache));
+  xSemaphoreGive(s_cache_mutex);
+  return true;
 }
 
 bool SdNvsPrefs::sdSave() {
   if (_read_only) return false;
+  if (fileMode()) return true;   // sdSet/remove/clear already dirtied the shared cache
   fs::FS* fs = activeFs();
   if (!fs) return false;
-  // Create the parent dir (SD needs it; SPIFFS is flat and treats the whole path
-  // as a filename, so mkdir is a harmless no-op there).
-  char dir[40];
-  strncpy(dir, _path, sizeof(dir) - 1); dir[sizeof(dir) - 1] = '\0';
-  char* slash = strrchr(dir, '/');
-  if (slash && slash != dir) { *slash = '\0'; fs->mkdir(dir); }
-#if defined(TDP4_POKE_TRACE)
-  printf("[SDW] %lu core%d kv w %s\n", (unsigned long)millis(), (int)xPortGetCoreID(), _path);
-#endif
-
-  char tmp[sizeof(_path) + 5], bak[sizeof(_path) + 5];
-  if (snprintf(tmp, sizeof(tmp), "%s.tmp", _path) >= (int)sizeof(tmp) ||
-      snprintf(bak, sizeof(bak), "%s.bak", _path) >= (int)sizeof(bak)) return false;
-  fs->remove(tmp);   // stale pre-swap temp; the intact live file remains authoritative
-
-  errno = 0;
-  File f = fs->open(tmp, FILE_WRITE);
-  if (!f) {
-    Serial.printf("[PREFS] save open failed %s (e%d)\n", tmp, errno);
-    return false;
-  }
-  bool ok = true;
-  size_t expected = 0;
-  for (auto& e : _sd) {
-    size_t kl = strnlen(e.key, sizeof(e.key));
-    size_t vl = e.val.size();
-    expected += 1 + kl + 2 + vl;
-    ok = ok && (f.write((uint8_t)kl) == 1);
-    ok = ok && (f.write((const uint8_t*)e.key, kl) == kl);
-    ok = ok && (f.write((uint8_t)(vl & 0xFF)) == 1);
-    ok = ok && (f.write((uint8_t)((vl >> 8) & 0xFF)) == 1);
-    if (vl) ok = ok && (f.write(e.val.data(), vl) == vl);
-    if (!ok) break;
-  }
+  std::vector<uint8_t> payload;
+  if (!serializeKv(_sd, payload)) return false;
+  File f = fs->open(_path, FILE_WRITE);
+  if (!f) return false;
+  const bool ok = payload.empty() || f.write(payload.data(), payload.size()) == payload.size();
   f.close();
+  return ok;
+}
 
-  // A short write leaves only the temp damaged. Verify the closed file size too
-  // before touching the live copy (catches buffered close/flush failures).
-  if (ok) {
-    File verify = fs->open(tmp, FILE_READ);
-    ok = verify && verify.size() == expected;
-    if (verify) verify.close();
+static bool scheduleOne(uint32_t now, bool force) {
+  if (!fileMode() || !ensureWorker()) return false;
+  WriteJob* job = nullptr;
+  char armed_path[40] = {0};
+  xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+  for (auto& cache : s_caches) {
+    if (!cache.loaded || !cache.dirty || cache.writing) continue;
+    if (!force && cache.retry_after_ms && (int32_t)(now - cache.retry_after_ms) < 0) continue;
+    const bool due = force || (uint32_t)(now - cache.dirty_last_ms) >= PREFS_QUIET_MS ||
+                     (uint32_t)(now - cache.dirty_first_ms) >= PREFS_MAX_WAIT_MS;
+    if (!due) continue;
+    job = new (std::nothrow) WriteJob();
+    if (!job) break;
+    job->fs = cache.fs;
+    strncpy(job->legacy_path, cache.legacy_path, sizeof(job->legacy_path) - 1);
+    job->kv = cache.kv;
+    job->generation = cache.generation + 1;
+    job->revision = cache.revision;
+    job->slot = cache.active_slot == 'a' ? 'b'
+              : cache.active_slot == 'b' ? 'a'
+              : cache.legacy_present ? 'b' : 'a';
+    cache.writing = true;
+    strncpy(armed_path, cache.legacy_path, sizeof(armed_path) - 1);
+    break;
   }
-  if (!ok) {
-    Serial.printf("[PREFS] save write failed %s (e%d)\n", tmp, errno);
-    fs->remove(tmp);
+  xSemaphoreGive(s_cache_mutex);
+  if (!job) return false;
+  if (xQueueSend(s_write_queue, &job, 0) != pdTRUE) {
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    if (FileCache* cache = findCacheLocked(armed_path)) cache->writing = false;
+    xSemaphoreGive(s_cache_mutex);
+    delete job;
     return false;
   }
+  return true;
+}
 
-  // Two-step swap with recovery breadcrumbs. At every point either the old
-  // live file, the verified temp, or the backup is complete; sdLoad() resolves
-  // leftovers after a reset between renames.
-  const bool had_live = fs->exists(_path);
-  if (fs->exists(bak)) fs->remove(bak);
-  if (had_live && !fs->rename(_path, bak)) {
-    Serial.printf("[PREFS] save backup rename failed %s (e%d)\n", _path, errno);
-    fs->remove(tmp);
-    return false;
+void SdNvsPrefs::tick(uint32_t now_ms) {
+  if (!fileMode()) return;
+  if (now_ms == 0) now_ms = millis();
+  scheduleOne(now_ms, false);
+}
+
+bool SdNvsPrefs::flush(uint32_t timeout_ms) {
+  if (!fileMode()) return true;
+  const uint32_t start = millis();
+  for (;;) {
+    scheduleOne(millis(), true);
+    bool pending = false;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    for (const auto& cache : s_caches)
+      if (cache.dirty || cache.writing) { pending = true; break; }
+    xSemaphoreGive(s_cache_mutex);
+    if (!pending) return true;
+    if ((uint32_t)(millis() - start) >= timeout_ms) return false;
+    delay(10);
   }
-  if (!fs->rename(tmp, _path)) {
-    Serial.printf("[PREFS] save commit rename failed %s (e%d)\n", _path, errno);
-    if (had_live) fs->rename(bak, _path);   // best-effort live rollback
-    return false;
+}
+
+bool SdNvsPrefs::busy() {
+  if (!fileMode() || !s_cache_mutex) return false;
+  bool result = false;
+  xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+  for (const auto& cache : s_caches)
+    if (cache.writing) { result = true; break; }
+  xSemaphoreGive(s_cache_mutex);
+  return result;
+}
+
+static bool explicitNamespacePath(const char* dir, const char* ns, char* out, size_t cap) {
+  if (!dir || !ns || !out) return false;
+  return snprintf(out, cap, "%s/%s.kv", dir, ns) < (int)cap;
+}
+
+static bool loadExplicitNamespace(fs::FS* fs, const char* legacy_path,
+                                  std::vector<SdNvsPrefs::Kv>& kv,
+                                  uint32_t& generation, char& active) {
+  char path_a[44], path_b[44];
+  if (!slotPath(legacy_path, 'a', path_a, sizeof(path_a)) ||
+      !slotPath(legacy_path, 'b', path_b, sizeof(path_b))) return false;
+  std::vector<SdNvsPrefs::Kv> a, b;
+  uint32_t gen_a = 0, gen_b = 0;
+  const bool ok_a = readSnapshot(fs, path_a, a, gen_a);
+  const bool ok_b = readSnapshot(fs, path_b, b, gen_b);
+  if (ok_a && (!ok_b || newerGeneration(gen_a, gen_b))) {
+    kv = std::move(a); generation = gen_a; active = 'a'; return true;
   }
-  if (had_live) fs->remove(bak);
+  if (ok_b) { kv = std::move(b); generation = gen_b; active = 'b'; return true; }
+  generation = 0;
+  active = 0;
+  return readLegacyFile(fs, legacy_path, kv);
+}
+
+bool SdNvsPrefs::readFileBool(fs::FS* fs, const char* dir, const char* ns,
+                              const char* key, bool& value) {
+  char legacy_path[40];
+  if (!fs || !key || !explicitNamespacePath(dir, ns, legacy_path, sizeof(legacy_path))) return false;
+  std::vector<Kv> kv;
+  uint32_t generation = 0;
+  char active = 0;
+  if (!loadExplicitNamespace(fs, legacy_path, kv, generation, active)) return false;
+  for (const auto& e : kv) {
+    if (strncmp(e.key, key, sizeof(e.key)) != 0) continue;
+    if (e.val.empty()) return false;
+    value = e.val[0] != 0;
+    return true;
+  }
+  return false;
+}
+
+bool SdNvsPrefs::writeFileBool(fs::FS* fs, const char* dir, const char* ns,
+                               const char* key, bool value) {
+  char legacy_path[40];
+  if (!fs || !key || key[0] == '\0' || strlen(key) > 15 ||
+      !explicitNamespacePath(dir, ns, legacy_path, sizeof(legacy_path))) return false;
+  std::vector<Kv> kv;
+  uint32_t generation = 0;
+  char active = 0;
+  const bool existed = loadExplicitNamespace(fs, legacy_path, kv, generation, active);
+  Kv* found = nullptr;
+  for (auto& e : kv)
+    if (strncmp(e.key, key, sizeof(e.key)) == 0) { found = &e; break; }
+  if (!found) {
+    kv.push_back(Kv{});
+    found = &kv.back();
+    strncpy(found->key, key, sizeof(found->key) - 1);
+  }
+  found->val.assign(1, value ? 1 : 0);
+  const char slot = active == 'a' ? 'b' : active == 'b' ? 'a' : existed ? 'b' : 'a';
+  if (!writeSnapshot(fs, legacy_path, slot, generation + 1, kv)) return false;
   return true;
 }
 
@@ -314,6 +636,26 @@ bool SdNvsPrefs::isKey(const char* key) {
 
 bool SdNvsPrefs::remove(const char* key) {
   if (!fileMode() && useNvs()) return _nvs_open && _nvs.remove(key);
+  if (fileMode()) {
+    if (_read_only || !s_cache_mutex) return false;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    FileCache* cache = findCacheLocked(_path);
+    if (!cache) { xSemaphoreGive(s_cache_mutex); return false; }
+    for (size_t i = 0; i < cache->kv.size(); ++i) {
+      if (strncmp(cache->kv[i].key, key, sizeof(cache->kv[i].key)) != 0) continue;
+      cache->kv.erase(cache->kv.begin() + i);
+      const uint32_t now = millis();
+      if (!cache->dirty) cache->dirty_first_ms = now;
+      cache->dirty = true;
+      cache->dirty_last_ms = now;
+      cache->retry_after_ms = 0;
+      ++cache->revision;
+      xSemaphoreGive(s_cache_mutex);
+      return true;
+    }
+    xSemaphoreGive(s_cache_mutex);
+    return false;
+  }
   for (size_t i = 0; i < _sd.size(); i++) {
     if (strncmp(_sd[i].key, key, sizeof(_sd[i].key)) != 0) continue;
     Kv old = _sd[i];
@@ -327,9 +669,18 @@ bool SdNvsPrefs::remove(const char* key) {
 
 bool SdNvsPrefs::clear() {
   if (fileMode()) {
-    std::vector<Kv> old = _sd;
-    _sd.clear();
-    if (!sdSave()) { _sd = std::move(old); return false; }
+    if (_read_only || !s_cache_mutex) return false;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    FileCache* cache = findCacheLocked(_path);
+    if (!cache) { xSemaphoreGive(s_cache_mutex); return false; }
+    cache->kv.clear();
+    const uint32_t now = millis();
+    if (!cache->dirty) cache->dirty_first_ms = now;
+    cache->dirty = true;
+    cache->dirty_last_ms = now;
+    cache->retry_after_ms = 0;
+    ++cache->revision;
+    xSemaphoreGive(s_cache_mutex);
     // Wipe any legacy NVS copy too, so a factory reset is permanent. Derive the
     // namespace from "<dir>/<ns>.kv".
     if (nvsHasLegacyData()) {

--- a/src/helpers/esp32/SdNvsPrefs.h
+++ b/src/helpers/esp32/SdNvsPrefs.h
@@ -71,9 +71,9 @@ private:
 
   bool   useNvs();              // legacy probe (NVS vs SD), cached globally
   Kv*    sdFind(const char* key);
-  void   sdSet(const char* key, const uint8_t* data, size_t len);
-  void   sdLoad();
-  void   sdSave();
+  bool   sdSet(const char* key, const uint8_t* data, size_t len);
+  bool   sdLoad();
+  bool   sdSave();
   uint64_t sdGetInt(const char* key, uint64_t def, int width);
   size_t sdPutInt(const char* key, uint64_t v, int width);
 };

--- a/src/helpers/esp32/SdNvsPrefs.h
+++ b/src/helpers/esp32/SdNvsPrefs.h
@@ -11,12 +11,12 @@ namespace fs { class FS; }   // forward decl only — keep this header's layout 
 // keep the touch app's settings OFF NVS.
 //
 // File mode (set by SdNvsPrefs::useFile() once at boot, after the SD/SPIFFS
-// storage decision): every namespace lives in a flat <dir>/<ns>.kv file on the
-// chosen filesystem — SD (/meshcomod) when a card is the active data store, else
-// SPIFFS (/prefs). Nothing new is written to NVS; NVS is read-only, used only to
-// migrate settings written by an older NVS build (they move to the file on their
-// next save). Legacy mode (before useFile, e.g. the early boot-rotation read):
-// NVS if it works, else /meshcomod/<ns>.kv on SD — the previous behaviour.
+// storage decision): every namespace is held in RAM and committed to alternating
+// <dir>/<ns>.kv / .alt snapshots. Setters only dirty the RAM copy; a worker writes
+// the inactive slot after a short quiet period, keeping filesystem latency off
+// the UI task. Each snapshot has a generation and CRC, so a reset can only lose
+// the newest pending update — it cannot turn an interrupted write into defaults.
+// Legacy <dir>/<ns>.kv and NVS data are read for migration.
 //
 // IMPORTANT: the monorepo lib ships a STALE copy of this header that other
 // translation units may pick up via an angle include. To avoid an ODR/layout
@@ -25,11 +25,20 @@ namespace fs { class FS; }   // forward decl only — keep this header's layout 
 // The file backend therefore uses file-static state in the .cpp, not a member.
 // Only the layout-neutral static useFile() is new.
 //
-// On-disk file format is unchanged: [keylen u8][key][vallen u16 LE][val].
 class SdNvsPrefs {
 public:
   static void useFile(fs::FS* fs, const char* dir);   // route prefs to <dir>/<ns>.kv
   static fs::FS* fileFs();   // the active file-mode fs, or nullptr when NVS-backed
+  static void tick(uint32_t now_ms = 0);              // schedule due snapshots; never blocks on I/O
+  static bool flush(uint32_t timeout_ms = 12000);     // force all queued snapshots before reset/sleep
+  static bool busy();                                  // a worker currently owns a filesystem handle
+
+  // Early boot needs `use_sd` before the regular backend is selected. These
+  // helpers use the same A/B format on an explicitly supplied filesystem.
+  static bool readFileBool(fs::FS* fs, const char* dir, const char* ns,
+                           const char* key, bool& value);
+  static bool writeFileBool(fs::FS* fs, const char* dir, const char* ns,
+                            const char* key, bool value);
 
   bool begin(const char* ns, bool readOnly = false);
   void end();
@@ -57,6 +66,10 @@ public:
   size_t   getBytes(const char* key, void* buf, size_t maxLen);
   size_t   putBytes(const char* key, const void* buf, size_t len);
 
+  // Public only so the file-static snapshot worker can preserve this class's
+  // ABI while sharing namespace caches across short-lived instances.
+  struct Kv { char key[16]; std::vector<uint8_t> val; };
+
 private:
   // --- NVS-backed path --- (LAYOUT MUST MATCH the lib's stale header — see above)
   Preferences _nvs;
@@ -64,7 +77,6 @@ private:
   bool        _read_only = false;
 
   // --- file-backed path ---
-  struct Kv { char key[16]; std::vector<uint8_t> val; };
   std::vector<Kv> _sd;          // in-RAM mirror of <dir>/<ns>.kv
   char            _path[40] = {0};
   bool            _sd_loaded = false;
@@ -73,7 +85,7 @@ private:
   Kv*    sdFind(const char* key);
   bool   sdSet(const char* key, const uint8_t* data, size_t len);
   bool   sdLoad();
-  bool   sdSave();
+  bool   sdSave();              // queue current RAM mirror (no filesystem I/O)
   uint64_t sdGetInt(const char* key, uint64_t def, int width);
   size_t sdPutInt(const char* key, uint64_t v, int width);
 };

--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -10,7 +10,6 @@
 #include <SPIFFS.h>
 #include <stddef.h>   // offsetof
 #include <string.h>   // memcpy
-#include <vector>     // writeUseSdToSpiffsKv record list
 
 static const char* TOUCH_NS = "touch";
 
@@ -30,11 +29,10 @@ static bool s_begun = false;
 // keys too. "use_sd" is mirrored to NVS on every UI toggle (main.cpp reads it at
 // boot via touchPrefsReadUseSdAtBoot); "setup_ok" is still NVS-only.
 //
-// On first run with the blob absent we read every legacy per-key into s_cfg, write
-// "cfg" ONCE, and only after that durable write do we remove() the legacy keys to
-// reclaim their entries. The write-before-remove ordering makes the migration
-// crash-safe and idempotent (a power-cut before the write just re-migrates next
-// boot; one after it finds "cfg" present and skips). `magic` rejects a garbage /
+// On first run with the blob absent we read every legacy per-key into s_cfg, add
+// "cfg", and remove the superseded file keys in the same queued RAM snapshot.
+// The released .kv remains the fallback until that complete A/B snapshot verifies,
+// making the migration crash-safe and idempotent. `magic` rejects a garbage /
 // short read (→ treat as absent → defaults); `ver` lets later builds add fields.
 static const char* KEY_CFG = "cfg";
 static const uint16_t TOUCH_CFG_MAGIC = 0x5743;   // 'WC' (WadaCfg)
@@ -215,8 +213,8 @@ static void cfgSetDefaults(TouchCfg& c) {
   c.hist_sync_after    = 2;     // chat flush: 2 failed background writes -> synchronous loop-task fallback
 }
 
-// Persist the whole blob using the same end()/begin(RW)/put/end()/begin(RO)
-// discipline every setter in this file uses. Returns true on a durable write.
+// Update the whole blob using the same end()/begin(RW)/put/end()/begin(RO)
+// discipline every setter in this file uses. File mode queues a coalesced write.
 static bool cfgFlush() {
   s_prefs.end();
   if (!s_prefs.begin(TOUCH_NS, false)) { s_begun = false; return false; }
@@ -327,9 +325,8 @@ static void cfgLoadOrMigrate() {
     }
   }
 
-  // Write "cfg" ONCE. Only after a durable write do we reclaim the legacy keys.
-  // If the write fails (e.g. NVS full / SD missing) we keep the legacy keys
-  // intact and retry the whole migration on the next boot.
+  // Add "cfg" and retire the old file keys in one RAM transaction. The A/B
+  // worker commits the complete result; until then the released .kv is intact.
   if (cfgFlush()) {
     s_prefs.end();
     if (s_prefs.begin(TOUCH_NS, false)) {
@@ -376,6 +373,10 @@ void touchPrefsReload() {
   s_cfg_loaded = false;
   touchPrefsBegin();
 }
+
+void touchPrefsTick(uint32_t now_ms) { SdNvsPrefs::tick(now_ms); }
+bool touchPrefsFlush(uint32_t timeout_ms) { return SdNvsPrefs::flush(timeout_ms); }
+bool touchPrefsIoBusy() { return SdNvsPrefs::busy(); }
 
 // Arduino's Preferences::getString()/getBytes() emit an [E] nvs_get_* "NOT_FOUND"
 // log every time a key is absent — which floods the (USB-CDC) console on a fresh
@@ -1234,36 +1235,23 @@ bool touchPrefsSetHomeIsDrawer(bool on) {
 // the data loads, so changing it needs a reboot. Key "use_sd" in the "touch"
 // namespace — main.cpp must see the same value the UI toggle writes.
 static const char* KEY_USE_SD_STORAGE = "use_sd";
-static const char* TOUCH_KV_BOOT_PATH = "/prefs/touch.kv";
-
-// SdNvsPrefs file mode writes touch.kv only — parse a bool for boot migration.
-static bool readBoolFromTouchKvFile(const char* want_key) {
-  if (!SPIFFS.exists(TOUCH_KV_BOOT_PATH)) return false;
-  File f = SPIFFS.open(TOUCH_KV_BOOT_PATH, FILE_READ);
-  if (!f) return false;
-  while (f.available() > 0) {
-    int kl = f.read();
-    if (kl <= 0 || kl > 15) break;
-    char k[16] = {0};
-    if (f.read((uint8_t*)k, kl) != kl) break;
-    int lo = f.read(), hi = f.read();
-    if (lo < 0 || hi < 0) break;
-    size_t vl = (size_t)lo | ((size_t)hi << 8);
-    if (vl > 2048) break;
-    if (strncmp(k, want_key, sizeof k) == 0) {
-      const bool on = (vl >= 1) && (f.read() != 0);
-      f.close();
-      return on;
-    }
-    for (size_t i = 0; i < vl; ++i) {
-      if (f.read() < 0) { f.close(); return false; }
-    }
-  }
-  f.close();
-  return false;
-}
+static const char* BOOT_PREFS_NS = "bootprefs";
 
 bool touchPrefsReadUseSdAtBoot() {
+  bool file_val = false;
+  bool found = SdNvsPrefs::readFileBool((fs::FS*)&SPIFFS, "/prefs", BOOT_PREFS_NS,
+                                       KEY_USE_SD_STORAGE, file_val);
+  // Once present, the explicit boot namespace is authoritative. This lets a
+  // Launcher device recover even if its best-effort NVS mirror is stale.
+  if (found) {
+    Preferences mirror;
+    if (mirror.begin(TOUCH_NS, false)) {
+      mirror.putBool(KEY_USE_SD_STORAGE, file_val);
+      mirror.end();
+    }
+    return file_val;
+  }
+
   bool nvs_val = false;
   Preferences p;
   if (p.begin(TOUCH_NS, true)) {
@@ -1271,69 +1259,22 @@ bool touchPrefsReadUseSdAtBoot() {
     p.end();
   }
   if (nvs_val) return true;
-  const bool file_val = readBoolFromTouchKvFile(KEY_USE_SD_STORAGE);
-  if (file_val) {
-    Serial.println("[BOOT] use_sd read from /prefs/touch.kv (syncing to NVS)");
+  // One-time migration for builds that stored the boot flag inside touch.kv.
+  found = SdNvsPrefs::readFileBool((fs::FS*)&SPIFFS, "/prefs", TOUCH_NS,
+                                   KEY_USE_SD_STORAGE, file_val);
+  if (found && file_val) {
+    Serial.println("[BOOT] use_sd read from SPIFFS boot prefs (syncing to NVS)");
     if (p.begin(TOUCH_NS, false)) {
       p.putBool(KEY_USE_SD_STORAGE, true);
       p.end();
     }
   }
-  return file_val;
+  return found && file_val;
 }
 
 bool touchPrefsGetUseSdStorage() {
   if (!s_begun) touchPrefsBegin();
   return s_prefs.getBool(KEY_USE_SD_STORAGE, false);   // default = SPIFFS
-}
-
-// Rewrite (or create) the SPIFFS copy of touch.kv with use_sd set, keeping every
-// other record. Needed because the boot storage decision can only read SPIFFS
-// (SD isn't mounted yet, see touchPrefsReadUseSdAtBoot): when prefs actively
-// live on the SD card, the toggle must land in BOTH file copies — otherwise
-// installs with unusable NVS (Launcher) could turn SD storage on but never OFF
-// again (the stale SPIFFS true would win every boot). PR #123 follow-up.
-static void writeUseSdToSpiffsKv(bool on) {
-  struct Rec { char k[16]; std::vector<uint8_t> v; };
-  std::vector<Rec> recs;
-  File f = SPIFFS.open(TOUCH_KV_BOOT_PATH, FILE_READ);
-  if (f) {
-    while (f.available() > 0 && recs.size() < 256) {
-      int kl = f.read();
-      if (kl <= 0 || kl > 15) break;
-      Rec r{};
-      if (f.read((uint8_t*)r.k, kl) != kl) break;
-      int lo = f.read(), hi = f.read();
-      if (lo < 0 || hi < 0) break;
-      size_t vl = (size_t)lo | ((size_t)hi << 8);
-      if (vl > 2048) break;
-      r.v.resize(vl);
-      if (vl && f.read(r.v.data(), vl) != (int)vl) break;
-      recs.push_back(std::move(r));
-    }
-    f.close();
-  }
-  bool found = false;
-  for (auto& r : recs) {
-    if (strncmp(r.k, KEY_USE_SD_STORAGE, sizeof r.k) == 0) { r.v.assign(1, on ? 1 : 0); found = true; }
-  }
-  if (!found) {
-    Rec r{};
-    strncpy(r.k, KEY_USE_SD_STORAGE, sizeof r.k - 1);
-    r.v.assign(1, on ? 1 : 0);
-    recs.push_back(std::move(r));
-  }
-  File w = SPIFFS.open(TOUCH_KV_BOOT_PATH, FILE_WRITE);   // truncate + rewrite
-  if (!w) return;
-  for (auto& r : recs) {
-    size_t kl = strnlen(r.k, sizeof r.k), vl = r.v.size();
-    w.write((uint8_t)kl);
-    w.write((const uint8_t*)r.k, kl);
-    w.write((uint8_t)(vl & 0xFF));
-    w.write((uint8_t)((vl >> 8) & 0xFF));
-    if (vl) w.write(r.v.data(), vl);
-  }
-  w.close();
 }
 
 bool touchPrefsSetUseSdStorage(bool use_sd) {
@@ -1351,11 +1292,12 @@ bool touchPrefsSetUseSdStorage(bool use_sd) {
     nvs.putBool(KEY_USE_SD_STORAGE, use_sd);
     nvs.end();
   }
-  // When prefs live on the SD card, boot's fallback still reads the SPIFFS
-  // copy — keep it in sync so the toggle works in BOTH directions there.
-  fs::FS* ffs = SdNvsPrefs::fileFs();
-  if (ffs && ffs != (fs::FS*)&SPIFFS) writeUseSdToSpiffsKv(use_sd);
-  return ok;
+  // The boot storage decision happens before SD is mounted. Keep a tiny,
+  // crash-safe SPIFFS A/B namespace as the Launcher-safe fallback regardless
+  // of where the rest of the preferences currently live.
+  const bool boot_ok = SdNvsPrefs::writeFileBool((fs::FS*)&SPIFFS, "/prefs", BOOT_PREFS_NS,
+                                                 KEY_USE_SD_STORAGE, use_sd);
+  return ok && boot_ok;
 }
 
 // UI language index (UiLang enum in i18n.h; 0 = English). Read at boot to pick

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -13,6 +13,11 @@ void touchPrefsBegin();
 // Force a fresh load of the settings blob. Call after SdNvsPrefs::useFile() at
 // boot: an earlier pref read may have cached the blob from the legacy backend.
 void touchPrefsReload();
+// Drive/force the deferred file-backed snapshot writer without exposing the
+// vendored core's stale SdNvsPrefs header to UI translation units.
+void touchPrefsTick(uint32_t now_ms);
+bool touchPrefsFlush(uint32_t timeout_ms = 12000);
+bool touchPrefsIoBusy();
 
 /** Screen timeout in seconds; 0 = never sleep. Default 20. */
 uint16_t touchPrefsGetScreenTimeoutSecs();

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -1807,13 +1807,16 @@ static void purgeDiscovered() {
   for (int i = 0; i < DISCOVERED_MAX; ++i) s_discovered[i].used = false;
 }
 
-// ---- Persist the discovered ring across reboots (NVS blob "disc") ----
+// ---- Persist the discovered ring across reboots ---------------------------
+// High-churn discovery data has its own namespace so an advert burst never
+// rewrites the critical touch settings snapshot.
 static const char*   KDISC = "disc";   // chunk 0 (older firmware wrote ≤24 records here)
+static const char*   DISC_NS = "discovered";
+static const char*   DISC_MARKER = "ver";
 static bool          s_disc_dirty   = false;
 static unsigned long s_disc_save_at = 0;
-// Compact on-disk record (84 B/entry). SdNvsPrefs's SD .kv backend (used under
-// Launcher) silently DROPS any single value > 2048 B on load (sdLoad bails on
-// the oversize record), so we cap each stored blob at DISC_PER_CHUNK records
+// Compact on-disk record (84 B/entry). SdNvsPrefs caps one value at 2048 B, so
+// we cap each stored blob at DISC_PER_CHUNK records
 // (2 + 24*84 = 2018 B) and split the ring across as many chunk keys ("disc",
 // "disc1", …) as DISCOVERED_MAX needs. We persist only what the Discovered list
 // redraws — the bulky parts of ContactInfo (out_path[64], shared_secret, …) are
@@ -1837,6 +1840,9 @@ static void discChunkKey(int chunk, char* out, size_t cap) {
 }
 static void saveDiscovered() {
   if (!s_discovered || !discBlob()) return;
+  SdNvsPrefs prefs;
+  if (!prefs.begin(DISC_NS, false)) return;
+  prefs.putUChar(DISC_MARKER, DISC_BLOB_VER);
   int src = 0;   // walk the ring once, emitting used entries into successive chunk blobs
   for (int chunk = 0; chunk < DISC_CHUNKS; ++chunk) {
     uint8_t* p = s_disc_blob;
@@ -1860,18 +1866,23 @@ static void saveDiscovered() {
     }
     *pcount = count;
     char key[8]; discChunkKey(chunk, key, sizeof key);
-    if (count > 0) touchPrefsSetBlob(key, s_disc_blob, (size_t)(p - s_disc_blob));
-    else           touchPrefsSetBlob(key, nullptr, 0);   // clear an empty trailing chunk
+    if (count > 0) prefs.putBytes(key, s_disc_blob, (size_t)(p - s_disc_blob));
+    else           prefs.remove(key);   // clear an empty trailing chunk
   }
+  prefs.end();
   s_disc_dirty = false;
 }
 static void loadDiscovered() {
   if (!s_discovered || !discBlob()) return;
   memset(s_discovered, 0, sizeof(LvDiscoveredEntry) * DISCOVERED_MAX);
+  SdNvsPrefs prefs;
+  const bool prefs_open = prefs.begin(DISC_NS, true);
+  const bool have_new = prefs_open && prefs.isKey(DISC_MARKER);
   int dst = 0;
   for (int chunk = 0; chunk < DISC_CHUNKS && dst < DISCOVERED_MAX; ++chunk) {
     char key[8]; discChunkKey(chunk, key, sizeof key);
-    size_t got = touchPrefsGetBlob(key, s_disc_blob, DISC_BLOB_SZ);
+    size_t got = have_new ? prefs.getBytes(key, s_disc_blob, DISC_BLOB_SZ)
+                          : touchPrefsGetBlob(key, s_disc_blob, DISC_BLOB_SZ);
     if (got < 2 || s_disc_blob[0] != DISC_BLOB_VER) continue;   // missing / garbage chunk -> skip
     uint8_t count = s_disc_blob[1];
     const uint8_t* p   = s_disc_blob + 2;
@@ -1892,6 +1903,20 @@ static void loadDiscovered() {
       e.ci.gps_lat      = (int32_t)discGetU32(p);
       e.ci.gps_lon      = (int32_t)discGetU32(p);
       e.ci.shared_secret_valid = false;   // force secret recompute on first use
+    }
+  }
+  prefs.end();
+  if (!have_new) {
+    // First boot after the split: queue the new namespace but leave legacy
+    // chunks intact until a later boot proves the new snapshot is durable.
+    saveDiscovered();
+  } else {
+    // The separate snapshot survived a reboot, so the old copies are now safe
+    // to retire from the critical touch namespace.
+    for (int chunk = 0; chunk < DISC_CHUNKS; ++chunk) {
+      char key[8]; discChunkKey(chunk, key, sizeof key);
+      if (touchPrefsGetBlob(key, s_disc_blob, DISC_BLOB_SZ) > 0)
+        touchPrefsSetBlob(key, nullptr, 0);
     }
   }
 }
@@ -34550,6 +34575,7 @@ static void doFactoryReset() {
   lv_refr_now(nullptr);
   delay(150);                      // let the overlay actually hit the panel
   wdtHeavyBegin();                 // SPIFFS format is a long flash burst
+  touchPrefsFlush();               // do not format under an open prefs worker handle
 #if CAP_SD
   factoryWipeSdData();             // SD /meshcomod data (tiles at /tiles root are kept)
 #endif
@@ -35779,6 +35805,7 @@ static void powerOffCb(lv_event_t* e) {
     g_lv.task->persistHistoryNow();        // flush chat before we go down
     discoveredFlushNow();                  // and the Discovered ring
     the_mesh.flushContactsIfDirty();       // and any coalesced contacts refresh
+    touchPrefsFlush();                     // and all queued A/B preference snapshots
     g_lv.task->showAlert(TR("Powering off\xE2\x80\xA6 click trackball to wake"), 1500);
   }
   // Let the toast paint, then enter deep sleep.
@@ -35827,6 +35854,7 @@ static void powerDownloadCb(lv_event_t* e) {
   if (g_lv.task) {
     g_lv.task->persistHistoryNow();   // flush chat before we go down
     discoveredFlushNow();             // and the Discovered ring
+    touchPrefsFlush();                 // and all queued A/B preference snapshots
     g_lv.task->showAlert(TR("Download mode\xE2\x80\xA6 reflash over USB"), 1500);
   }
   lv_refr_now(NULL);
@@ -45765,6 +45793,7 @@ void UITask::rebootDevice() {
   }
   discoveredFlushNow();   // persist the Discovered ring before we go down
   the_mesh.flushContactsIfDirty();   // and any coalesced contacts refresh (card-less devices)
+  touchPrefsFlush();       // finish queued A/B snapshots before reset
   if (_board) _board->reboot();
 }
 
@@ -46128,7 +46157,7 @@ static void sdHealthTick() {
   // Hold off while the core-0 worker is (or may be about to be) on the card —
   // SD.end() under an open worker file handle is the crash we must not add.
   // On a truly wedged card the worker's own ops fail fast, so this clears.
-  if (s_hist_flush_busy || s_hist_flush_req || s_sdinfo_request) return;
+  if (s_hist_flush_busy || s_hist_flush_req || s_sdinfo_request || touchPrefsIoBusy()) return;
 #if defined(HAS_TDECK_GT911) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
   if (s_sdfw_request) return;     // worker streaming a firmware download to /BINS (T-Deck only)
 #endif
@@ -46174,6 +46203,10 @@ static void sdHealthTick() {
 
 void UITask::loop() {
   unsigned long now = millis();
+#if defined(ESP32)
+  // Snapshot copying is quick; all filesystem I/O runs on the core-0 worker.
+  touchPrefsTick(now);
+#endif
 #if !defined(HAS_TANMATSU)
   // REMOTE mode: draw/refresh the physical-panel placeholder (first pass via the IP
   // sentinel, then whenever the IP changes), and clear the bootloop guard once this
@@ -46219,9 +46252,8 @@ void UITask::loop() {
 #endif
   g_ui_stall_max = 0; g_ui_stall_tag = ""; s_ui_cp_tag = "ui:head"; s_ui_cp_t0 = now;
 #if defined(ESP32)
-  // Persist the clock floor every 15 min (small prefs-blob write; SdNvsPrefs
-  // rewrites a file on the Launcher-SD backend, so keep the cadence low). Power
-  // loss costs at most this window of floor progress — a soft reset keeps the
+  // Persist the clock floor every 15 min (coalesced into the next prefs snapshot).
+  // Power loss costs at most this window of floor progress — a soft reset keeps the
   // ESP32 RTC domain ticking, so only true power-off needs the persisted copy.
   { static unsigned long s_floor_due = 0;
     if (now >= s_floor_due) {
@@ -47173,7 +47205,8 @@ void UITask::shutdown(bool restart) {
   if (_threads_dirty) saveThreadsToStorage();
   if (_msgs_dirty) saveMsgsToStorage();
 #if defined(ESP32)
-  touchPrefsSetClockFloor(rtc_clock.getFloor());   // clock floor: final synchronous save (#89)
+  touchPrefsSetClockFloor(rtc_clock.getFloor());   // queue final clock-floor update (#89)
+  touchPrefsFlush();                                // finish queued A/B snapshots
 #endif
   if (_display) {
     _display->startFrame();

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -45093,13 +45093,6 @@ void UITask::onLvTabChanged(int tab_index) {
     if (tab_index > k_last) tab_index = k_last;
   }
   _touch_screen = static_cast<TouchUiScreen>(static_cast<uint8_t>(tab_index));
-#if defined(ESP32_PLATFORM) && defined(HAS_TOUCH_UI)
-  SdNvsPrefs prefs;
-  if (prefs.begin("meshTouch", false)) {
-    prefs.putUChar("tab", static_cast<uint8_t>(tab_index));
-    prefs.end();
-  }
-#endif
 }
 
 void UITask::appendDiag(const char* message) {


### PR DESCRIPTION
## Summary

- keep file-backed preference namespaces in a shared RAM mirror and coalesce updates for 750 ms
- commit snapshots from a core-0 worker so slow SPIFFS or SD writes never block LVGL callbacks
- alternate between `.kv` and `.alt` snapshots with generation numbers plus payload/footer CRCs
- write the validation footer last, preserving the previous valid slot across resets or short writes
- move discovered-node blobs into their own namespace so advert churn does not rewrite critical settings
- force pending snapshots before reboot, download mode, deep sleep, shutdown, or factory reset

## Root cause

`SdNvsPrefs::sdSave()` synchronously truncated and rewrote the entire namespace for every setter. A transient failure could leave a valid prefix which `sdLoad()` accepted after clearing its RAM state, making missing keys fall back to defaults. The attempted temporary/backup repair made every preference update perform multiple filesystem metadata operations and caused multi-second UI hitches.

The replacement never clears a loaded namespace after a transient storage failure. Setters mutate RAM, and the inactive snapshot is written and verified off-thread. Boot selects the highest valid generation; a torn inactive slot is ignored.

## Storage and migration

The released `.kv` path doubles as slot A and `.alt` is slot B. The first migration writes `.alt` without touching the released file; the next commit rotates back onto `.kv`. There are only two namespace files during migration and steady state—no `.tmp`, `.bak`, rename, copy, or delete cycle.

The key/value payload remains at the start of `.kv`, with the new footer appended after it, so older firmware can still read its records. Snapshot payloads are capped at 64 KiB to bound RAM and storage use on smaller boards.

Discovered nodes migrate into `discovered.kv` / `discovered.alt`. Legacy chunks are removed from the touch namespace only after the separate snapshot has survived a reboot.

## Verification

- `platformio run -e LilyGo_TDeck_companion_radio_touch`
- `platformio run -e heltec_v4_tft_companion_radio_usb_tcp_touch`
- `git diff --check`
- app-only flash to a TDeck with NVS, SPIFFS, SD, partition table, and user data preserved
- hardware migration: `.kv` -> `.alt` verified in 1129 ms on the worker
- hardware reboot: `.alt` loaded and rotated back to `.kv` in 1003 ms on the worker
- exact commit `2001ef7` flashed and verified; subsequent background snapshot completed in 753 ms
- no preference-write latency appeared in the UI stall log; observed stalls remained in the pre-existing GPS/LVGL paths

Fixes #195

## Checklist

- [x] no synchronous preference writes on normal setters
- [x] bounded two-slot storage
- [x] released `.kv` migration without a wipe
- [x] TDeck and Heltec V4 builds pass
- [x] TDeck hardware migration/reboot tested
- [x] DCO signed-off commit

Model: GPT-5.6 Sol | Harness: Codex in T3 Code