### PR TITLE
fix(tpager): arbitrate shared SPI SD lifecycle

### DIFF
--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -103,7 +103,8 @@ bool touchPrefsGetUseMiles();
 bool touchPrefsSetUseMiles(bool use_miles);
 
 /** Map tile source: false = tile server + on-device cache (default), true = read tiles off the
- *  microSD card (/tiles/<z>/<x>/<y>.jpg). T-Deck only (the V4 TFT has no SD slot). */
+ *  microSD card (/tiles/<z>/<x>/<y>.jpg). Persistent on T-Deck; the Pager currently resets
+ *  this runtime choice to the server/cache mode at boot. */
 bool touchPrefsGetTilesFromSd();
 bool touchPrefsSetTilesFromSd(bool from_sd);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,7 +227,39 @@ void halt() {
 #if defined(TLORA_PAGER)
 static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
 static constexpr const char* kSdMigrationCompleteTmp = "/meshcomod/.spiffs-migration-v1.tmp";
-bool meshcomodSdMigrationComplete() { return SD.exists(kSdMigrationComplete); }
+
+// Manual recovery may resume onto an empty card or the same profile, but it
+// must never fill one identity's missing files from another profile. Compare
+// the small identity files without logging their contents before arming the
+// durable migration latch. A read failure is treated as a mismatch.
+bool meshcomodSdProfileMatchesInternal() {
+  static constexpr const char* kInternalIdentity = "/identity/_main.id";
+  static constexpr const char* kSdIdentity = "/meshcomod/identity/_main.id";
+  File internal = SPIFFS.open(kInternalIdentity, FILE_READ);
+  if (!internal) return false;
+  if (!SD.exists(kSdIdentity)) {
+    internal.close();
+    return true;
+  }
+  File card = SD.open(kSdIdentity, FILE_READ);
+  if (!card || internal.size() != card.size()) {
+    internal.close();
+    if (card) card.close();
+    return false;
+  }
+  uint8_t internal_buf[64];
+  uint8_t card_buf[64];
+  bool matches = true;
+  while (matches && internal.available()) {
+    const size_t n = internal.read(internal_buf, sizeof internal_buf);
+    if (n == 0 || card.read(card_buf, n) != n || memcmp(internal_buf, card_buf, n) != 0)
+      matches = false;
+  }
+  if (card.available()) matches = false;
+  internal.close();
+  card.close();
+  return matches;
+}
 #endif
 
 bool meshcomodMigrateSpiffsToSd(bool force) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,11 @@ static uint32_t _atoi(const char* sp) {
     #include <SD.h>
     #include <Preferences.h>
     #ifndef PIN_SD_CS
-      #define PIN_SD_CS 39      // T-Deck microSD chip-select (V4-R8 sets 3 in the env)
+      #if defined(TLORA_PAGER)
+        #define PIN_SD_CS PAGER_PIN_SD_CS
+      #else
+        #define PIN_SD_CS 39    // T-Deck microSD chip-select (V4-R8 sets 3 in the env)
+      #endif
     #endif
   #endif
   extern "C" void set_boot_phase(int phase);
@@ -477,10 +481,10 @@ void setup() {
   bool sd_storage = false;
 #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
   {
-   #if defined(HELTEC_LORA_V4_R8)
+   #if defined(TLORA_PAGER)
+    extern SPIClass* tloraPagerSharedSPI();    // display/radio/SD shared bus
+   #elif defined(HELTEC_LORA_V4_R8)
     extern SPIClass* heltecV4R8SharedSPI();   // FSPI, shared with the TFT (CS=3)
-   #elif defined(TLORA_PAGER)
-    extern SPIClass* tloraPagerSharedSPI();   // the display/radio's shared SPIClass (#193)
    #else
     extern SPIClass* tdeckSharedSPI();        // LoRa SPI bus
    #endif
@@ -506,14 +510,41 @@ void setup() {
     // device has no usable SPIFFS, the user opted in, or it's a brand-new device.
     bool want_full_sd = !spiffs_ok || use_sd_pref || fresh_install;
 
-   #if defined(HELTEC_LORA_V4_R8)
-    SPIClass* _spi = heltecV4R8SharedSPI();
-   #elif defined(TLORA_PAGER)
+   #if defined(TLORA_PAGER)
     SPIClass* _spi = tloraPagerSharedSPI();
+   #elif defined(HELTEC_LORA_V4_R8)
+    SPIClass* _spi = heltecV4R8SharedSPI();
    #else
     SPIClass* _spi = tdeckSharedSPI();
-   #endif
+    #endif
     bool sd_mounted = false;
+#if defined(TLORA_PAGER)
+    if (!_spi) {
+      Serial.println("[BOOT] SD: shared SPI unavailable");
+    } else if (!board.sdCardPresent()) {
+      Serial.println("[BOOT] SD: no card detected");
+    } else {
+      // Match LilyGo's pager bring-up: the card shares the already-running
+      // display/radio SPIClass and gets one conservative 4 MHz mount attempt.
+      // Do not tear down that live shared bus or hide arbitration bugs behind
+      // delays/retry ladders.
+      Serial.println("[BOOT] SD: card detected; mounting at 4 MHz");
+      const bool sd_begin_ok = SD.begin(PIN_SD_CS, *_spi, 4000000, "/sd", 6);
+      sd_mounted = sd_begin_ok && SD.cardType() != CARD_NONE;
+      if (!sd_mounted) {
+        if (sd_begin_ok) {
+          // Release only the unusable mount created above. SD.end() unregisters
+          // this SD VFS; it does not stop the shared SPIClass used by TFT/radio.
+          SD.end();
+        }
+        // Keep the board bring-up invariant explicit even if the SD library
+        // changed this pin while unwinding a failed mount.
+        pinMode(PIN_SD_CS, OUTPUT);
+        digitalWrite(PIN_SD_CS, HIGH);
+      }
+      Serial.printf("[BOOT] SD mount: %s\n", sd_mounted ? "ok" : "failed");
+    }
+#else
     if (_spi) {
       // Try to mount the card on EVERY boot: even a device that keeps identity on SPIFFS
       // wants its churn-heavy contacts/channels on the card.
@@ -562,6 +593,7 @@ void setup() {
         }
       }
     }
+#endif
     if (sd_mounted) {
       g_contacts_on_sd = true;   // every branch below routes contacts/channels to the card
       if (want_full_sd) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,6 +215,7 @@ void halt() {
 // Both filesystems must be mounted by the caller.
 bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!SPIFFS.exists("/identity/_main.id")) return false;   // nothing worth adopting
+  const bool sd_identity_preexisting = SD.exists("/meshcomod/identity/_main.id");
   SD.mkdir("/meshcomod");
   SD.mkdir("/meshcomod/identity");
   SD.mkdir("/meshcomod/bl");
@@ -263,11 +264,23 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
   }
   root.close();
   // The boot path skips files the card already has — an identity already on the
-  // card counts as "landed" (nothing needed migrating).
+  // card counts as "landed" (nothing needed migrating). Identity alone is not
+  // enough, though: adopting after a larger history/prefs copy failed hides the
+  // complete SPIFFS store behind a partial SD tree.
   if (!force && !identity_ok && SD.exists("/meshcomod/identity/_main.id")) identity_ok = true;
   Serial.printf("[BOOT] SPIFFS -> SD migration: %d copied, %d failed, identity %s\n",
                 copied, failed, identity_ok ? "ok" : "MISSING");
-  return identity_ok;
+  const bool complete = identity_ok && failed == 0;
+  if (!complete && !sd_identity_preexisting &&
+      SD.exists("/meshcomod/identity/_main.id")) {
+    // This attempt introduced the adoption key. Roll it back so a missing NVS
+    // breadcrumb cannot make the next boot mistake a partial tree for a complete
+    // migration. Successfully copied non-identity files are harmless and let a
+    // later retry resume without clobbering them.
+    if (!SD.remove("/meshcomod/identity/_main.id"))
+      Serial.println("[BOOT] SD migrate: could not roll back partial identity");
+  }
+  return complete;
 }
 
 // Clear the boot safe-mode latch (see the SPIFFS->SD migration above): called after a
@@ -604,11 +617,11 @@ void setup() {
         // card lacks; a failed migration keeps the device on SPIFFS this boot
         // rather than adopting a card without the identity on it.
         bool adopt = true;
-        if (SPIFFS.exists("/identity/_main.id") && !SD.exists("/meshcomod/identity/_main.id")) {
+        if (SPIFFS.exists("/identity/_main.id")) {
           // Boot safe-mode (GH #142/#148): a wedged or corrupt SD card can hang / WDT-reboot the
           // device mid-migration, stranding it on the boot screen EVERY boot (reset can't escape,
           // only a downgrade could). Drop an NVS breadcrumb before migrating and clear it only if
-          // the copy RETURNS. If it's still set at the next boot, the last migration never finished
+          // the copy fully completes. If it's still set at the next boot, the last migration failed
           // -> skip it and boot from SPIFFS (the data is safe there); Settings > "Copy internal data
           // to SD" re-arms a deliberate retry. A merely-slow (healthy) card completes thanks to the
           // in-loop WDT feed, so it never latches here.
@@ -619,11 +632,20 @@ void setup() {
             if (mp_ok) _mp.end();
             adopt = false;
             Serial.println("[BOOT] prior SD migration did not complete -> skipping (staying on SPIFFS); retry via Settings > Copy internal data to SD");
-          } else {
+          } else if (!SD.exists("/meshcomod/identity/_main.id")) {
             if (mp_ok) { _mp.putBool("sd_mig_busy", true); _mp.end(); }
             adopt = meshcomodMigrateSpiffsToSd(false);
-            Preferences _mp2; if (_mp2.begin("touch", false)) { _mp2.remove("sd_mig_busy"); _mp2.end(); }
+            // Keep the breadcrumb latched after a returned-but-incomplete copy.
+            // That matters when identity landed before a larger history file
+            // failed: the next boot must not adopt the partial SD tree merely
+            // because the identity now exists. Manual Copy-to-SD clears it only
+            // after a fully successful retry.
+            if (adopt) {
+              Preferences _mp2; if (_mp2.begin("touch", false)) { _mp2.remove("sd_mig_busy"); _mp2.end(); }
+            }
             if (!adopt) Serial.println("[BOOT] SD migration incomplete -> staying on SPIFFS this boot");
+          } else {
+            if (mp_ok) _mp.end();
           }
         }
         if (adopt) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,21 +209,28 @@ void halt() {
 // "lost profile settings". The data was never gone — it was orphaned on SPIFFS.
 // Copies every SPIFFS file into SD:/meshcomod ("/prefs/<ns>.kv" flattens to
 // "/meshcomod/<ns>.kv", matching SdNvsPrefs's SD layout). Returns true only when
-// every file and a last-written completion marker landed on the card — the caller
-// must NOT adopt the card otherwise. force=true (the Settings "Copy internal data to SD" recovery button)
+// every file landed on the card; Pager additionally requires a last-written
+// completion marker. The caller must NOT adopt the card otherwise. force=true
+// (the Settings "Copy internal data to SD" recovery button)
 // overwrites whatever the card holds; the boot path never clobbers existing files.
 // Both filesystems must be mounted by the caller.
+#if defined(TLORA_PAGER)
 static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
 static constexpr const char* kSdMigrationCompleteTmp = "/meshcomod/.spiffs-migration-v1.tmp";
+bool meshcomodSdMigrationComplete() { return SD.exists(kSdMigrationComplete); }
+#endif
 
 bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!SPIFFS.exists("/identity/_main.id")) return false;   // nothing worth adopting
   const bool sd_identity_preexisting = SD.exists("/meshcomod/identity/_main.id");
-  // The marker is the commit record. Remove it before an explicit overwrite so
-  // a reset halfway through cannot leave the old marker blessing mixed data.
+  // On Pager the marker is the cross-file commit record. Remove it before an
+  // explicit overwrite so a reset halfway through cannot leave the old marker
+  // blessing mixed data.
   if (force) {
+#if defined(TLORA_PAGER)
     SD.remove(kSdMigrationComplete);
     SD.remove(kSdMigrationCompleteTmp);
+#endif
   }
   SD.mkdir("/meshcomod");
   SD.mkdir("/meshcomod/identity");
@@ -296,6 +303,7 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
   Serial.printf("[BOOT] SPIFFS -> SD migration: %d copied, %d failed, identity %s\n",
                 copied, failed, identity_ok ? "ok" : "MISSING");
   bool complete = identity_ok && failed == 0;
+#if defined(TLORA_PAGER)
   if (complete) {
     SD.remove(kSdMigrationCompleteTmp);
     File marker = SD.open(kSdMigrationCompleteTmp, FILE_WRITE);
@@ -311,6 +319,7 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
       complete = false;
     }
   }
+#endif
   if (!complete && !sd_identity_preexisting &&
       SD.exists("/meshcomod/identity/_main.id")) {
     // This attempt introduced the adoption key. Roll it back so a missing NVS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,15 +238,6 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
   // a profile-reconciliation action into an overwrite.
   force = false;
 #endif
-  // On Pager the marker is the cross-file commit record. Remove it before an
-  // explicit overwrite so a reset halfway through cannot leave the old marker
-  // blessing mixed data.
-  if (force) {
-#if defined(TLORA_PAGER)
-    SD.remove(kSdMigrationComplete);
-    SD.remove(kSdMigrationCompleteTmp);
-#endif
-  }
   SD.mkdir("/meshcomod");
   SD.mkdir("/meshcomod/identity");
   SD.mkdir("/meshcomod/bl");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,6 +232,12 @@ bool meshcomodSdMigrationComplete() { return SD.exists(kSdMigrationComplete); }
 
 bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!SPIFFS.exists("/identity/_main.id")) return false;   // nothing worth adopting
+#if defined(TLORA_PAGER)
+  // Pager recovery is always resumable/non-clobbering. Keep that invariant in
+  // the migration primitive itself so a future caller cannot accidentally turn
+  // a profile-reconciliation action into an overwrite.
+  force = false;
+#endif
   // On Pager the marker is the cross-file commit record. Remove it before an
   // explicit overwrite so a reset halfway through cannot leave the old marker
   // blessing mixed data.
@@ -788,18 +794,11 @@ void setup() {
           Preferences _mp;
           const bool mp_ok = _mp.begin("touch", false);
           const bool mig_busy = mp_ok && _mp.getBool("sd_mig_busy", false);
-#if defined(TLORA_PAGER)
           // An identity makes this an existing SD profile, even if it predates
-          // the migration-complete marker. Overlaying its missing files from
-          // SPIFFS would mix two profiles (for example, history from the card
-          // with the internal channel table). Only migrate onto an empty card;
-          // sd_mig_busy still rejects a migration interrupted after identity.
+          // the Pager migration-complete marker. Never auto-overlay missing
+          // internal files onto an established card profile.
           const bool needs_migration =
               !SD.exists("/meshcomod/identity/_main.id");
-#else
-          const bool needs_migration =
-              !SD.exists("/meshcomod/identity/_main.id");
-#endif
           if (mig_busy) {
             if (mp_ok) _mp.end();
             adopt = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,6 +232,33 @@ static constexpr const char* kSdIdentity = "/meshcomod/identity/_main.id";
 static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
 static constexpr const char* kSdMigrationCompleteTmp = "/meshcomod/.spiffs-migration-v1.tmp";
 
+// Byte-compare the card's identity against the internal one without logging
+// either. Any read failure counts as a mismatch. True means the card carries
+// THIS device's profile — migration never deletes its SPIFFS sources, so a
+// device that already adopted the card still has a byte-identical copy here.
+static bool sdIdentityMatchesInternal() {
+  File internal = SPIFFS.open(kInternalIdentity, FILE_READ);
+  if (!internal) return false;
+  File card = SD.open(kSdIdentity, FILE_READ);
+  if (!card || internal.size() == 0 || internal.size() != card.size()) {
+    internal.close();
+    if (card) card.close();
+    return false;
+  }
+  uint8_t internal_buf[64];
+  uint8_t card_buf[64];
+  bool matches = true;
+  while (matches && internal.available()) {
+    const size_t n = internal.read(internal_buf, sizeof internal_buf);
+    if (n == 0 || card.read(card_buf, n) != n || memcmp(internal_buf, card_buf, n) != 0)
+      matches = false;
+  }
+  if (card.available()) matches = false;
+  internal.close();
+  card.close();
+  return matches;
+}
+
 #if defined(TLORA_PAGER)
 static constexpr const char* kSdMigrationOwner = "/meshcomod/.spiffs-migration-v1.owner";
 static constexpr const char* kSdMigrationOwnerTmp = "/meshcomod/.spiffs-migration-v1.owner.tmp";
@@ -311,7 +338,10 @@ static bool ensureSdMigrationOwner() {
   if (SD.exists(kSdMigrationOwnerTmp)) {
     if (sdDigestFileMatches(kSdMigrationOwnerTmp, digest))
       return SD.rename(kSdMigrationOwnerTmp, kSdMigrationOwner);
-    if (!SD.remove(kSdMigrationOwnerTmp)) return false;   // only our own incomplete marker
+    // Someone else's half-written claim. Clearing it is safe because the tree
+    // check below still refuses any card that holds real payload; a stranded
+    // tmp marker on an otherwise empty card is not an established profile.
+    if (!SD.remove(kSdMigrationOwnerTmp)) return false;
   }
   // Without a matching owner marker, only a tree containing no file payload is
   // safe to claim. Empty directories from an interrupted mkdir sequence are OK.
@@ -328,30 +358,10 @@ static bool ensureSdMigrationOwner() {
 // the small identity files without logging their contents before arming the
 // durable migration latch. A read failure is treated as a mismatch.
 bool meshcomodSdProfileMatchesInternal() {
-  File internal = SPIFFS.open(kInternalIdentity, FILE_READ);
-  if (!internal) return false;
-  if (!SD.exists(kSdIdentity)) {
-    internal.close();
-    return ensureSdMigrationOwner();
-  }
-  File card = SD.open(kSdIdentity, FILE_READ);
-  if (!card || internal.size() != card.size()) {
-    internal.close();
-    if (card) card.close();
-    return false;
-  }
-  uint8_t internal_buf[64];
-  uint8_t card_buf[64];
-  bool matches = true;
-  while (matches && internal.available()) {
-    const size_t n = internal.read(internal_buf, sizeof internal_buf);
-    if (n == 0 || card.read(card_buf, n) != n || memcmp(internal_buf, card_buf, n) != 0)
-      matches = false;
-  }
-  if (card.available()) matches = false;
-  internal.close();
-  card.close();
-  return matches;
+  if (!SPIFFS.exists(kInternalIdentity)) return false;
+  // An empty card is claimable; a populated one must prove it is ours.
+  if (!SD.exists(kSdIdentity)) return ensureSdMigrationOwner();
+  return sdIdentityMatchesInternal();
 }
 #endif
 
@@ -929,9 +939,27 @@ void setup() {
             // state was only the tiny crash window before the NVS latch clear.
             // Otherwise fail closed even if an older identity still exists.
             const bool committed = !needs_migration && SD.exists(kSdMigrationComplete);
-            if (committed) {
+            // Upgrade amnesty. Pre-#206 firmware had no completion marker and
+            // cleared the latch whenever the copy RETURNED, not when it
+            // succeeded. A device whose migration died after the identity landed
+            // therefore adopted the card anyway and has been running full-SD
+            // ever since, with sd_mig_busy stuck at 1 and no marker that could
+            // ever exist. Demanding the marker on upgrade would demote that live
+            // card to a months-stale SPIFFS snapshot. If the card's identity is
+            // byte-identical to ours the card demonstrably holds THIS profile
+            // and is the newer store, so adopt it -- but keep the recovery
+            // banner up so a reconciling Copy-to-SD can fill whatever the
+            // interrupted copy missed.
+            const bool legacy_adopted =
+                !committed && !needs_migration && sdIdentityMatchesInternal();
+            if (committed || legacy_adopted) {
               if (mp_ok) _mp.remove("sd_mig_busy");
-              Serial.println("[BOOT] SD migration committed before reset -> adopting completed profile");
+              if (legacy_adopted) {
+                g_sd_migration_blocked = true;   // surface the reconcile action
+                Serial.println("[BOOT] pre-marker SD profile matches internal identity -> adopting; reconcile via Settings > Copy internal data to SD");
+              } else {
+                Serial.println("[BOOT] SD migration committed before reset -> adopting completed profile");
+              }
             } else {
               adopt = false;
               g_sd_migration_blocked = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -237,7 +237,12 @@ static constexpr const char* kSdMigrationOwner = "/meshcomod/.spiffs-migration-v
 static constexpr const char* kSdMigrationOwnerTmp = "/meshcomod/.spiffs-migration-v1.owner.tmp";
 
 static bool sdProfileTreeContainsFile(const char* path, uint8_t depth = 0) {
-  if (!SD.exists(path)) return false;
+  // Only the root may be judged absent. A recursive child came straight from
+  // openNextFile(), so it provably exists and re-stat'ing it can only produce a
+  // false negative — which would be the one verdict that lets a foreign
+  // residual subtree read as empty and get claimed. Below the root, let the
+  // open() fail-closed path govern instead.
+  if (depth == 0 && !SD.exists(path)) return false;
   if (depth >= 8) return true;   // unexpected/deep content is not safe to adopt
   File dir = SD.open(path, FILE_READ);
   if (!dir) return true;         // unreadable content is not an empty profile

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,9 @@ static uint32_t _atoi(const char* sp) {
   #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
     #include <SD.h>
     #include <Preferences.h>
+    #if defined(TLORA_PAGER)
+      #include <mbedtls/sha256.h>
+    #endif
     #ifndef PIN_SD_CS
       #if defined(TLORA_PAGER)
         #define PIN_SD_CS PAGER_PIN_SD_CS
@@ -218,15 +221,20 @@ void halt() {
 // "lost profile settings". The data was never gone — it was orphaned on SPIFFS.
 // Copies every SPIFFS file into SD:/meshcomod ("/prefs/<ns>.kv" flattens to
 // "/meshcomod/<ns>.kv", matching SdNvsPrefs's SD layout). Returns true only when
-// every file landed on the card; Pager additionally requires a last-written
-// completion marker. The caller must NOT adopt the card otherwise. force=true
+// every file landed on the card and a last-written completion marker commits
+// that attempt. The caller must NOT adopt the card otherwise. force=true
 // (the Settings "Copy internal data to SD" recovery button) overwrites whatever
 // the card holds on legacy targets. Pager recovery is deliberately non-clobbering;
 // its boot and manual paths only fill missing files and commit the marker last.
 // Both filesystems must be mounted by the caller.
-#if defined(TLORA_PAGER)
+static constexpr const char* kInternalIdentity = "/identity/_main.id";
+static constexpr const char* kSdIdentity = "/meshcomod/identity/_main.id";
 static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
 static constexpr const char* kSdMigrationCompleteTmp = "/meshcomod/.spiffs-migration-v1.tmp";
+
+#if defined(TLORA_PAGER)
+static constexpr const char* kSdMigrationOwner = "/meshcomod/.spiffs-migration-v1.owner";
+static constexpr const char* kSdMigrationOwnerTmp = "/meshcomod/.spiffs-migration-v1.owner.tmp";
 
 static bool sdProfileTreeContainsFile(const char* path, uint8_t depth = 0) {
   if (!SD.exists(path)) return false;
@@ -251,19 +259,67 @@ static bool sdProfileTreeContainsFile(const char* path, uint8_t depth = 0) {
   return false;
 }
 
+static bool internalIdentityDigest(uint8_t out[32]) {
+  File identity = SPIFFS.open(kInternalIdentity, FILE_READ);
+  if (!identity) return false;
+  mbedtls_sha256_context ctx;
+  mbedtls_sha256_init(&ctx);
+  int rc = mbedtls_sha256_starts_ret(&ctx, 0);
+  uint8_t chunk[128];
+  while (rc == 0 && identity.available()) {
+    const size_t n = identity.read(chunk, sizeof chunk);
+    if (n == 0) { rc = -1; break; }
+    rc = mbedtls_sha256_update_ret(&ctx, chunk, n);
+  }
+  if (rc == 0) rc = mbedtls_sha256_finish_ret(&ctx, out);
+  mbedtls_sha256_free(&ctx);
+  identity.close();
+  return rc == 0;
+}
+
+static bool sdDigestFileMatches(const char* path, const uint8_t expected[32]) {
+  File marker = SD.open(path, FILE_READ);
+  if (!marker || marker.size() != 32) {
+    if (marker) marker.close();
+    return false;
+  }
+  uint8_t actual[32];
+  const bool matches = marker.read(actual, sizeof actual) == sizeof actual &&
+                       memcmp(actual, expected, sizeof actual) == 0;
+  marker.close();
+  return matches;
+}
+
+static bool ensureSdMigrationOwner() {
+  uint8_t digest[32];
+  if (!internalIdentityDigest(digest)) return false;
+  if (SD.exists(kSdMigrationOwner))
+    return sdDigestFileMatches(kSdMigrationOwner, digest);
+  if (SD.exists(kSdMigrationOwnerTmp)) {
+    if (sdDigestFileMatches(kSdMigrationOwnerTmp, digest))
+      return SD.rename(kSdMigrationOwnerTmp, kSdMigrationOwner);
+    if (!SD.remove(kSdMigrationOwnerTmp)) return false;   // only our own incomplete marker
+  }
+  // Without a matching owner marker, only a tree containing no file payload is
+  // safe to claim. Empty directories from an interrupted mkdir sequence are OK.
+  if (sdProfileTreeContainsFile("/meshcomod")) return false;
+  if (!SD.exists("/meshcomod") && !SD.mkdir("/meshcomod")) return false;
+  File marker = SD.open(kSdMigrationOwnerTmp, FILE_WRITE);
+  const bool wrote = marker && marker.write(digest, sizeof digest) == sizeof digest;
+  if (marker) marker.close();
+  return wrote && SD.rename(kSdMigrationOwnerTmp, kSdMigrationOwner);
+}
+
 // Manual recovery may resume onto an empty card or the same profile, but it
 // must never fill one identity's missing files from another profile. Compare
 // the small identity files without logging their contents before arming the
 // durable migration latch. A read failure is treated as a mismatch.
 bool meshcomodSdProfileMatchesInternal() {
-  static constexpr const char* kInternalIdentity = "/identity/_main.id";
-  static constexpr const char* kSdIdentity = "/meshcomod/identity/_main.id";
   File internal = SPIFFS.open(kInternalIdentity, FILE_READ);
   if (!internal) return false;
   if (!SD.exists(kSdIdentity)) {
-    const bool has_payload = sdProfileTreeContainsFile("/meshcomod");
     internal.close();
-    return !has_payload;
+    return ensureSdMigrationOwner();
   }
   File card = SD.open(kSdIdentity, FILE_READ);
   if (!card || internal.size() != card.size()) {
@@ -285,6 +341,17 @@ bool meshcomodSdProfileMatchesInternal() {
   return matches;
 }
 #endif
+
+bool meshcomodPrepareSdMigration() {
+  if (SD.exists(kSdMigrationCompleteTmp) && !SD.remove(kSdMigrationCompleteTmp))
+    return false;
+  if (SD.exists(kSdMigrationComplete) && !SD.remove(kSdMigrationComplete))
+    return false;
+#if defined(TLORA_PAGER)
+  if (!SD.exists(kSdIdentity) && !ensureSdMigrationOwner()) return false;
+#endif
+  return true;
+}
 
 bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!SPIFFS.exists("/identity/_main.id")) return false;   // nothing worth adopting
@@ -458,7 +525,6 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
   Serial.printf("[BOOT] SPIFFS -> SD migration: %d copied, %d failed, identity %s\n",
                 copied, failed, identity_ok ? "ok" : "MISSING");
   bool complete = identity_ok && failed == 0;
-#if defined(TLORA_PAGER)
   if (complete) {
     if (SD.exists(kSdMigrationCompleteTmp) &&
         !SD.remove(kSdMigrationCompleteTmp)) {
@@ -483,7 +549,6 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
       return false;
     }
   }
-#endif
   return complete;
 }
 
@@ -742,7 +807,7 @@ void setup() {
     SPIClass* _spi = heltecV4R8SharedSPI();
    #else
     SPIClass* _spi = tdeckSharedSPI();
-    #endif
+   #endif
     bool sd_mounted = false;
 #if defined(TLORA_PAGER)
     if (!_spi) {
@@ -847,15 +912,25 @@ void setup() {
           const bool needs_migration =
               !SD.exists("/meshcomod/identity/_main.id");
           if (mig_busy) {
+            // A completion marker written after identity proves the interrupted
+            // state was only the tiny crash window before the NVS latch clear.
+            // Otherwise fail closed even if an older identity still exists.
+            const bool committed = !needs_migration && SD.exists(kSdMigrationComplete);
+            if (committed) {
+              if (mp_ok) _mp.remove("sd_mig_busy");
+              Serial.println("[BOOT] SD migration committed before reset -> adopting completed profile");
+            } else {
+              adopt = false;
+              g_sd_migration_blocked = true;
+              Serial.println("[BOOT] prior SD migration did not complete -> skipping (staying on SPIFFS); retry via Settings > Copy internal data to SD");
+            }
             if (mp_ok) _mp.end();
-            adopt = false;
-            g_sd_migration_blocked = true;
-            Serial.println("[BOOT] prior SD migration did not complete -> skipping (staying on SPIFFS); retry via Settings > Copy internal data to SD");
           } else if (needs_migration) {
             // Do not start without a durable rollback breadcrumb. If NVS is
             // unavailable, a reset after identity lands would otherwise leave
             // no evidence that the SD tree is only partially migrated.
-            const bool armed = mp_ok && _mp.putBool("sd_mig_busy", true) == 1;
+            const bool prepared = mp_ok && meshcomodPrepareSdMigration();
+            const bool armed = prepared && _mp.putBool("sd_mig_busy", true) == 1;
             if (mp_ok) _mp.end();
             adopt = armed && meshcomodMigrateSpiffsToSd(false);
             // Keep the breadcrumb latched after a returned-but-incomplete copy.
@@ -869,7 +944,7 @@ void setup() {
             g_sd_migration_blocked = !adopt;
             if (!adopt) Serial.println(armed
                 ? "[BOOT] SD migration incomplete -> staying on SPIFFS this boot"
-                : "[BOOT] SD migration breadcrumb unavailable -> staying on SPIFFS this boot");
+                : "[BOOT] SD migration preparation/breadcrumb unavailable -> staying on SPIFFS this boot");
           } else {
             if (mp_ok) _mp.end();
           }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,6 +228,29 @@ void halt() {
 static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
 static constexpr const char* kSdMigrationCompleteTmp = "/meshcomod/.spiffs-migration-v1.tmp";
 
+static bool sdProfileTreeContainsFile(const char* path, uint8_t depth = 0) {
+  if (!SD.exists(path)) return false;
+  if (depth >= 8) return true;   // unexpected/deep content is not safe to adopt
+  File dir = SD.open(path, FILE_READ);
+  if (!dir) return true;         // unreadable content is not an empty profile
+  if (!dir.isDirectory()) {
+    dir.close();
+    return true;
+  }
+  for (File entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
+    const bool is_dir = entry.isDirectory();
+    char child[160];
+    strlcpy(child, entry.path(), sizeof child);
+    entry.close();
+    if (!is_dir || child[0] == '\0' || sdProfileTreeContainsFile(child, depth + 1)) {
+      dir.close();
+      return true;
+    }
+  }
+  dir.close();
+  return false;
+}
+
 // Manual recovery may resume onto an empty card or the same profile, but it
 // must never fill one identity's missing files from another profile. Compare
 // the small identity files without logging their contents before arming the
@@ -238,8 +261,9 @@ bool meshcomodSdProfileMatchesInternal() {
   File internal = SPIFFS.open(kInternalIdentity, FILE_READ);
   if (!internal) return false;
   if (!SD.exists(kSdIdentity)) {
+    const bool has_payload = sdProfileTreeContainsFile("/meshcomod");
     internal.close();
-    return true;
+    return !has_payload;
   }
   File card = SD.open(kSdIdentity, FILE_READ);
   if (!card || internal.size() != card.size()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,10 +247,18 @@ static bool sdProfileTreeContainsFile(const char* path, uint8_t depth = 0) {
   }
   for (File entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
     const bool is_dir = entry.isDirectory();
+    if (!is_dir) {
+      entry.close();
+      dir.close();
+      return true;
+    }
     char child[160];
-    strlcpy(child, entry.path(), sizeof child);
+    const char* entry_path = entry.path();
+    const bool path_ok = entry_path && strlcpy(child, entry_path, sizeof child) < sizeof child;
     entry.close();
-    if (!is_dir || child[0] == '\0' || sdProfileTreeContainsFile(child, depth + 1)) {
+    // A truncated/unreadable directory name must fail closed. Treating the
+    // truncated path as absent could make a foreign residual subtree look empty.
+    if (!path_ok || child[0] == '\0' || sdProfileTreeContainsFile(child, depth + 1)) {
       dir.close();
       return true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,10 @@ extern "C" void set_boot_phase(int phase) { g_boot_phase = phase; }
 // "Store data on SD" toggle is only a stored intent — if the card didn't mount at boot, contacts
 // silently stay on internal flash. The Storage settings page reads this to show the REAL location.
 bool g_contacts_on_sd = false;
+// True when full SD adoption was requested but the guarded SPIFFS -> SD copy
+// could not be proven complete. Settings surfaces the recovery action; contacts
+// may still use SD as the secondary store while identity/prefs remain internal.
+bool g_sd_migration_blocked = false;
 #endif
 
 
@@ -332,12 +336,21 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
   return complete;
 }
 
+bool meshcomodArmSdMigLatch() {
+  Preferences prefs;
+  if (!prefs.begin("touch", false)) return false;
+  const bool armed = prefs.putBool("sd_mig_busy", true) == 1;
+  prefs.end();
+  return armed;
+}
+
 // Clear the boot safe-mode latch (see the SPIFFS->SD migration above): called after a
 // successful manual "Copy internal data to SD" so a deliberate retry re-arms boot-time
 // auto-adoption. The boot path re-latches on its own if a later migration wedges. GH #142/#148.
 void meshcomodClearSdMigLatch() {
   Preferences _mp;
   if (_mp.begin("touch", false)) { _mp.remove("sd_mig_busy"); _mp.end(); }
+  g_sd_migration_blocked = false;
 }
 #endif
 
@@ -691,6 +704,7 @@ void setup() {
           if (mig_busy) {
             if (mp_ok) _mp.end();
             adopt = false;
+            g_sd_migration_blocked = true;
             Serial.println("[BOOT] prior SD migration did not complete -> skipping (staying on SPIFFS); retry via Settings > Copy internal data to SD");
           } else if (needs_migration) {
             // Do not start without a durable rollback breadcrumb. If NVS is
@@ -707,6 +721,7 @@ void setup() {
             if (adopt) {
               Preferences _mp2; if (_mp2.begin("touch", false)) { _mp2.remove("sd_mig_busy"); _mp2.end(); }
             }
+            g_sd_migration_blocked = !adopt;
             if (!adopt) Serial.println(armed
                 ? "[BOOT] SD migration incomplete -> staying on SPIFFS this boot"
                 : "[BOOT] SD migration breadcrumb unavailable -> staying on SPIFFS this boot");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,13 +209,22 @@ void halt() {
 // "lost profile settings". The data was never gone — it was orphaned on SPIFFS.
 // Copies every SPIFFS file into SD:/meshcomod ("/prefs/<ns>.kv" flattens to
 // "/meshcomod/<ns>.kv", matching SdNvsPrefs's SD layout). Returns true only when
-// the identity file landed on the card — the caller must NOT adopt the card
-// otherwise. force=true (the Settings "Copy internal data to SD" recovery button)
+// every file and a last-written completion marker landed on the card — the caller
+// must NOT adopt the card otherwise. force=true (the Settings "Copy internal data to SD" recovery button)
 // overwrites whatever the card holds; the boot path never clobbers existing files.
 // Both filesystems must be mounted by the caller.
+static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
+static constexpr const char* kSdMigrationCompleteTmp = "/meshcomod/.spiffs-migration-v1.tmp";
+
 bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!SPIFFS.exists("/identity/_main.id")) return false;   // nothing worth adopting
   const bool sd_identity_preexisting = SD.exists("/meshcomod/identity/_main.id");
+  // The marker is the commit record. Remove it before an explicit overwrite so
+  // a reset halfway through cannot leave the old marker blessing mixed data.
+  if (force) {
+    SD.remove(kSdMigrationComplete);
+    SD.remove(kSdMigrationCompleteTmp);
+  }
   SD.mkdir("/meshcomod");
   SD.mkdir("/meshcomod/identity");
   SD.mkdir("/meshcomod/bl");
@@ -239,8 +248,11 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
     else
       snprintf(dst, sizeof dst, "/meshcomod%s", src);
     if (!force && SD.exists(dst)) { f.close(); continue; }   // boot path: never clobber
+    char tmp[120];
+    snprintf(tmp, sizeof tmp, "%s.mig", dst);
+    SD.remove(tmp);
     File s = SPIFFS.open(src, FILE_READ);
-    File d = s ? SD.open(dst, FILE_WRITE) : File();          // FILE_WRITE truncates
+    File d = s ? SD.open(tmp, FILE_WRITE) : File();
     bool ok = s && d;
     size_t since_feed = 0;
     while (ok && s.available()) {
@@ -256,8 +268,21 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
     }
     if (s) s.close();
     if (d) d.close();
-    if (ok) { ++copied; if (strcmp(src, "/identity/_main.id") == 0) identity_ok = true; }
-    else    { ++failed; Serial.printf("[BOOT] SD migrate FAILED: %s\n", src); if (SD.exists(dst)) SD.remove(dst); }
+    // Commit each destination only after its temporary file is complete. This
+    // prevents a power cut from leaving an existing-looking truncated file that
+    // a later non-clobbering retry would skip.
+    if (ok) {
+      if (force && SD.exists(dst) && !SD.remove(dst)) ok = false;
+      if (ok && !SD.rename(tmp, dst)) ok = false;
+    }
+    if (ok) {
+      ++copied;
+      if (strcmp(src, "/identity/_main.id") == 0) identity_ok = true;
+    } else {
+      ++failed;
+      Serial.printf("[BOOT] SD migrate FAILED: %s\n", src);
+      SD.remove(tmp);
+    }
     f.close();
     esp_task_wdt_reset();
     yield();
@@ -270,7 +295,22 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!force && !identity_ok && SD.exists("/meshcomod/identity/_main.id")) identity_ok = true;
   Serial.printf("[BOOT] SPIFFS -> SD migration: %d copied, %d failed, identity %s\n",
                 copied, failed, identity_ok ? "ok" : "MISSING");
-  const bool complete = identity_ok && failed == 0;
+  bool complete = identity_ok && failed == 0;
+  if (complete) {
+    SD.remove(kSdMigrationCompleteTmp);
+    File marker = SD.open(kSdMigrationCompleteTmp, FILE_WRITE);
+    bool marker_ok = marker && marker.print("complete v1\n") == 12;
+    if (marker) marker.close();
+    if (marker_ok) {
+      SD.remove(kSdMigrationComplete);
+      marker_ok = SD.rename(kSdMigrationCompleteTmp, kSdMigrationComplete);
+    }
+    if (!marker_ok) {
+      SD.remove(kSdMigrationCompleteTmp);
+      Serial.println("[BOOT] SD migrate FAILED: completion marker");
+      complete = false;
+    }
+  }
   if (!complete && !sd_identity_preexisting &&
       SD.exists("/meshcomod/identity/_main.id")) {
     // This attempt introduced the adoption key. Roll it back so a missing NVS
@@ -628,13 +668,28 @@ void setup() {
           Preferences _mp;
           const bool mp_ok = _mp.begin("touch", false);
           const bool mig_busy = mp_ok && _mp.getBool("sd_mig_busy", false);
+#if defined(TLORA_PAGER)
+          // #193 predates the completion marker. Re-walk an unmarked Pager tree
+          // without clobbering existing files, filling any missing files from
+          // SPIFFS and committing the marker last before it can be adopted.
+          const bool needs_migration =
+              !SD.exists("/meshcomod/identity/_main.id") ||
+              !SD.exists(kSdMigrationComplete);
+#else
+          const bool needs_migration =
+              !SD.exists("/meshcomod/identity/_main.id");
+#endif
           if (mig_busy) {
             if (mp_ok) _mp.end();
             adopt = false;
             Serial.println("[BOOT] prior SD migration did not complete -> skipping (staying on SPIFFS); retry via Settings > Copy internal data to SD");
-          } else if (!SD.exists("/meshcomod/identity/_main.id")) {
-            if (mp_ok) { _mp.putBool("sd_mig_busy", true); _mp.end(); }
-            adopt = meshcomodMigrateSpiffsToSd(false);
+          } else if (needs_migration) {
+            // Do not start without a durable rollback breadcrumb. If NVS is
+            // unavailable, a reset after identity lands would otherwise leave
+            // no evidence that the SD tree is only partially migrated.
+            const bool armed = mp_ok && _mp.putBool("sd_mig_busy", true) == 1;
+            if (mp_ok) _mp.end();
+            adopt = armed && meshcomodMigrateSpiffsToSd(false);
             // Keep the breadcrumb latched after a returned-but-incomplete copy.
             // That matters when identity landed before a larger history file
             // failed: the next boot must not adopt the partial SD tree merely
@@ -643,7 +698,9 @@ void setup() {
             if (adopt) {
               Preferences _mp2; if (_mp2.begin("touch", false)) { _mp2.remove("sd_mig_busy"); _mp2.end(); }
             }
-            if (!adopt) Serial.println("[BOOT] SD migration incomplete -> staying on SPIFFS this boot");
+            if (!adopt) Serial.println(armed
+                ? "[BOOT] SD migration incomplete -> staying on SPIFFS this boot"
+                : "[BOOT] SD migration breadcrumb unavailable -> staying on SPIFFS this boot");
           } else {
             if (mp_ok) _mp.end();
           }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,11 @@ extern "C" void set_boot_phase(int phase) { g_boot_phase = phase; }
 // "Store data on SD" toggle is only a stored intent — if the card didn't mount at boot, contacts
 // silently stay on internal flash. The Storage settings page reads this to show the REAL location.
 bool g_contacts_on_sd = false;
+// True only when DataStore adopted SD as the primary identity/preferences
+// backend for this boot. The UI history selector uses the same decision so an
+// established card identity can never be paired with another profile's
+// internal chat history merely because an old card lacks a migration marker.
+bool g_full_data_on_sd = false;
 // True when full SD adoption was requested but the guarded SPIFFS -> SD copy
 // could not be proven complete. Settings surfaces the recovery action; contacts
 // may still use SD as the secondary store while identity/prefs remain internal.
@@ -825,6 +830,7 @@ void setup() {
         }
         if (adopt) {
           sd_storage = store.useSdStorage();
+          g_full_data_on_sd = sd_storage;
           // On a genuine first run, persist the auto-pick so the "Store data on SD"
           // toggle reflects it and the choice sticks on every later boot.
           if (fresh_install && sd_storage && !use_sd_pref) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,8 +215,9 @@ void halt() {
 // "/meshcomod/<ns>.kv", matching SdNvsPrefs's SD layout). Returns true only when
 // every file landed on the card; Pager additionally requires a last-written
 // completion marker. The caller must NOT adopt the card otherwise. force=true
-// (the Settings "Copy internal data to SD" recovery button)
-// overwrites whatever the card holds; the boot path never clobbers existing files.
+// (the Settings "Copy internal data to SD" recovery button) overwrites whatever
+// the card holds on legacy targets. Pager recovery is deliberately non-clobbering;
+// its boot and manual paths only fill missing files and commit the marker last.
 // Both filesystems must be mounted by the caller.
 #if defined(TLORA_PAGER)
 static constexpr const char* kSdMigrationComplete = "/meshcomod/.spiffs-migration-v1";
@@ -226,7 +227,6 @@ bool meshcomodSdMigrationComplete() { return SD.exists(kSdMigrationComplete); }
 
 bool meshcomodMigrateSpiffsToSd(bool force) {
   if (!SPIFFS.exists("/identity/_main.id")) return false;   // nothing worth adopting
-  const bool sd_identity_preexisting = SD.exists("/meshcomod/identity/_main.id");
   // On Pager the marker is the cross-file commit record. Remove it before an
   // explicit overwrite so a reset halfway through cannot leave the old marker
   // blessing mixed data.
@@ -244,95 +244,188 @@ bool meshcomodMigrateSpiffsToSd(bool force) {
                                  // but the FAT card needs the real parent dir or every copy fails
   SD.mkdir("/meshcomod/apps");   // Lua apps installed to internal storage before a card existed
   bool identity_ok = false;
+  bool identity_deferred = false;
   int copied = 0, failed = 0;
   static uint8_t buf[4096];
+  // This routine runs only on loopTask. Keep the working paths off its stack:
+  // the manual recovery used to be called from a deep LVGL event callback and
+  // field evidence showed this buffer being corrupted after dozens of files.
+  static char src[96];
+  static char dst[112];
+  static char tmp[120];
+  const UBaseType_t low_water = uxTaskGetStackHighWaterMark(nullptr);
+  Serial.printf("[BOOT] SD migration start, loop stack low-water: %u bytes\n",
+                (unsigned)(low_water * sizeof(StackType_t)));
+  auto ensureSdParents = [](const char* path) -> bool {
+    char parent[112];
+    strlcpy(parent, path, sizeof(parent));
+    for (char* slash = strchr(parent + 1, '/'); slash; slash = strchr(slash + 1, '/')) {
+      *slash = '\0';
+      const bool ok = SD.exists(parent) || SD.mkdir(parent);
+      *slash = '/';
+      if (!ok) return false;
+    }
+    return true;
+  };
+  // Copy identity last. Its presence is the boot-time adoption key, so landing
+  // it before a later history/settings failure could make a partial card look
+  // complete if the NVS in-progress breadcrumb were ever lost. Existing card
+  // identities are never replaced by the non-clobbering Pager path.
+  auto copyFile = [&](File& source, const char* destination,
+                      const char*& fail_stage) -> bool {
+    snprintf(tmp, sizeof tmp, "%s.mig", destination);
+    fail_stage = "parents";
+    bool ok = ensureSdParents(destination);
+    if (ok && SD.exists(tmp)) {
+      fail_stage = "stale temp";
+      ok = SD.remove(tmp);   // only our own prior migration residue
+    }
+    File d;
+    if (ok) {
+      fail_stage = "open temp";
+      d = SD.open(tmp, FILE_WRITE);
+      ok = (bool)d;
+    }
+    size_t since_feed = 0;
+    const size_t source_size = source.size();
+    size_t source_read = 0;
+    while (ok && source_read < source_size) {
+      fail_stage = "read source";
+      const size_t remain = source_size - source_read;
+      const size_t n = source.read(buf, remain < sizeof(buf) ? remain : sizeof(buf));
+      if (n == 0) { ok = false; break; }
+      fail_stage = "write temp";
+      if (d.write(buf, n) != n) { ok = false; break; }
+      source_read += n;
+      // A large history file on a slow card can exceed the task-WDT window.
+      since_feed += n;
+      if (since_feed >= 32768) { esp_task_wdt_reset(); since_feed = 0; }
+    }
+    source.close();
+    if (d) d.close();
+    // Commit only a complete temporary file, preserving the old destination
+    // until its replacement is ready.
+    if (ok) {
+      fail_stage = "replace destination";
+      if (force && SD.exists(destination) && !SD.remove(destination)) ok = false;
+      if (ok) {
+        fail_stage = "commit rename";
+        if (!SD.rename(tmp, destination)) ok = false;
+      }
+    }
+    return ok;
+  };
   File root = SPIFFS.open("/");
+  if (!root || !root.isDirectory()) {
+    if (root) root.close();
+    Serial.println("[BOOT] SD migrate FAILED: open SPIFFS root");
+    return false;
+  }
   for (File f = root.openNextFile(); f; f = root.openNextFile()) {
     if (f.isDirectory()) { f.close(); continue; }
-    // SPIFFS is flat: name() is the full path ("/identity/_main.id", "/prefs/touch.kv", ...)
-    const char* sp = f.name();
-    char src[96];
+    // Arduino-ESP32 File::name() is only the basename (pathToFileName()). Use
+    // path() so nested SPIFFS names retain identity/, prefs/, msgs/, etc. The
+    // old name() assumption made us reopen "/_main.id" instead of
+    // "/identity/_main.id", causing the first full-SD boot migration to fail.
+    const char* sp = f.path();
     snprintf(src, sizeof src, "%s%s", sp[0] == '/' ? "" : "/", sp);
-    char dst[112];
     if (strncmp(src, "/prefs/", 7) == 0)
       snprintf(dst, sizeof dst, "/meshcomod/%s", src + 7);   // kv files sit flat on the card
     else
       snprintf(dst, sizeof dst, "/meshcomod%s", src);
-    if (!force && SD.exists(dst)) { f.close(); continue; }   // boot path: never clobber
-    char tmp[120];
-    snprintf(tmp, sizeof tmp, "%s.mig", dst);
-    SD.remove(tmp);
-    File s = SPIFFS.open(src, FILE_READ);
-    File d = s ? SD.open(tmp, FILE_WRITE) : File();
-    bool ok = s && d;
-    size_t since_feed = 0;
-    while (ok && s.available()) {
-      const size_t n = s.read(buf, sizeof buf);
-      if (n == 0 || d.write(buf, n) != n) ok = false;
-      // Feed the task-WDT mid-file: a large history file on a slow/cold SD card can take
-      // longer than the 20 s task-WDT to copy in 4 KB chunks, and this runs on loopTask
-      // during setup() — without the feed the dog panics and reboot-loops the boot (GH
-      // #142/#148). The copy still can't tolerate a genuinely wedged FAT layer; the
-      // NVS breadcrumb at the call site handles that.
-      since_feed += n;
-      if (since_feed >= 32768) { esp_task_wdt_reset(); since_feed = 0; }
+    if (!force && SD.exists(dst)) {
+      if (strcmp(src, "/identity/_main.id") == 0) identity_ok = true;
+      f.close();
+      continue;   // boot path: never clobber
     }
-    if (s) s.close();
-    if (d) d.close();
-    // Commit each destination only after its temporary file is complete. This
-    // prevents a power cut from leaving an existing-looking truncated file that
-    // a later non-clobbering retry would skip.
-    if (ok) {
-      if (force && SD.exists(dst) && !SD.remove(dst)) ok = false;
-      if (ok && !SD.rename(tmp, dst)) ok = false;
+    if (strcmp(src, "/identity/_main.id") == 0) {
+      identity_deferred = true;
+      f.close();
+      continue;
     }
+    const char* fail_stage = nullptr;
+    const bool ok = copyFile(f, dst, fail_stage);
     if (ok) {
       ++copied;
-      if (strcmp(src, "/identity/_main.id") == 0) identity_ok = true;
     } else {
       ++failed;
-      Serial.printf("[BOOT] SD migrate FAILED: %s\n", src);
+      Serial.printf("[BOOT] SD migrate FAILED (%s): %s\n", fail_stage, src);
+#if defined(TLORA_PAGER)
+      // A failed FAT operation can mean the card/volume is wedged. Do not issue
+      // remove(), exists(), or another copy against that same volume: the old
+      // cleanup call was exactly where the first requested SD boot could hang.
+      // The .mig name is never adopted and a later explicit retry removes it.
+      break;
+#else
       SD.remove(tmp);
+#endif
     }
-    f.close();
     esp_task_wdt_reset();
     yield();
   }
   root.close();
+  if (failed != 0) {
+    Serial.printf("[BOOT] SPIFFS -> SD migration stopped after %d copied, %d failed\n",
+                  copied, failed);
+    return false;   // breadcrumb remains armed; no more SD calls on this boot
+  }
+  if (identity_deferred) {
+    strlcpy(src, "/identity/_main.id", sizeof(src));
+    strlcpy(dst, "/meshcomod/identity/_main.id", sizeof(dst));
+    File identity = SPIFFS.open(src, FILE_READ);
+    const char* fail_stage = "open source";
+    const bool identity_opened = (bool)identity;
+    bool ok = identity_opened;
+    if (ok) ok = copyFile(identity, dst, fail_stage);
+    if (!ok) {
+      if (identity) identity.close();
+      ++failed;
+      Serial.printf("[BOOT] SD migrate FAILED (%s): %s\n", fail_stage, src);
+#if !defined(TLORA_PAGER)
+      if (identity_opened) SD.remove(tmp);
+#endif
+      Serial.printf("[BOOT] SPIFFS -> SD migration stopped after %d copied, %d failed\n",
+                    copied, failed);
+      return false;
+    }
+    ++copied;
+    identity_ok = true;
+    esp_task_wdt_reset();
+    yield();
+  }
   // The boot path skips files the card already has — an identity already on the
   // card counts as "landed" (nothing needed migrating). Identity alone is not
   // enough, though: adopting after a larger history/prefs copy failed hides the
   // complete SPIFFS store behind a partial SD tree.
-  if (!force && !identity_ok && SD.exists("/meshcomod/identity/_main.id")) identity_ok = true;
   Serial.printf("[BOOT] SPIFFS -> SD migration: %d copied, %d failed, identity %s\n",
                 copied, failed, identity_ok ? "ok" : "MISSING");
   bool complete = identity_ok && failed == 0;
 #if defined(TLORA_PAGER)
   if (complete) {
-    SD.remove(kSdMigrationCompleteTmp);
+    if (SD.exists(kSdMigrationCompleteTmp) &&
+        !SD.remove(kSdMigrationCompleteTmp)) {
+      Serial.println("[BOOT] SD migrate FAILED: stale completion temp");
+      return false;
+    }
     File marker = SD.open(kSdMigrationCompleteTmp, FILE_WRITE);
     bool marker_ok = marker && marker.print("complete v1\n") == 12;
     if (marker) marker.close();
     if (marker_ok) {
-      SD.remove(kSdMigrationComplete);
-      marker_ok = SD.rename(kSdMigrationCompleteTmp, kSdMigrationComplete);
+      if (SD.exists(kSdMigrationComplete) &&
+          !SD.remove(kSdMigrationComplete)) {
+        marker_ok = false;
+      } else {
+        marker_ok = SD.rename(kSdMigrationCompleteTmp, kSdMigrationComplete);
+      }
     }
     if (!marker_ok) {
-      SD.remove(kSdMigrationCompleteTmp);
       Serial.println("[BOOT] SD migrate FAILED: completion marker");
-      complete = false;
+      // Treat marker failure like any other volume failure. Leaving the
+      // marker temp is harmless; touching the failed card again can hang.
+      return false;
     }
   }
 #endif
-  if (!complete && !sd_identity_preexisting &&
-      SD.exists("/meshcomod/identity/_main.id")) {
-    // This attempt introduced the adoption key. Roll it back so a missing NVS
-    // breadcrumb cannot make the next boot mistake a partial tree for a complete
-    // migration. Successfully copied non-identity files are harmless and let a
-    // later retry resume without clobbering them.
-    if (!SD.remove("/meshcomod/identity/_main.id"))
-      Serial.println("[BOOT] SD migrate: could not roll back partial identity");
-  }
   return complete;
 }
 
@@ -691,12 +784,13 @@ void setup() {
           const bool mp_ok = _mp.begin("touch", false);
           const bool mig_busy = mp_ok && _mp.getBool("sd_mig_busy", false);
 #if defined(TLORA_PAGER)
-          // #193 predates the completion marker. Re-walk an unmarked Pager tree
-          // without clobbering existing files, filling any missing files from
-          // SPIFFS and committing the marker last before it can be adopted.
+          // An identity makes this an existing SD profile, even if it predates
+          // the migration-complete marker. Overlaying its missing files from
+          // SPIFFS would mix two profiles (for example, history from the card
+          // with the internal channel table). Only migrate onto an empty card;
+          // sd_mig_busy still rejects a migration interrupted after identity.
           const bool needs_migration =
-              !SD.exists("/meshcomod/identity/_main.id") ||
-              !SD.exists(kSdMigrationComplete);
+              !SD.exists("/meshcomod/identity/_main.id");
 #else
           const bool needs_migration =
               !SD.exists("/meshcomod/identity/_main.id");

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10876,29 +10876,67 @@ static void useSdStorageToggleCb(lv_event_t* e) {
 #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
 // "Copy internal data to SD": recovery for the beta_36 upgrades where the live
 // profile was orphaned on internal flash while the honored SD toggle adopted an
-// empty card (which then minted a fresh identity). Overwrites the card's copies
-// with EVERYTHING from internal flash, forces the SD pref on, reboots.
+// empty card (which then minted a fresh identity). Pager resumes without
+// replacing files already on the card; legacy targets retain their explicit
+// overwrite behavior. On success this forces the SD pref on and reboots.
 extern bool meshcomodMigrateSpiffsToSd(bool force);   // main.cpp
 extern bool meshcomodArmSdMigLatch();                  // durable in-progress guard
 extern void meshcomodClearSdMigLatch();               // main.cpp (GH #142/#148 boot safe-mode)
 extern bool g_sd_migration_blocked;
-static void sdRestoreApply() {
-  if (!g_lv.task) return;
-  if (!fmSdTryMount()) { g_lv.task->showAlert(TR("No SD card"), 1600); return; }
-  g_lv.task->showAlert(TR("Copying internal data to SD..."), 6000);
-  lv_refr_now(nullptr);                 // paint the notice before the blocking copy
-  // Land everything in RAM first — this path used to reboot WITHOUT persisting,
-  // silently dropping every message since the last lazy flush.
+static bool sdRuntimeLifecycleBusy();
+static bool s_sd_restore_pending = false;
+
+// Run the blocking filesystem walk only after lv_timer_handler() has returned.
+// Doing it directly in the confirmation callback stacked the migration's File
+// objects and path buffers on top of LVGL's event/render frames; on Pager that
+// eventually corrupted a source path and made SPIFFS reads fail mid-copy.
+// Quiesce both persistence workers before enumerating SPIFFS so no handle can
+// be rewritten underneath the walk.
+static void sdRestoreRun() {
+  if (!s_sd_restore_pending || !g_lv.task) return;
+  if (sdRuntimeLifecycleBusy()) return;
+  s_sd_restore_pending = false;
+
+  if (!fmSdTryMount()) {
+    g_lv.task->showAlert(TR("No SD card"), 1600);
+    return;
+  }
+
+  WdtHeavyGuard idle_wdt_guard;
+
+  // Land everything in RAM first. The history worker and queued A/B preference
+  // snapshots must both be idle before the migration opens either filesystem.
   g_lv.task->persistHistoryNow();
+  discoveredFlushNow();
+  if (!touchPrefsFlush()) {
+    g_sd_migration_blocked = true;
+    g_lv.task->showAlert(TR("Copy blocked: internal data is busy"), 2600);
+    return;
+  }
+  // A separate SD consumer (tile/notification/info worker) may have started
+  // while the internal writers were draining. Defer instead of overlapping
+  // its open FAT handle with the migration.
+  if (sdRuntimeLifecycleBusy()) {
+    s_sd_restore_pending = true;
+    return;
+  }
+
   if (!meshcomodArmSdMigLatch()) {
     g_sd_migration_blocked = true;
     g_lv.task->showAlert(TR("Copy blocked: migration guard unavailable"), 2600);
     return;
   }
+  const UBaseType_t low_water = uxTaskGetStackHighWaterMark(nullptr);
+  Serial.printf("[BOOT] deferred SD migration, loop stack low-water: %u bytes\n",
+                (unsigned)(low_water * sizeof(StackType_t)));
   bool ok = false;
   {
     LoopWdtGuard loop_wdt_guard;
+#if defined(TLORA_PAGER)
+    ok = meshcomodMigrateSpiffsToSd(false);
+#else
     ok = meshcomodMigrateSpiffsToSd(true);
+#endif
   }
   if (!ok) {
     g_sd_migration_blocked = true;
@@ -10910,10 +10948,26 @@ static void sdRestoreApply() {
   delay(400);                           // let the alert render before the restart
   board.reboot();
 }
+
+static void sdRestoreApply() {
+  if (!g_lv.task) return;
+  if (s_sd_restore_pending) return;
+#if defined(TLORA_PAGER)
+  g_lv.task->showAlert(TR("Resuming missing files to SD...\nThis may take a few minutes; keep powered."), 180000);
+#else
+  g_lv.task->showAlert(TR("Copying internal data to SD...\nThis may take a few minutes; keep powered."), 180000);
+#endif
+  s_sd_restore_pending = true;
+}
 static void sdRestoreFromInternalCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
+#if defined(TLORA_PAGER)
+  showConfirm(TR("Copy only missing internal files to SD,\nkeep existing SD data, then reboot?"),
+              TR("Resume"), sdRestoreApply);
+#else
   showConfirm(TR("Overwrite the SD card's settings and\nidentity with the internal copies,\nthen reboot?"),
               TR("Copy"), sdRestoreApply);
+#endif
 }
 #endif
 #endif
@@ -49266,6 +49320,10 @@ void UITask::loop() {
   uiCp("ui:lvgl");
   lv_timer_handler();
   uiCp("ui:tail");
+#if (CAP_SD || defined(TLORA_PAGER)) && \
+    (defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER))
+  sdRestoreRun();   // intentionally outside the LVGL event/render call stack
+#endif
 #if !defined(HAS_TANMATSU)
   webMirrorTick();   // coalesced, rate-capped, backpressure-gated send of the dirty region
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -25590,8 +25590,8 @@ static void queueTileForFetch(uint8_t z, int32_t x, int32_t y) {
   // microSD-tile mode: fetch missing tiles only when the cache lives ON the card
   // (s_tile_fs == &SD) — then downloads merge into the SD library (#20). Without an
   // SD-backed cache, stay read-only/offline as before. (WiFi-down guard below still
-  // keeps it fully offline when there's no link.) SD exists only on the T-Deck build;
-  // elsewhere s_tiles_from_sd is always false, so the simple guard is equivalent.
+  // keeps it fully offline when there's no link.) This applies to the T-Deck and Pager;
+  // boards without SD keep s_tiles_from_sd false, so the simple guard is equivalent.
   // The SD-pack offline mode is OSM-only; topo has no SD packs, so it always
   // fetches from the proxy regardless of the microSD-tiles setting.
 #if CAP_SD || defined(TLORA_PAGER)
@@ -46027,9 +46027,9 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     _sensors->setSettingValue("gps", "1");
   }
 #if defined(TLORA_PAGER)
-  // T-Deck's portable preference has no matching Pager toggle (CAP_SD=0).
-  // Ignore it here: the Pager still uses SD as its automatic cache fallback,
-  // but a card moved from a T-Deck cannot silently disable all online fetches.
+  // Start the Pager in server/cache mode on every boot. Its runtime SD-tile
+  // switch is intentionally not persistent yet, so a card moved from a T-Deck
+  // cannot silently disable all online fetches.
   s_tiles_from_sd = false;
 #else
   s_tiles_from_sd = touchPrefsGetTilesFromSd();   // map tile source: server (default) vs microSD

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10892,10 +10892,13 @@ static void useSdStorageToggleCb(lv_event_t* e) {
 #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
 // "Copy internal data to SD": recovery for the beta_36 upgrades where the live
 // profile was orphaned on internal flash while the honored SD toggle adopted an
-// empty card (which then minted a fresh identity). Pager resumes without
-// replacing files already on the card; legacy targets retain their explicit
-// overwrite behavior. On success this forces the SD pref on and reboots.
+// empty card. Pager resumes only onto a card with no identity or the identical
+// profile; legacy targets retain their explicit overwrite behavior. On success
+// this forces the SD pref on and reboots.
 extern bool meshcomodMigrateSpiffsToSd(bool force);   // main.cpp
+#if defined(TLORA_PAGER)
+extern bool meshcomodSdProfileMatchesInternal();      // compares bytes without logging identity data
+#endif
 extern bool meshcomodArmSdMigLatch();                  // durable in-progress guard
 extern void meshcomodClearSdMigLatch();               // main.cpp (GH #142/#148 boot safe-mode)
 extern bool g_sd_migration_blocked;
@@ -10938,6 +10941,13 @@ static void sdRestoreRun() {
     s_sd_restore_pending = true;
     return;
   }
+
+#if defined(TLORA_PAGER)
+  if (!meshcomodSdProfileMatchesInternal()) {
+    g_lv.task->showAlert(TR("Copy blocked: SD card holds a different or unreadable profile"), 3600);
+    return;
+  }
+#endif
 
   if (!meshcomodArmSdMigLatch()) {
     g_sd_migration_blocked = true;
@@ -10982,7 +10992,7 @@ static void sdRestoreApply() {
 static void sdRestoreFromInternalCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(TLORA_PAGER)
-  showConfirm(TR("Copy only missing internal files to SD,\nkeep existing SD data, then reboot?"),
+  showConfirm(TR("Copy only missing internal files to a matching SD profile,\nkeep existing SD data, then reboot?"),
               TR("Resume"), sdRestoreApply);
 #else
   showConfirm(TR("Overwrite the SD card's settings and\nidentity with the internal copies,\nthen reboot?"),
@@ -26994,7 +27004,7 @@ static void mapOptZoomButtonsCb(lv_event_t* e) {
   mapZoomControlsApply();
 }
 
-#if CAP_SD || defined(TLORA_PAGER)
+#if CAP_SD
 // Map tile source toggle (in the map options popup): ON = tiles live on the microSD
 // card — read the user's SD library AND cache Wi-Fi-fetched gaps there (#20), so the
 // library grows and downloads survive; OFF = tile server + internal LittleFS cache.
@@ -43815,29 +43825,6 @@ static bool    s_ui_data_boot_finalized = false;
 // whole boot. Switching a live ring from SPIFFS to a newly inserted card can
 // purge history that was never loaded into RAM; switching a 5000-record SD ring
 // to SPIFFS can fill the small internal partition.
-#if defined(TLORA_PAGER)
-extern bool meshcomodSdMigrationComplete();
-static bool uiHistoryStoreExists(fs::FS& fs, const char* root,
-                                 bool trust_segment_commit = true) {
-  // Thread metadata by itself is not a message store. It can land before a
-  // larger message file fails during SPIFFS -> SD migration; treating that one
-  // small file as authoritative would hide the complete SPIFFS history.
-  const char* files[] = { k_ui_msgs_path, k_ui_history_path };
-  char path[64];
-  for (const char* file : files) {
-    snprintf(path, sizeof path, "%s%s", root, file);
-    if (fs.exists(path)) return true;
-  }
-  // store.ok commits a coherent segment set on its native filesystem. During
-  // a cross-filesystem copy it may arrive before later segments, so the SD copy
-  // is authoritative only after the outer migration marker was committed last.
-  if (trust_segment_commit) {
-    snprintf(path, sizeof path, "%s%s", root, k_ui_seg_ok);
-    if (fs.exists(path)) return true;
-  }
-  return false;
-}
-#endif
 static bool uiDataFsReady() {
   if (s_ui_data_fs != nullptr) return true;   // cache SUCCESS only — a failed resolve MUST stay retryable
 #if defined(TLORA_PAGER)

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -43893,6 +43893,18 @@ static bool uiDataFsReady() {
     strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
     return true;
   }
+  // A failed/incomplete reconciliation deliberately leaves the primary
+  // profile on internal flash. An older completion marker may still exist on
+  // the card, so it cannot be allowed to select SD history and recreate a
+  // split identity/history profile while the durable busy latch is armed.
+  if (g_sd_migration_blocked) {
+    if (SPIFFS.begin(false)) {
+      s_ui_data_fs = &SPIFFS;
+      s_ui_data_root[0] = '\0';
+      return true;
+    }
+    return false;
+  }
   // Prefer an existing card history. On upgrade, however, an empty card must
   // not hide a Pager history that already lives in SPIFFS; keep using that
   // established store instead of silently re-homing it without a migration.

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10873,13 +10873,15 @@ static void useSdStorageToggleCb(lv_event_t* e) {
                                          : TR("Data -> internal on reboot"), 1800);
 }
 
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
 // "Copy internal data to SD": recovery for the beta_36 upgrades where the live
 // profile was orphaned on internal flash while the honored SD toggle adopted an
 // empty card (which then minted a fresh identity). Overwrites the card's copies
 // with EVERYTHING from internal flash, forces the SD pref on, reboots.
 extern bool meshcomodMigrateSpiffsToSd(bool force);   // main.cpp
+extern bool meshcomodArmSdMigLatch();                  // durable in-progress guard
 extern void meshcomodClearSdMigLatch();               // main.cpp (GH #142/#148 boot safe-mode)
+extern bool g_sd_migration_blocked;
 static void sdRestoreApply() {
   if (!g_lv.task) return;
   if (!fmSdTryMount()) { g_lv.task->showAlert(TR("No SD card"), 1600); return; }
@@ -10888,12 +10890,21 @@ static void sdRestoreApply() {
   // Land everything in RAM first — this path used to reboot WITHOUT persisting,
   // silently dropping every message since the last lazy flush.
   g_lv.task->persistHistoryNow();
+  if (!meshcomodArmSdMigLatch()) {
+    g_sd_migration_blocked = true;
+    g_lv.task->showAlert(TR("Copy blocked: migration guard unavailable"), 2600);
+    return;
+  }
   bool ok = false;
   {
     LoopWdtGuard loop_wdt_guard;
     ok = meshcomodMigrateSpiffsToSd(true);
   }
-  if (!ok) { g_lv.task->showAlert(TR("Copy failed (no internal identity)"), 2200); return; }
+  if (!ok) {
+    g_sd_migration_blocked = true;
+    g_lv.task->showAlert(TR("Copy incomplete: SD data may be mixed. Retry before reboot."), 4200);
+    return;
+  }
   meshcomodClearSdMigLatch();           // manual copy succeeded -> re-arm boot auto-adoption (GH #142/#148)
   touchPrefsSetUseSdStorage(true);      // make sure the reboot adopts the card
   delay(400);                           // let the alert render before the restart
@@ -12150,6 +12161,7 @@ static void buildDeviceSettings(int sec) {
      even with it ON. This line shows the truth and flags that mismatch. */
   {
     extern bool g_contacts_on_sd;
+    extern bool g_sd_migration_blocked;
     const bool want_sd = touchPrefsGetUseSdStorage();
     lv_obj_t* st = lv_label_create(body);
     lv_label_set_long_mode(st, LV_LABEL_LONG_WRAP);
@@ -12161,6 +12173,9 @@ static void buildDeviceSettings(int sec) {
           ? TR("SD data is unavailable - identity, settings, contacts and channels cannot be saved until the card is reinserted.")
           : TR("SD data is unavailable - contacts and channels cannot be saved until the card is reinserted."));
       lv_obj_set_style_text_color(st, lv_color_hex(0xE34B4B), LV_PART_MAIN);
+    } else if (want_sd && g_sd_migration_blocked) {
+      lv_label_set_text(st, TR("SD data migration is incomplete. Identity and settings remain internal; use Copy internal data to SD to retry."));
+      lv_obj_set_style_text_color(st, lv_color_hex(0xE3A127), LV_PART_MAIN);
     } else if (g_contacts_on_sd) {
       lv_label_set_text(st, TR("Contacts are saved to the SD card."));
       lv_obj_set_style_text_color(st, lv_color_hex(COLOR_STATUS_OK), LV_PART_MAIN);
@@ -12179,8 +12194,8 @@ static void buildDeviceSettings(int sec) {
      orphaned on internal flash when the honored SD toggle adopted an empty (or
      fresh-identity) card. This copies EVERYTHING from internal flash over the
      card's copies and reboots into the restored profile. This is a SPIFFS->SD
-     recovery on T-Deck and Pager; Tanmatsu uses SD_MMC with no SPIFFS. */
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+     recovery on T-Deck, V4-R8 and Pager; Tanmatsu uses SD_MMC with no SPIFFS. */
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
   {
     lv_obj_t* b = lv_btn_create(body);
     lv_obj_set_size(b, lv_pct(96), SC(30));
@@ -12194,7 +12209,7 @@ static void buildDeviceSettings(int sec) {
     lv_obj_center(lbl);
     y += SC(40);
   }
-#endif  // HAS_TDECK_GT911 || TLORA_PAGER (SPIFFS->SD recovery copy)
+#endif  // HAS_TDECK_GT911 || HELTEC_LORA_V4_R8 || TLORA_PAGER (SPIFFS->SD recovery copy)
 #endif
 
   }
@@ -14447,7 +14462,7 @@ static bool     s_telem_manual_pending = false; // a manual request is awaiting 
 static uint32_t s_telem_deadline_ms = 0;        // manual-request timeout (separate from ping)
 static int      s_telem_win_now_h  = 0;         // display window: newer bound (hours ago)
 static int      s_telem_win_past_h = 24;        // display window: older bound (hours ago)
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
 static void openTelemetryWindow(const uint8_t* key6, const char* name, int state);   // fwd
 #endif
 static constexpr unsigned long UI_PING_TIMEOUT_MS = 30000;  // 30 s for flood paths
@@ -14522,7 +14537,7 @@ static void actionSheetTelemetryCb(lv_event_t* e) {
   bool ok = the_mesh.getContactByIdx(s_action_sheet_mesh_idx, c);
   closeActionSheet();
   if (!ok) { g_lv.task->showAlert(TR("Contact gone"), 1200); return; }
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // Open the telemetry window on its history; it does NOT auto-request. The user
   // taps the Request button (refresh glyph, left of the gear) to poll.
   memcpy(s_telem_node, c.id.pub_key, 6);
@@ -17073,7 +17088,7 @@ static inline void sdNoteIoFailure() {
 // the 24h chart still works. SD path lives under /meshcomod with the other files;
 // SPIFFS (flat) uses a top-level path.
 static fs::FS& battLogFs() {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (SD.cardType() != CARD_NONE) {
     if (SD.exists("/meshcomod")) return SD;
     // cardType() says present (cached) but real I/O failed — wedge/removal tell.
@@ -17084,7 +17099,7 @@ static fs::FS& battLogFs() {
   return SPIFFS;
 }
 static bool battLogOnSd() {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   return SD.cardType() != CARD_NONE && SD.exists("/meshcomod");
 #else
   return false;
@@ -17443,7 +17458,7 @@ static void batteryTapCb(lv_event_t* e) {
   openBatteryChartWindow();
 }
 
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
 // ----- Per-node telemetry log (/meshcomod/telemetry/<id>.log) -----
 // One file per node (6-byte pubkey prefix, hex). Columns (tab-separated):
 //   epoch \t YYYY-MM-DD HH:MM \t battery_mv \t tempC*10 \t humidity%
@@ -21178,7 +21193,7 @@ static uint32_t  s_disc_log_count = 0;     // sightings written to SD this sessi
 static lv_obj_t* s_disc_footer = nullptr;  // bottom status line: GPS / wardrive state
 
 static void discoverLogSighting(int32_t lat_e6, int32_t lon_e6, const MyMesh::DiscoverHit& h) {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (SD.cardType() == CARD_NONE) return;
   markSdIo();
   SD.mkdir("/meshcomod");
@@ -25489,7 +25504,7 @@ static void queueTileForFetch(uint8_t z, int32_t x, int32_t y) {
   // elsewhere s_tiles_from_sd is always false, so the simple guard is equivalent.
   // The SD-pack offline mode is OSM-only; topo has no SD packs, so it always
   // fetches from the proxy regardless of the microSD-tiles setting.
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (s_map_style == 0 && s_tiles_from_sd && s_tile_fs != &SD) return;
 #else
   if (s_map_style == 0 && s_tiles_from_sd) return;
@@ -25629,7 +25644,7 @@ static bool loadTileJpeg(uint8_t z, int32_t x, int32_t y,
   char path[48];
   snprintf(path, sizeof(path), "%s/%u/%ld/%ld.jpg",
            mapTileRoot(), (unsigned)z, (long)x, (long)y);
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (s_tiles_from_sd && s_map_style == 0) {   // SD packs are OSM-only; topo uses the online /tiles/topo cache
     // Tile source = microSD: read straight off the card (fully offline, no server fetch).
     if (s_sd_fail_note_ms) return false;   // card suspected dead — don't stack per-tile SPI timeouts (sdHealthTick arbitrates)
@@ -25771,7 +25786,7 @@ static void mapNoteStorageChanged() {
 #if defined(ESP32)
 // Is *some* tile source available to probe at all? (SD pack or LittleFS /tiles.)
 static bool mapTileSourceReady() {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (s_tiles_from_sd) return true;
 #endif
   return s_tiles_fs_ready;
@@ -25782,7 +25797,7 @@ static bool mapTileSourceReady() {
 // online cache), so an SD /maps/osm offline pack was invisible to zoom — the loader
 // drew its tiles but the buttons reported "Max/Min zoom for this pack" offline.
 static bool tileExistsAt(uint8_t z, long x, long y) {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (s_tiles_from_sd && s_map_style == 0) {   // topo isn't on SD packs — probe the online cache below
     if (s_sd_fail_note_ms) return false;   // card suspected dead — skip the five per-tile probes (sdHealthTick arbitrates)
     if (!s_sd_mounted) return false;       // never ladder from the zoom guard (see loadTileJpeg)
@@ -26108,7 +26123,7 @@ static void renderMapTiles() {
   }
 
 #if defined(ESP32)
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (s_tiles_from_sd) {
     lv_label_set_text(s_map_status_lbl,
         TR("Map tiles: microSD\n\n"
@@ -26897,12 +26912,22 @@ static void mapOptZoomButtonsCb(lv_event_t* e) {
   mapZoomControlsApply();
 }
 
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
 // Map tile source toggle (in the map options popup): ON = tiles live on the microSD
 // card — read the user's SD library AND cache Wi-Fi-fetched gaps there (#20), so the
 // library grows and downloads survive; OFF = tile server + internal LittleFS cache.
 static void mapOptTilesSdCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  // The worker dereferences the shared cache backend throughout a request. Do
+  // not repoint it while a queued/in-flight fetch may still own a File on the
+  // old filesystem; on Pager that would also hide the live SD handle from the
+  // VFS lifecycle gate and permit SD.end() underneath it.
+  if (s_tile_fetch_pending > 0) {
+    if (s_tiles_from_sd) lv_obj_add_state(lv_event_get_target(e), LV_STATE_CHECKED);
+    else                 lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);
+    if (g_lv.task) g_lv.task->showAlert(TR("Tile download in progress - retry"), 1800);
+    return;
+  }
   const bool on = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
   touchPrefsSetTilesFromSd(on);
   s_tiles_from_sd = on;
@@ -27086,7 +27111,7 @@ static void openMapOptions() {
   lv_obj_set_pos(title, 0, 0);
   int y = 26;
 
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // Row: tile source — microSD (offline) vs the tile server. The important one,
   // so it sits at the very top.
   {
@@ -28955,7 +28980,7 @@ static void crashDumpCheck() {
   // so the whole crash-report UI stays off (everything downstream gates on s_crash_dump_size,
   // which then stays 0). The panic coredump still sits in its flash partition for a USB/esptool
   // pull if we ever need it.
-#if CAP_FILESYSTEM
+#if CAP_FILESYSTEM || defined(TLORA_PAGER)
   crashWdtCaptureRead();   // pull the Task-WDT culprit (if any) before checking for a dump
   size_t addr = 0, size = 0;
   if (esp_core_dump_image_check() == ESP_OK &&
@@ -28980,7 +29005,7 @@ static bool crashDumpExport(char* out_path, size_t out_cap) {
   bool used_sd = false;
   fs::FS* dst = nullptr;
   const char* path = "/wadamesh-crash.elf";
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (fmSdTryMount()) { dst = &SD; used_sd = true; }
 #elif defined(HAS_TANMATSU) || defined(HAS_TDISPLAY_P4)
   if (tanSdTryMount()) { dst = &SD_MMC; used_sd = true; }   // microSD on SDMMC slot 0
@@ -34176,7 +34201,7 @@ static uint8_t* lockscreenDecodeWallpaper(int* out_w, int* out_h) {
   // this path only runs for user-selected wallpapers.)
   fs::FS* fsp = &SPIFFS;
   const char* fp = path;
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (!strncmp(path, "sd:", 3)) { fsp = &SD; fp = path + 3; fmSdTryMount(); }   // mount on demand so the chosen SD wallpaper decodes (T-Deck SD only)
 #endif
 
@@ -34826,7 +34851,7 @@ static void backupScan() {
     }
     root.close();
   }
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // SD card: scan the root AND the /meshcomod data folder. SD-storage builds keep
   // their data under /meshcomod, so users naturally drop a backup next to it —
   // previously only the root was scanned, so a json in /meshcomod never showed up
@@ -34876,7 +34901,7 @@ static void doBackupImportChosen() {
   fs::FS* fsp = nullptr;
   const char* path = s_backup_chosen;
   if (!strncmp(path, "int:", 4)) { fsp = backupInternalFs(); path += 4; }
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   else if (!strncmp(path, "sd:", 3)) { fsp = &SD; path += 3; }
 #endif
   if (!fsp) { g_lv.task->showAlert(TR("Import: storage unavailable"), 2000); return; }
@@ -35033,7 +35058,7 @@ static void doExportBackupFile(const char* fname) {
 
   char path[96]; snprintf(path, sizeof path, "/%s", fname);
   File f; const char* where = "internal";
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // Actually mount the card (SD.cardType alone reads CARD_NONE until something
   // mounts it) so a backup truly lands on — and lists from — the SD card.
   if (fmSdTryMount()) { f = SD.open(path, FILE_WRITE); if (f) where = "SD"; }
@@ -35055,7 +35080,7 @@ static void doDeleteBackup() {
   const char* path = s_backup_del_path;
   bool ok = false;
   if (!strncmp(path, "int:", 4)) { ok = backupInternalFs()->remove(path + 4); }   // FFat on Tanmatsu/P4, SPIFFS elsewhere
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   else if (!strncmp(path, "sd:", 3)) { if (fmSdTryMount()) ok = SD.remove(path + 3); }
 #endif
   s_backup_del_path[0] = '\0';
@@ -35122,7 +35147,7 @@ static void doFactoryReset() {
     lv_obj_del(ov);
     if (g_lv.task) {
       g_lv.task->flushHistorySoon();
-      g_lv.task->showAlert(TR("Factory reset blocked: SD is busy; retry"), 2600);
+      g_lv.task->showAlert(TR("Factory reset blocked: SD activity is still running; close tools and retry."), 3600);
     }
     return;
   }
@@ -35141,7 +35166,7 @@ static void doFactoryReset() {
     lv_obj_del(ov);
     if (g_lv.task) {
       g_lv.task->flushHistorySoon();
-      g_lv.task->showAlert(TR("Factory reset blocked: SD wipe failed; remove card and retry"), 4200);
+      g_lv.task->showAlert(TR("Factory reset incomplete: SD data may already be partially erased. Retry to finish, or remove the card before resetting internal data."), 6000);
     }
     return;
   }
@@ -39069,7 +39094,7 @@ static void statusBarReaderBackCb(lv_event_t* e) {
 // compression) is the quickest viewable format to emit — rows are a direct copy
 // of the RGB565 framebuffer (LV_COLOR_16_SWAP is 0). Saved to /screenshots.
 static void takeScreenshotToSd() {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   auto toast = [&](const char* m){ if (g_lv.task) g_lv.task->showAlert(m, 1800); };
   if (SD.cardType() == CARD_NONE) { toast(TR("Screenshot: no SD card")); return; }
   const int W = lv_disp_get_hor_res(nullptr);
@@ -42716,7 +42741,7 @@ void UITask::onPingReply(const ContactInfo& contact, const uint8_t* data, size_t
 // popup) instead of a single-slot toast, so the full multi-line reading stays on
 // screen until tapped away and can scroll if it's long. Tap the dimmed backdrop
 // to close.
-#if CAP_SD   // telemetry window + per-node log/poll are SD-backed (T-Deck only)
+#if CAP_SD || defined(TLORA_PAGER)   // telemetry window + per-node log/poll use the mounted SD store
 static lv_obj_t* s_telemetry_root    = nullptr;
 static lv_obj_t* s_telem_config_root = nullptr;   // settings panel spawned on top
 static lv_obj_t* s_telem_poll_ta     = nullptr;   // auto-poll interval input (config panel)
@@ -43375,7 +43400,7 @@ void UITask::onTelemetryReply(const ContactInfo& contact, const uint8_t* data, s
     if (p > 0 && (size_t)p >= body_cap - 1) break;   // body buffer full
   }
 done: {
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // Log every reply (manual or auto-poll) to the per-node telemetry file.
   if (any) telemetryLogAppend(contact.id.pub_key, (uint32_t)time(nullptr), tl_mv, tl_t10, tl_h);
 #endif
@@ -43397,7 +43422,7 @@ done: {
     snprintf(msg, sizeof(msg), "%s: %uB %s",
              nm, (unsigned)len, hex);
   }
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // Update the telemetry window ONLY for the node it's showing, and only when a
   // manual request is in flight — auto-poll just logs (above) without a window.
   if (s_telem_manual_pending && memcmp(s_telem_node, contact.id.pub_key, 6) == 0) {
@@ -46122,7 +46147,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   // mirrors this when the toggle flips at runtime.
   s_tile_fs_default = s_tile_fs;
   strncpy(s_tile_root_default, s_tile_root, sizeof s_tile_root_default - 1);
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   if (s_tiles_from_sd && (sdAdoptLiveMount() || fmSdTryMount())) {
     s_tile_fs = &SD;
     s_tile_root[0] = '\0';
@@ -48452,7 +48477,7 @@ void UITask::loop() {
     snprintf(msg, sizeof(msg), TR("No reply from %s"), s_ui_ping_target_name);
     showAlert(msg, 3500);
   }
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // Manual telemetry request timed out — flip the open window to "failed" (it
   // still shows the history). Auto-poll has no deadline, so it never lands here.
   if (s_telem_manual_pending && s_telem_deadline_ms != 0 && now >= s_telem_deadline_ms) {
@@ -49145,7 +49170,7 @@ void UITask::loop() {
   }
 
   batteryLogTick((uint32_t)now);   // 5-min battery sample (SD on T-Deck, else SPIFFS)
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   telemetryPollTick((uint32_t)now); // auto-poll due nodes -> log (no window)
 #endif
   uiCp("ui:verchk");
@@ -49396,7 +49421,7 @@ static const PopupEnt k_popup_registry[] = {
                                                                           PF_COUNT },
 #endif
   { P_OPEN(s_confirm_modal),         []{ confirmDismiss(); },             PF_COUNT },
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   { P_OPEN(s_telem_config_root),     []{ telemetryConfigClose(); },       PF_COUNT },   // sits on the telemetry window
   { P_OPEN(s_telemetry_root),        []{ telemetryClose(); },             PF_COUNT },
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10896,6 +10896,7 @@ static void useSdStorageToggleCb(lv_event_t* e) {
 // profile; legacy targets retain their explicit overwrite behavior. On success
 // this forces the SD pref on and reboots.
 extern bool meshcomodMigrateSpiffsToSd(bool force);   // main.cpp
+extern bool meshcomodPrepareSdMigration();            // clears the prior commit marker / claims empty Pager tree
 #if defined(TLORA_PAGER)
 extern bool meshcomodSdProfileMatchesInternal();      // compares bytes without logging identity data
 #endif
@@ -10949,6 +10950,12 @@ static void sdRestoreRun() {
   }
 #endif
 
+  if (!meshcomodPrepareSdMigration()) {
+    g_sd_migration_blocked = true;
+    g_lv.task->showAlert(TR("Copy blocked: SD profile could not be prepared safely"), 3200);
+    return;
+  }
+
   if (!meshcomodArmSdMigLatch()) {
     g_sd_migration_blocked = true;
     g_lv.task->showAlert(TR("Copy blocked: migration guard unavailable"), 2600);
@@ -10957,16 +10964,11 @@ static void sdRestoreRun() {
   const UBaseType_t low_water = uxTaskGetStackHighWaterMark(nullptr);
   Serial.printf("[BOOT] deferred SD migration, loop stack low-water: %u bytes\n",
                 (unsigned)(low_water * sizeof(StackType_t)));
-  bool ok = false;
+  LoopWdtGuard loop_wdt_guard;
 #if defined(TLORA_PAGER)
-  // The copy loop feeds the task watchdog itself. Avoid changing the loop
-  // task's original watchdog subscription on the Pager.
-  ok = meshcomodMigrateSpiffsToSd(false);
+  const bool ok = meshcomodMigrateSpiffsToSd(false);
 #else
-  {
-    LoopWdtGuard loop_wdt_guard;
-    ok = meshcomodMigrateSpiffsToSd(true);
-  }
+  const bool ok = meshcomodMigrateSpiffsToSd(true);
 #endif
   if (!ok) {
     g_sd_migration_blocked = true;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -43709,16 +43709,23 @@ static bool    s_ui_data_boot_finalized = false;
 // purge history that was never loaded into RAM; switching a 5000-record SD ring
 // to SPIFFS can fill the small internal partition.
 #if defined(TLORA_PAGER)
-static bool uiHistoryStoreExists(fs::FS& fs, const char* root) {
+extern bool meshcomodSdMigrationComplete();
+static bool uiHistoryStoreExists(fs::FS& fs, const char* root,
+                                 bool trust_segment_commit = true) {
   // Thread metadata by itself is not a message store. It can land before a
   // larger message file fails during SPIFFS -> SD migration; treating that one
   // small file as authoritative would hide the complete SPIFFS history.
-  const char* files[] = {
-    k_ui_msgs_path, k_ui_history_path, k_ui_seg_ok,
-  };
+  const char* files[] = { k_ui_msgs_path, k_ui_history_path };
   char path[64];
   for (const char* file : files) {
     snprintf(path, sizeof path, "%s%s", root, file);
+    if (fs.exists(path)) return true;
+  }
+  // store.ok commits a coherent segment set on its native filesystem. During
+  // a cross-filesystem copy it may arrive before later segments, so the SD copy
+  // is authoritative only after the outer migration marker was committed last.
+  if (trust_segment_commit) {
+    snprintf(path, sizeof path, "%s%s", root, k_ui_seg_ok);
     if (fs.exists(path)) return true;
   }
   return false;
@@ -43765,9 +43772,14 @@ static bool uiDataFsReady() {
   // not hide a Pager history that already lives in SPIFFS; keep using that
   // established store instead of silently re-homing it without a migration.
   if (fmSdTryMount()) {
-    const bool sd_has_history = uiHistoryStoreExists(SD, "/meshcomod");
+    const bool sd_migration_complete = meshcomodSdMigrationComplete();
+    const bool sd_has_history = uiHistoryStoreExists(
+        SD, "/meshcomod", sd_migration_complete);
     const bool spiffs_ready = SPIFFS.begin(false);
-    if (!sd_has_history && spiffs_ready && uiHistoryStoreExists(SPIFFS, "")) {
+    const bool spiffs_has_history =
+        spiffs_ready && uiHistoryStoreExists(SPIFFS, "");
+    if (spiffs_has_history &&
+        (!sd_migration_complete || !sd_has_history)) {
       s_ui_data_fs = &SPIFFS;
       s_ui_data_root[0] = '\0';
       return true;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -715,6 +715,24 @@ static void initTouchFontFallbacks() {
   g_font_14.fallback = &s_person_font14;
 }
 
+#if defined(MULTI_TRANSPORT_COMPANION)
+// Cross-core tile lifecycle count. Increment before publishing a queue item so
+// the worker cannot open an SD File during a false-zero window; every read and
+// update is atomic because the producer and consumer run on different cores.
+volatile uint16_t s_tile_fetch_pending = 0;
+static inline uint16_t tileFetchPendingLoad() {
+  return __atomic_load_n(&s_tile_fetch_pending, __ATOMIC_ACQUIRE);
+}
+static inline void tileFetchPendingInc() {
+  __atomic_fetch_add(&s_tile_fetch_pending, (uint16_t)1, __ATOMIC_RELEASE);
+}
+static inline void tileFetchPendingDec() {
+  const uint16_t pending = tileFetchPendingLoad();
+  if (pending > 0)
+    __atomic_fetch_sub(&s_tile_fetch_pending, (uint16_t)1, __ATOMIC_RELEASE);
+}
+#endif
+
 // ---- I2S notification sound (T-Deck MAX98357A amp / pager ES8311 codec) ----
 // Synthesized beeps and small WAV playback for UI feedback (message arrived,
 // etc), both driven over I2S. The legacy genericBuzzer (RTTTL on a digital
@@ -733,8 +751,6 @@ static constexpr i2s_port_t kI2sPort = I2S_NUM_0;
 // beeping while tiles are downloading — the I2S DMA buffers + Wi-Fi RX DMA + a
 // tile decode all contend for the scarce internal DMA RAM, and this build is
 // already tight enough that tile downloads can OOM-reboot on their own.
-extern volatile uint16_t s_tile_fetch_pending;
-
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
 static bool fmSdTryMount();   // defined far below (microSD mount)
 #endif
@@ -999,7 +1015,7 @@ static void tdeckNotifyTaskFn(void* arg) {
 // download (DMA-RAM contention → reboot) and won't stack itself. Caller checks the
 // sound pref.
 static void tdeckPlayNotifySlot(int slot) {
-  if (s_tile_fetch_pending > 0) return;   // don't fight the Wi-Fi/tile DMA buffers
+  if (tileFetchPendingLoad() > 0) return;   // don't fight the Wi-Fi/tile DMA buffers
   if (s_notify_playing) return;           // already chiming — don't stack tasks/I2S
   s_notify_slot = slot;
   s_notify_vol = (int)touchPrefsGetSoundVolume() * 130;   // 0..100 -> 0..13000 amplitude
@@ -1012,7 +1028,7 @@ static void tdeckPlayNotifySlot(int slot) {
 }
 // Preview an arbitrary WAV (not yet saved to a slot) on the notify task.
 static void tdeckPreviewWavFile(const char* prefpath) {
-  if (s_tile_fetch_pending > 0 || s_notify_playing) return;
+  if (tileFetchPendingLoad() > 0 || s_notify_playing) return;
   strncpy(s_notify_path, prefpath, sizeof s_notify_path - 1);
   s_notify_path[sizeof s_notify_path - 1] = '\0';
   s_notify_slot = TOUCH_SND_MSG;          // if the file fails, the task plays the msg chime
@@ -1086,7 +1102,7 @@ static void pagerNotifyTaskFn(void* arg) {
 }
 
 static void pagerPlayNotifySlot(int slot) {
-  if (s_tile_fetch_pending > 0) return;
+  if (tileFetchPendingLoad() > 0) return;
   if (s_notify_playing) return;
   s_notify_slot = slot;
   s_notify_vol = (int)touchPrefsGetSoundVolume();   // 0..100 -> the codec's hw volume register
@@ -1097,7 +1113,7 @@ static void pagerPlayNotifySlot(int slot) {
   }
 }
 static void pagerPreviewWavFile(const char* prefpath) {
-  if (s_tile_fetch_pending > 0 || s_notify_playing) return;
+  if (tileFetchPendingLoad() > 0 || s_notify_playing) return;
   strncpy(s_notify_path, prefpath, sizeof s_notify_path - 1);
   s_notify_path[sizeof s_notify_path - 1] = '\0';
   s_notify_slot = TOUCH_SND_MSG;
@@ -10932,14 +10948,16 @@ static void sdRestoreRun() {
   Serial.printf("[BOOT] deferred SD migration, loop stack low-water: %u bytes\n",
                 (unsigned)(low_water * sizeof(StackType_t)));
   bool ok = false;
+#if defined(TLORA_PAGER)
+  // The copy loop feeds the task watchdog itself. Avoid changing the loop
+  // task's original watchdog subscription on the Pager.
+  ok = meshcomodMigrateSpiffsToSd(false);
+#else
   {
     LoopWdtGuard loop_wdt_guard;
-#if defined(TLORA_PAGER)
-    ok = meshcomodMigrateSpiffsToSd(false);
-#else
     ok = meshcomodMigrateSpiffsToSd(true);
-#endif
   }
+#endif
   if (!ok) {
     g_sd_migration_blocked = true;
     g_lv.task->showAlert(TR("Copy incomplete: SD data may be mixed. Retry before reboot."), 4200);
@@ -18843,10 +18861,15 @@ static bool fmSdTryMount() {
   // here would invalidate open prefs/history files beneath the boot sequence.
 #if defined(TLORA_PAGER)
   // An SD-backed worker can enter here while its own busy flag is set. It may
-  // use an already-live VFS without touching the loop task's mount diagnostics
-  // or 64-bit size field. A cached CARD_NONE below only clears stale diagnostics.
-  if (SD.cardType() != CARD_NONE && sdRuntimeLifecycleBusy())
-    return board.sdCardState() != TLoraPagerBoard::SdCardState::Absent;
+  // use an already-live VFS without changing its lifetime. Keep the mount
+  // diagnostics coherent so every successful return has the same contract.
+  if (SD.cardType() != CARD_NONE && sdRuntimeLifecycleBusy()) {
+    if (board.sdCardState() == TLoraPagerBoard::SdCardState::Absent) return false;
+    s_sd_mounted = true;
+    s_sd_size = SD.cardSize();
+    s_sd_retry_after_ms = 0;
+    return true;
+  }
 #endif
   if (sdAdoptLiveMount()) return true;
   s_sd_mounted = false;
@@ -23947,7 +23970,6 @@ static constexpr int     k_tile_fetch_queue_size = 64;   // holds a full zoomed-
 static QueueHandle_t     s_tile_fetch_queue   = nullptr;
 static TaskHandle_t      s_tile_fetch_task    = nullptr;
 static volatile bool     s_tile_fetch_dirty   = false;
-volatile uint16_t s_tile_fetch_pending = 0;   // non-static: tdeckPlayNotify reads it via extern (above)
 #if defined(TLORA_PAGER)
 // Card-detect sets this before the VFS can be unmounted. It stops producers and
 // lets the worker discard its queued SD jobs, so the lifecycle gate converges
@@ -25209,7 +25231,7 @@ static void tileFetchTaskFn(void* arg) {
       s_tile_fetch_last_wr = 'R';
       ++s_tile_fetch_failed;
       tileFetchForget(req.z, req.x, req.y);
-      if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+      tileFetchPendingDec();
       continue;
     }
 #endif
@@ -25220,7 +25242,7 @@ static void tileFetchTaskFn(void* arg) {
       s_tile_fetch_last_wr = 'W';
       ++s_tile_fetch_failed;
       tileFetchForget(req.z, req.x, req.y);   // transient — re-arm for retry once Wi-Fi is back (#20)
-      if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+      tileFetchPendingDec();
       continue;
     }
 
@@ -25249,7 +25271,7 @@ static void tileFetchTaskFn(void* arg) {
         vf.close();
         if (mr == 3 && m[0] == 0xFF && m[1] == 0xD8 && m[2] == 0xFF) {
           ++s_tile_fetch_ok;                         // already on disk + valid -> skip the re-download
-          if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+          tileFetchPendingDec();
           continue;
         }
         tileCacheRemove(path_jpg);   // present but unreadable/short/bad -> fall through and re-download
@@ -25282,7 +25304,7 @@ static void tileFetchTaskFn(void* arg) {
         s_tile_fetch_last_wr = 'H';
         ++s_tile_fetch_failed;
         tileFetchForget(req.z, req.x, req.y);
-        if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+        tileFetchPendingDec();
         continue;
       }
     }
@@ -25293,7 +25315,7 @@ static void tileFetchTaskFn(void* arg) {
       s_tile_fetch_last_wr = 'S';
       ++s_tile_fetch_failed;
       tileFetchForget(req.z, req.x, req.y);   // transient — retry after space frees (#20)
-      if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+      tileFetchPendingDec();
       continue;
     }
 
@@ -25410,7 +25432,7 @@ static void tileFetchTaskFn(void* arg) {
     // remains and the device reboots.
     http.end();
     client.stop();
-    if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+    tileFetchPendingDec();
 
     if (wrote) {
       WIRE_DBG("[TILE]  -> wrote %s\n", path_jpg);
@@ -25581,9 +25603,13 @@ static void queueTileForFetch(uint8_t z, int32_t x, int32_t y) {
   if (!ensureTileFetchTaskRunning()) return;
   if (!s_tile_fetch_queue) return;
   TileFetchReq req = {z, x, y};
+  // Publish the lifecycle count before the queue item. Otherwise the worker can
+  // dequeue and open an SD File before the producer increments the count.
+  tileFetchPendingInc();
   if (xQueueSend(s_tile_fetch_queue, &req, 0) == pdTRUE) {
     tileFetchMarkSeen(z, x, y);    // only remember it once it's truly queued
-    ++s_tile_fetch_pending;
+  } else {
+    tileFetchPendingDec();
   }
 }
 
@@ -26132,7 +26158,7 @@ static void renderMapTiles() {
     // screen, which is heavy on internal DMA RAM — doing that per-tile WHILE the
     // Wi-Fi worker holds a socket pushed the heap into an OOM reboot. When tiles
     // are arriving from the network, let LVGL batch one redraw at the end.
-    if (s_tile_fetch_pending == 0) lv_refr_now(NULL);
+    if (tileFetchPendingLoad() == 0) lv_refr_now(NULL);
     // Yield to the IDLE task after each tile's read + decode + paint. This loop
     // runs on loopTask, which is what the task watchdog watches via IDLE1; a full
     // 9-tile load (or a few slow SD reads) can otherwise pin the core long enough
@@ -26978,7 +27004,7 @@ static void mapOptTilesSdCb(lv_event_t* e) {
   // not repoint it while a queued/in-flight fetch may still own a File on the
   // old filesystem; on Pager that would also hide the live SD handle from the
   // VFS lifecycle gate and permit SD.end() underneath it.
-  if (s_tile_fetch_pending > 0) {
+  if (tileFetchPendingLoad() > 0) {
     if (s_tiles_from_sd) lv_obj_add_state(lv_event_get_target(e), LV_STATE_CHECKED);
     else                 lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);
     if (g_lv.task) g_lv.task->showAlert(TR("Tile download in progress - retry"), 1800);
@@ -28361,9 +28387,9 @@ static void refreshMapInfoLabel() {
   char tail[28];
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
   const bool wifi_up = (WiFi.status() == WL_CONNECTED);
-  if (s_tile_fetch_pending > 0) {
+  if (tileFetchPendingLoad() > 0) {
     snprintf(tail, sizeof(tail), "\xe2\x86\x93 %u downloading",
-             (unsigned)s_tile_fetch_pending);
+             (unsigned)tileFetchPendingLoad());
   } else if (s_map_last_missing > 0 && !wifi_up) {
     snprintf(tail, sizeof(tail), "Wi-Fi off \xe2\x80\x94 gaps");
   } else {
@@ -43817,14 +43843,11 @@ static bool uiDataFsReady() {
 #if defined(TLORA_PAGER)
   if (s_ui_data_boot_finalized) {
     // A boot-adopted card owns the active identity/profile. Never fall back to
-    // another profile's internal history if that card becomes unavailable.
+    // another profile's internal history if that card becomes unavailable. If
+    // history failed to resolve during begin(), also never attach it later in
+    // this boot: the RAM ring was not loaded from that card, and a subsequent
+    // flush could otherwise replace its existing segments with an empty ring.
     if (g_full_data_on_sd) {
-      if (fmSdTryMount()) {
-        SD.mkdir("/meshcomod");
-        s_ui_data_fs = &SD;
-        strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
-        return true;
-      }
       return false;
     }
     // Never adopt unseen card history after the boot loader has finished, but
@@ -48221,7 +48244,7 @@ static bool sdRuntimeLifecycleBusy() {
               touchPrefsIoBusy();
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
   busy = busy || s_notify_playing ||
-         (s_tile_fs == &SD && s_tile_fetch_pending > 0);
+         (s_tile_fs == &SD && tileFetchPendingLoad() > 0);
 #endif
   return busy;
 }

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -92,8 +92,7 @@
   #endif
 #elif defined(TLORA_PAGER)
   #include <SD.h>             // microSD (CS=21) on the shared radio/display SPI bus --
-                               // file manager browse + WAV picker only; no format support
-                               // this pass (see fmSdTryMount()'s comment)
+                               // storage + file manager/WAV access; formatting stays disabled
   #define PIN_SD_CS PAGER_PIN_SD_CS   // from TLoraPagerBoard.h, already visible via
                                       // MyMesh.h -> target.h -> TLoraPagerBoard.h above
   #include <driver/i2s.h>     // pager ES8311 codec (notification tones + WAV playback)
@@ -909,9 +908,9 @@ static bool wavOpen(const char* prefpath, File& f) {
   if (!prefpath || !prefpath[0]) return false;
   fs::FS* fsp = &SPIFFS; const char* fp = prefpath;
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)   // only the T-Deck/pager sound picker ever writes an "sd:"-prefixed pref
-  // No fmSdTryMount() here: this runs on the throwaway notify task, and walking
-  // the SD.end()+SD.begin() mount ladder from a second task races the loop
-  // task's own SD use (the one documented single-task assumption). If the card
+  // No fmSdTryMount() here: this runs on the throwaway notify task, and changing
+  // the SD VFS lifecycle from a second task races the loop task's own SD use.
+  // If the card
   // isn't mounted the open below fails fast and the chime falls back; mounting
   // is owned by boot adoption / sdHealthTick's reinsert watch / the FM paths.
   if (!strncmp(prefpath, "sd:", 3)) { fsp = &SD; fp = prefpath + 3; }
@@ -4774,6 +4773,7 @@ static bool          s_verchk_recheck  = false;  // force a fresh check now (e.g
 // with the worker's own SD writes) — doing it on the UI thread froze the About sheet and
 // dropped the Back tap. Off-load it to the core-0 worker; sysInfoText reads these.
 static volatile bool s_sdinfo_request  = false;  // UI -> worker: rescan SD usage
+static volatile bool s_sdinfo_busy     = false;  // worker is inside the FAT scan
 // UI -> worker: write the chat-history snapshot to storage. The full-file write
 // can stall for multiple seconds in SPIFFS garbage collection on SD-less boards
 // (Heltec V4); on the loop thread that froze the whole UI, incl. touch wake
@@ -4933,6 +4933,7 @@ static int  segGatherRange(const UITask::UIMessage* ring, int cap, int count, in
 static UITask::UIMessage* segEnsureBuf(UITask::UIMessage** slot);
 // fwd decls — the ops live with the storage code far below.
 static void uiDataEnsureDirs();
+static bool uiHistWaitWorkerIdle();
 static int  uiSegScan(uint32_t* out_first_seqs, int max_out, bool sweep_tmps);
 static bool uiSegOpenValidated(uint32_t first_seq, File& f, uint16_t* rec_size_out);
 static bool uiSegReadRec(File& f, uint16_t disk_sz, UITask::UIMessage* out, uint32_t* seq_out);
@@ -10674,16 +10675,20 @@ static void sysInfoTextRest(char* buf, size_t cap) {
                 (unsigned)(sketch_size / 1024u),
                 (unsigned)(sketch_free / 1024u));
 
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   // microSD size + free. The FAT scan (usedBytes()) is done by the core-0 worker — never
   // on this UI thread — so the About sheet can't freeze on it. We just read the worker's
   // cached result here and request a (re)scan at most every 30 s.
   {
     static uint32_t sd_req_ms = 0;
     const uint32_t nowm = millis();
+    // Once armed, only the worker may clear this request (after publishing
+    // busy). A loop-side timeout creates a false/false window in the VFS gate
+    // and can let SD.end() race the worker's totalBytes()/usedBytes() scan.
     if (!s_sdinfo_request && (sd_req_ms == 0 || (uint32_t)(nowm - sd_req_ms) >= 30000)) {
       sd_req_ms = nowm ? nowm : 1;
-      s_sdinfo_request = true;   // worker rescans off-thread
+      if (ensureTileFetchTaskRunning())
+        s_sdinfo_request = true;   // worker rescans off-thread
     }
     if (!s_sdinfo_done)
       p += snprintf(buf + p, cap - p, "microSD\n  \xE2\x80\xA6\n\n");          // … (computing)
@@ -10854,7 +10859,7 @@ static inline const char* mapTileUrlPath() { return s_map_style == 1 ? "/opentop
 
 // Distance units toggle (km <-> miles). Applies immediately — saves the
 // pref and forces the contacts list to re-render its distance badges.
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
 // Store all data (identity/prefs/contacts/channels) on SD under /meshcomod vs
 // internal SPIFFS. Read at boot before data loads, so it only takes effect on
 // the next reboot.
@@ -10868,7 +10873,7 @@ static void useSdStorageToggleCb(lv_event_t* e) {
                                          : TR("Data -> internal on reboot"), 1800);
 }
 
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
 // "Copy internal data to SD": recovery for the beta_36 upgrades where the live
 // profile was orphaned on internal flash while the honored SD toggle adopted an
 // empty card (which then minted a fresh identity). Overwrites the card's copies
@@ -11550,7 +11555,7 @@ static void lockwallDisplayName(const char* path, char* out, int cap) {
 static void openLockWallPickerCb(lv_event_t* e);   // defined with the picker, below
 static void lockColorChosenCb(lv_event_t* e);
 #endif  // HAS_TDECK_GT911 || HAS_THINKNODE_M9
-#if CAP_SOUND_FILES   // custom WAV notification sounds -- T-Deck (SD or SPIFFS) or pager (SPIFFS only)
+#if CAP_SOUND_FILES   // custom WAV notification sounds -- T-Deck/pager (SD or SPIFFS)
 // Per-event notification-sound picker (Settings -> Sound). Mirrors the wallpaper picker.
 static lv_obj_t* s_snd_btn_lbl[3] = { nullptr, nullptr, nullptr };
 static int  s_snd_pending_slot = TOUCH_SND_MSG;    // slot we're choosing a sound for
@@ -12125,7 +12130,7 @@ static void buildDeviceSettings(int sec) {
   }
 
   if (sec == DSEC_GENERAL) {   // --- Storage (SD) ---
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
   /* Store all data (identity/prefs/contacts/channels) on the SD card under
      /meshcomod instead of internal flash — for running under Launcher, or just
      to keep everything on a card. Read at boot, so it applies after a reboot. */
@@ -12151,7 +12156,12 @@ static void buildDeviceSettings(int sec) {
     lv_obj_set_width(st, lv_pct(96));
     lv_obj_set_style_text_font(st, &g_font_12, LV_PART_MAIN);
     lv_obj_set_pos(st, 0, y);
-    if (g_contacts_on_sd) {
+    if (g_contacts_on_sd && SD.cardType() == CARD_NONE) {
+      lv_label_set_text(st, want_sd
+          ? TR("SD data is unavailable - identity, settings, contacts and channels cannot be saved until the card is reinserted.")
+          : TR("SD data is unavailable - contacts and channels cannot be saved until the card is reinserted."));
+      lv_obj_set_style_text_color(st, lv_color_hex(0xE34B4B), LV_PART_MAIN);
+    } else if (g_contacts_on_sd) {
       lv_label_set_text(st, TR("Contacts are saved to the SD card."));
       lv_obj_set_style_text_color(st, lv_color_hex(COLOR_STATUS_OK), LV_PART_MAIN);
     } else if (want_sd) {
@@ -12168,9 +12178,9 @@ static void buildDeviceSettings(int sec) {
   /* Recovery for the beta_36 "lost my profile" upgrades: the live data was
      orphaned on internal flash when the honored SD toggle adopted an empty (or
      fresh-identity) card. This copies EVERYTHING from internal flash over the
-     card's copies and reboots into the restored profile. T-Deck only: the
-     migration is SPIFFS->SD; the Tanmatsu's CAP_SD is SD_MMC with no SPIFFS. */
-#if defined(HAS_TDECK_GT911)
+     card's copies and reboots into the restored profile. This is a SPIFFS->SD
+     recovery on T-Deck and Pager; Tanmatsu uses SD_MMC with no SPIFFS. */
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
   {
     lv_obj_t* b = lv_btn_create(body);
     lv_obj_set_size(b, lv_pct(96), SC(30));
@@ -12184,7 +12194,7 @@ static void buildDeviceSettings(int sec) {
     lv_obj_center(lbl);
     y += SC(40);
   }
-#endif  // HAS_TDECK_GT911 (SPIFFS->SD recovery copy)
+#endif  // HAS_TDECK_GT911 || TLORA_PAGER (SPIFFS->SD recovery copy)
 #endif
 
   }
@@ -17628,6 +17638,22 @@ static bool      s_fm_img_fs = false;       // viewer is in full-screen mode
 static bool          s_sd_mounted   = false;   // microSD mount state
 static uint64_t      s_sd_size      = 0;       // card capacity (bytes)
 static unsigned long s_sd_retry_after_ms = 0;  // don't re-probe SD before this (backoff)
+#if defined(TLORA_PAGER)
+static uint32_t      s_sd_data_warn_next_ms = 0;
+static inline uint32_t sdDataWarnDeadline(uint32_t now) {
+  const uint32_t next = now + 60000;
+  return next ? next : 1;
+}
+static inline void sdPagerParkCs() {
+  pinMode(PIN_SD_CS, OUTPUT);
+  digitalWrite(PIN_SD_CS, HIGH);
+}
+static const char* sdRemovedAlertText() {
+  extern bool g_contacts_on_sd;
+  return g_contacts_on_sd ? TR("SD removed - card-backed data cannot be saved")
+                          : TR("SD card removed");
+}
+#endif
 static int       s_sd_format_pending = 0;   // deferred FAT32 format (runs after notice paints)
 static lv_obj_t* s_fm_fmt_overlay = nullptr; // full-screen "formatting..." notice
 static lv_obj_t* s_fm_actions    = nullptr;  // per-entry action sheet
@@ -18718,20 +18744,10 @@ static void fmFmtSize64(uint64_t bytes, char* out, size_t outsz) {
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)   // microSD mount/format helpers — Arduino SD on the shared SPI bus
 // One shared-SPI accessor per board: the T-Deck/M9 expose their pre-begun SPIClass
 // via tdeckSharedSPI()/m9SharedSPI(); the V4-R8's microSD shares its TFT FSPI bus
-// (heltecV4R8SharedSPI()); the pager's radio+display already share TFT_eSPI's own
-// instance directly (variants/lilygo_tlora_pager/target.cpp), so reuse that the
-// same way.
+// (heltecV4R8SharedSPI()); the pager accessor returns the same TFT_eSPI SPIClass
+// already used by its display and RadioLib module.
 #if defined(TLORA_PAGER)
-static inline SPIClass* sdSharedSPI() { return &TFT_eSPI::getSPIinstance(); }
-// Card-detect via the XL9555 expander (PAGER_EXPAND_SD_DET). Polarity is INVERTED
-// from what you'd guess — confirmed against LilyGoLib's own LilyGo_LoRa_Pager.cpp
-// installSD() (`if (io.digitalRead(EXPANDS_SD_DET)) return false;`): HIGH = no card
-// seated, LOW = card present. Skip the whole mount ladder when no card is seated,
-// so opening the File Manager / WAV picker on a bare pager doesn't grind through
-// the ladder's worst-case delay on every call.
-static inline bool pagerSdCardPresent() {
-  return board.io_expander.digitalRead(PAGER_EXPAND_SD_DET) == LOW;
-}
+static inline SPIClass* sdSharedSPI() { return tloraPagerSharedSPI(); }
 #elif defined(HELTEC_LORA_V4_R8)
 static inline SPIClass* sdSharedSPI() { return heltecV4R8SharedSPI(); }   // V4-R8: micro-SD shares the TFT FSPI bus (CS=3)
 #elif defined(HAS_THINKNODE_M9)
@@ -18742,8 +18758,28 @@ static inline SPIClass* sdSharedSPI() { return tdeckSharedSPI(); }
 // Mount the microSD on its shared SPI bus. Safe to call repeatedly (no-op
 // once mounted). SD.begin's internal spi.begin() is a no-op because the bus is
 // already initialised by the radio/display, so those pins are untouched.
+static bool sdAdoptLiveMount() {
+  if (SD.cardType() == CARD_NONE) return false;
+  s_sd_mounted = true;
+  s_sd_size = SD.cardSize();
+  s_sd_retry_after_ms = 0;
+  return true;
+}
+static bool sdRuntimeLifecycleBusy();
 static bool fmSdTryMount() {
-  if (s_sd_mounted) return true;
+  // main.cpp may already have mounted this global SD object for DataStore.
+  // Adopt that live VFS before considering any lifecycle operation: SD.end()
+  // here would invalidate open prefs/history files beneath the boot sequence.
+#if defined(TLORA_PAGER)
+  // An SD-backed worker can enter here while its own busy flag is set. It may
+  // use an already-live VFS without touching the loop task's mount diagnostics
+  // or 64-bit size field. A cached CARD_NONE below only clears stale diagnostics.
+  if (SD.cardType() != CARD_NONE && sdRuntimeLifecycleBusy())
+    return board.sdCardState() != TLoraPagerBoard::SdCardState::Absent;
+#endif
+  if (sdAdoptLiveMount()) return true;
+  s_sd_mounted = false;
+  s_sd_size = 0;
   // Fast-fail inside the post-failure backoff window. Hot paths call this
   // directly (map tile lookups on the loop task, history writes via
   // uiDataFsReady, WAV chimes) — without this gate every such call re-walks
@@ -18751,10 +18787,18 @@ static bool fmSdTryMount() {
   // Explicit user retries clear the backoff first (fmSdMountOrFormatCb).
   if (s_sd_retry_after_ms && millis() < s_sd_retry_after_ms) return false;
 #if defined(TLORA_PAGER)
-  if (!pagerSdCardPresent()) return false;
+  if (sdRuntimeLifecycleBusy()) return false;
+  if (!board.sdCardPresent()) return false;
 #endif
   SPIClass* spi = sdSharedSPI();
   if (!spi) return false;
+#if defined(TLORA_PAGER)
+  // Vendor-compatible Pager sequence: the shared display/radio bus is already
+  // running, all other CS lines are parked HIGH, and the card gets one 4 MHz
+  // mount attempt. Never tear down that live shared bus or add a retry ladder.
+  const bool begin_ok = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6);
+  const bool mounted = begin_ok && SD.cardType() != CARD_NONE;
+#else
   // Cold microSD cards — especially the first mount after boot — often fail
   // the initial SD.begin and historically only recovered after a physical
   // reinsert (which power-cycles the card). The T-Deck shares ONE power rail
@@ -18816,19 +18860,41 @@ static bool fmSdTryMount() {
       }
     }
   }
+#endif
   if (mounted) {
     s_sd_mounted = true;
     s_sd_size = SD.cardSize();
     s_sd_retry_after_ms = 0;                    // clear any prior backoff
     markSdIo();                                 // mount touched the card -> blip the LED
+#if defined(TLORA_PAGER)
+    // History stays pinned to the backend loaded during UITask::begin(); a
+    // later mount only restores the independently SD-backed data consumers.
+    s_sd_data_warn_next_ms = 0;
+#endif
     return true;
   }
+#if defined(TLORA_PAGER)
+  if (begin_ok) {
+    // Clean up only the unusable VFS created by our quiescent mount attempt.
+    // SD.end() leaves the display/radio SPIClass running.
+    SD.end();
+  }
+  sdPagerParkCs();
+#else
   SD.end();                                     // clean up on failure
+#endif
   s_sd_retry_after_ms = millis() + 10000;       // back off so we don't hammer the card
   return false;
 }
 static void fmSdUnmount() {
-  if (s_sd_mounted) { SD.end(); s_sd_mounted = false; s_sd_size = 0; }
+  if (s_sd_mounted) {
+    SD.end();
+#if defined(TLORA_PAGER)
+    sdPagerParkCs();
+#endif
+    s_sd_mounted = false;
+    s_sd_size = 0;
+  }
   s_sd_retry_after_ms = 0;   // a reinsert should be able to mount right away
 }
 // True when the card still answers real I/O. SD.cardType() is useless for this:
@@ -19014,8 +19080,10 @@ static void fmFullPath(const char* name, char* out, size_t outsz) {
   else                             snprintf(out, outsz, "%s/%s", s_fm_path, name);
 }
 
-// Recursively delete a file or directory tree.
-static void fmRmRecursive(fs::FS* fs, const char* path) {
+// Recursively delete a file or directory tree. Return false immediately when
+// an entry cannot be removed; rewinding onto the same undeletable FAT entry
+// forever would hang factory reset with its watchdog intentionally suspended.
+static bool fmRmRecursive(fs::FS* fs, const char* path) {
   File d = fs->open(path);
   const bool isdir = d && d.isDirectory();
   if (isdir) {
@@ -19035,15 +19103,16 @@ static void fmRmRecursive(fs::FS* fs, const char* path) {
       const bool have = (base[0] != '\0');
       if (have) snprintf(child, sizeof child, "%s/%s", path, base);
       e.close();
-      if (!have) break;                 // nameless entry — don't spin forever
-      if (cdir) fmRmRecursive(fs, child); else fs->remove(child);
+      if (!have) { d.close(); return false; }
+      const bool removed = cdir ? fmRmRecursive(fs, child) : fs->remove(child);
+      if (!removed) { d.close(); return false; }
       d.rewindDirectory();
     }
     d.close();
-    fs->rmdir(path);
+    return fs->rmdir(path);
   } else {
     if (d) d.close();
-    fs->remove(path);
+    return fs->remove(path);
   }
 }
 
@@ -20149,7 +20218,8 @@ static void fmShowRoots() {
   // The card-detect line makes "not present" unambiguous, unlike the T-Deck (no detect
   // pin at all) -- so unlike its always-shown "tap to mount/format" fallback row, a bare
   // pager just shows no SD row at all rather than a row that can never succeed.
-  if (pagerSdCardPresent() && (s_sd_mounted || millis() >= s_sd_retry_after_ms) && fmSdTryMount()) {
+  if (board.sdCardPresent() && (s_sd_mounted || millis() >= s_sd_retry_after_ms) &&
+      fmSdTryMount() && s_sd_mounted) {
     char sdl[48], cs[16];
     fmFmtSize64(s_sd_size, cs, sizeof cs);
     snprintf(sdl, sizeof sdl, TR("SD card   %s"), cs);
@@ -23807,6 +23877,12 @@ static QueueHandle_t     s_tile_fetch_queue   = nullptr;
 static TaskHandle_t      s_tile_fetch_task    = nullptr;
 static volatile bool     s_tile_fetch_dirty   = false;
 volatile uint16_t s_tile_fetch_pending = 0;   // non-static: tdeckPlayNotify reads it via extern (above)
+#if defined(TLORA_PAGER)
+// Card-detect sets this before the VFS can be unmounted. It stops producers and
+// lets the worker discard its queued SD jobs, so the lifecycle gate converges
+// instead of being kept busy forever by a map that is still requesting tiles.
+static volatile bool     s_pager_sd_removal_pending = false;
+#endif
 static volatile uint16_t s_tile_fetch_ok      = 0;
 static volatile uint16_t s_tile_fetch_failed  = 0;
 // On-screen heartbeat: bumped each loop iteration of the fetch task so we
@@ -24977,9 +25053,13 @@ static void tileFetchTaskFn(void* arg) {
       if (luaNetWorkerPending()) { luaNetWorkerService(&client, &http); continue; }
     }
 #endif
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
     // microSD usage for the About page — the FAT scan runs here, off the UI thread.
     if (s_sdinfo_request) {
+      // Publish busy before clearing request so the loop task never observes a
+      // false/false gap and tears down the VFS underneath totalBytes/usedBytes.
+      s_sdinfo_busy = true;
+      __sync_synchronize();
       s_sdinfo_request = false;
       if (SD.cardType() != CARD_NONE) {
         const uint64_t t = SD.totalBytes(), u = SD.usedBytes();
@@ -24988,6 +25068,7 @@ static void tileFetchTaskFn(void* arg) {
         s_sdinfo_ok = false;
       }
       s_sdinfo_done = true;
+      s_sdinfo_busy = false;
       continue;
     }
 #endif
@@ -25052,6 +25133,15 @@ static void tileFetchTaskFn(void* arg) {
     // disk (the prefetch now enqueues without stat'ing) would otherwise be a
     // tight no-yield loop of tileCacheExists() and could starve core-0 IDLE.
     vTaskDelay(1);
+#if defined(TLORA_PAGER)
+    if (s_pager_sd_removal_pending && s_tile_fs == &SD) {
+      s_tile_fetch_last_wr = 'R';
+      ++s_tile_fetch_failed;
+      tileFetchForget(req.z, req.x, req.y);
+      if (s_tile_fetch_pending > 0) --s_tile_fetch_pending;
+      continue;
+    }
+#endif
     if (WiFi.status() != WL_CONNECTED) {
       WIRE_DBG("[TILE] skip z=%u x=%ld y=%ld: WiFi down\n",
                     (unsigned)req.z, (long)req.x, (long)req.y);
@@ -25171,7 +25261,11 @@ static void tileFetchTaskFn(void* arg) {
       s_tile_fetch_step = 'd';
       s_tile_fetch_last_wr = 'e';                  // HTTP error (code shown as "http" on the map)
     }
-    if (code == HTTP_CODE_OK) {
+    bool sd_cache_available = true;
+#if defined(TLORA_PAGER)
+    sd_cache_available = !(s_pager_sd_removal_pending && s_tile_fs == &SD);
+#endif
+    if (code == HTTP_CODE_OK && sd_cache_available) {
       s_tile_fetch_step = 'r';
       int content_len = http.getSize();
       // Sanity cap — refuse anything > 100 KB. Tiles are typically 10-30 KB.
@@ -25399,6 +25493,9 @@ static void queueTileForFetch(uint8_t z, int32_t x, int32_t y) {
   if (s_map_style == 0 && s_tiles_from_sd && s_tile_fs != &SD) return;
 #else
   if (s_map_style == 0 && s_tiles_from_sd) return;
+#endif
+#if defined(TLORA_PAGER)
+  if (s_pager_sd_removal_pending && s_tile_fs == &SD) return;
 #endif
   if (WiFi.status() != WL_CONNECTED) return;
   if (tileFetchSeen(z, x, y)) return;
@@ -25640,7 +25737,23 @@ static void freeMapTiles() {
 //     outage are retried instead of being remembered as in-flight forever
 //   * re-renders immediately when the map is the visible tab
 static void mapNoteStorageChanged() {
-#if CAP_SD
+#if defined(TLORA_PAGER)
+  if (!s_sd_mounted && s_tile_fs == &SD) {
+    s_tile_fs = nullptr;
+    s_tile_root[0] = '\0';
+    if (s_tile_fs_default == &SD) {
+      s_tile_fs_default = nullptr;
+      s_tile_root_default[0] = '\0';
+    }
+    s_tiles_fs_ready = false;
+  } else if (s_sd_mounted && !s_tiles_fs_ready) {
+    s_tile_fs = &SD;
+    s_tile_root[0] = '\0';
+    s_tile_fs_default = &SD;
+    s_tile_root_default[0] = '\0';
+    s_tiles_fs_ready = true;
+  }
+#elif CAP_SD
   if (s_sd_mounted && !s_tiles_fs_ready) {
     // No tile backend was resolved at boot; the card can serve as one now
     // (same layout the boot fallback uses: SD ROOT /tiles/<z>/<x>/<y>).
@@ -34395,7 +34508,7 @@ static void serviceLockscreen() {
 }
 #endif  // core lock screen (HAS_TDECK_GT911 || HAS_TANMATSU)
 
-#if CAP_SOUND_FILES   // custom WAV notification sounds -- T-Deck (SD/SPIFFS) or pager (SPIFFS only)
+#if CAP_SOUND_FILES   // custom WAV notification sounds -- T-Deck/pager (SD or SPIFFS)
 // ---- Notification-sound chooser (Settings -> Sound) ------------------------
 // Tapping a slot button opens a small menu: "Choose .wav from files" (opens the
 // File Manager, exactly like the wallpaper picker; opening a .wav there offers
@@ -34958,42 +35071,19 @@ static void backupDeleteCb(lv_event_t* e) {
   showConfirm(TR("Delete this backup file?\nThis cannot be undone."), TR("Delete"), doDeleteBackup);
 }
 
-#if CAP_SD
+#if CAP_SD || defined(TLORA_PAGER)
 // Wipe the SD data folder (/meshcomod/*) — identity, prefs, logs, telemetry, and
 // any orphaned pre-#20 /meshcomod/tiles cache. The live Wi-Fi tile cache + offline
 // packs now live at the SD ROOT (/tiles, /maps/osm), outside /meshcomod, so a
 // factory reset keeps the map tiles automatically.
-static void factoryWipeSdData() {
-  if (!fmSdTryMount()) return;
-  File d = SD.open("/meshcomod");
-  if (!d || !d.isDirectory()) { if (d) d.close(); return; }
-  // Collect the entries to wipe FIRST, then delete. Removing during the
-  // openNextFile() walk skips entries on FatFS — a partial wipe is what left
-  // data behind after a factory reset.
-  static const int kMax = 24;
-  char names[kMax][48];
-  bool dirs[kMax];
-  int n = 0;
-  File e = d.openNextFile();
-  while (e && n < kMax) {
-    const char* full = e.name();
-    const char* base = strrchr(full, '/'); base = base ? base + 1 : full;
-    if (base[0]) {
-      strncpy(names[n], base, sizeof(names[n]) - 1);
-      names[n][sizeof(names[n]) - 1] = '\0';
-      dirs[n] = e.isDirectory();
-      ++n;
-    }
-    e.close();
-    e = d.openNextFile();
-  }
-  if (e) e.close();
-  d.close();
-  for (int i = 0; i < n; ++i) {
-    char child[200];
-    snprintf(child, sizeof child, "/meshcomod/%s", names[i]);
-    if (dirs[i]) fmRmRecursive(&SD, child); else SD.remove(child);
-  }
+static bool factoryWipeSdData() {
+  if (!fmSdTryMount() || !sdProbeAlive()) return false;
+  if (!SD.exists("/meshcomod"))
+    return sdProbeAlive() && !SD.exists("/meshcomod");
+  fmRmRecursive(&SD, "/meshcomod");
+  // A failed FAT operation can make exists() look false too, so verify the
+  // card still answers real I/O before accepting the destructive operation.
+  return sdProbeAlive() && !SD.exists("/meshcomod");
 }
 #endif
 
@@ -35015,8 +35105,51 @@ static void doFactoryReset() {
   delay(150);                      // let the overlay actually hit the panel
   wdtHeavyBegin();                 // SPIFFS format is a long flash burst
   touchPrefsFlush();               // do not format under an open prefs worker handle
-#if CAP_SD
-  factoryWipeSdData();             // SD /meshcomod data (tiles at /tiles root are kept)
+  uiHistWaitWorkerIdle();          // do not erase under an open history handle
+  if (s_hist_flush_busy) {
+    wdtHeavyEnd();
+    lv_obj_del(ov);
+    if (g_lv.task) {
+      g_lv.task->flushHistorySoon();
+      g_lv.task->showAlert(TR("Factory reset blocked: storage is busy"), 2600);
+    }
+    return;
+  }
+#if CAP_SD || defined(TLORA_PAGER)
+#if defined(TLORA_PAGER)
+  if (sdRuntimeLifecycleBusy()) {
+    wdtHeavyEnd();
+    lv_obj_del(ov);
+    if (g_lv.task) {
+      g_lv.task->flushHistorySoon();
+      g_lv.task->showAlert(TR("Factory reset blocked: SD is busy; retry"), 2600);
+    }
+    return;
+  }
+#endif
+  s_sd_retry_after_ms = 0;         // explicit reset request bypasses mount backoff
+  const bool sd_wiped = factoryWipeSdData();   // keeps root-level /tiles and /maps
+#if defined(TLORA_PAGER)
+  // Never erase internal identity/NVS while a positively detected or still-
+  // mounted card may hold the old /meshcomod identity. An UNKNOWN detect with
+  // no live card falls back to CARD_NONE so a failed XL9555 does not permanently
+  // disable the Pager's only factory-reset path.
+  const TLoraPagerBoard::SdCardState sd_state = board.sdCardState();
+  const bool card_may_still_hold_data =
+      sd_state == TLoraPagerBoard::SdCardState::Present ||
+      (sd_state == TLoraPagerBoard::SdCardState::Unknown && SD.cardType() != CARD_NONE);
+  if (!sd_wiped && card_may_still_hold_data) {
+    wdtHeavyEnd();
+    lv_obj_del(ov);
+    if (g_lv.task) {
+      g_lv.task->flushHistorySoon();
+      g_lv.task->showAlert(TR("Factory reset blocked: SD wipe failed; remove card and retry"), 4200);
+    }
+    return;
+  }
+#else
+  (void)sd_wiped;
+#endif
 #endif
   the_mesh.uiFactoryReset();       // SPIFFS.format() + nvs_flash_erase()
   ESP.restart();                   // fresh boot: new identity + first-boot wizard
@@ -43570,8 +43703,42 @@ void UITask::flushHistoryIfDue(unsigned long now) {
 // the chat to the SD card.
 static fs::FS* s_ui_data_fs       = nullptr;
 static char    s_ui_data_root[16] = "";
+#if defined(TLORA_PAGER)
+static bool    s_ui_data_boot_finalized = false;
+#endif
+// History stays on the filesystem selected during UITask::begin() for the
+// whole boot. Switching a live ring from SPIFFS to a newly inserted card can
+// purge history that was never loaded into RAM; switching a 5000-record SD ring
+// to SPIFFS can fill the small internal partition.
+#if defined(TLORA_PAGER)
+static bool uiHistoryStoreExists(fs::FS& fs, const char* root) {
+  const char* files[] = {
+    k_ui_threads_path, k_ui_msgs_path, k_ui_history_path, k_ui_seg_ok,
+  };
+  char path[64];
+  for (const char* file : files) {
+    snprintf(path, sizeof path, "%s%s", root, file);
+    if (fs.exists(path)) return true;
+  }
+  return false;
+}
+#endif
 static bool uiDataFsReady() {
   if (s_ui_data_fs != nullptr) return true;   // cache SUCCESS only — a failed resolve MUST stay retryable
+#if defined(TLORA_PAGER)
+  if (s_ui_data_boot_finalized) {
+    // Never adopt unseen card history after the boot loader has finished, but
+    // keep retrying the already-loaded internal backend if its first mount was
+    // transiently unavailable. This avoids a RAM-only history session without
+    // risking a switch to a card whose history was never loaded.
+    if (SPIFFS.begin(false)) {
+      s_ui_data_fs = &SPIFFS;
+      s_ui_data_root[0] = '\0';
+      return true;
+    }
+    return false;
+  }
+#endif
 #if defined(HAS_TANMATSU) || defined(HAS_TDISPLAY_P4)
   // Tanmatsu + T-Display P4: prefer the microSD card. On the Tanmatsu the internal FFat 'locfd'
   // loses frequently-rewritten data (broken FAT metadata; see the tile-cache notes); on the
@@ -43592,13 +43759,27 @@ static bool uiDataFsReady() {
     strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
     return true;
   }
+#elif defined(TLORA_PAGER)
+  // Prefer an existing card history. On upgrade, however, an empty card must
+  // not hide a Pager history that already lives in SPIFFS; keep using that
+  // established store instead of silently re-homing it without a migration.
+  if (fmSdTryMount()) {
+    const bool sd_has_history = uiHistoryStoreExists(SD, "/meshcomod");
+    const bool spiffs_ready = SPIFFS.begin(false);
+    if (!sd_has_history && spiffs_ready && uiHistoryStoreExists(SPIFFS, "")) {
+      s_ui_data_fs = &SPIFFS;
+      s_ui_data_root[0] = '\0';
+      return true;
+    }
+    SD.mkdir("/meshcomod");
+    s_ui_data_fs = &SD;
+    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+    return true;
+  }
+  if (SPIFFS.begin(false)) { s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0'; return true; }
 #elif defined(HAS_TDECK_GT911)
-  // T-Deck: the SD card is the persistent user-data store (large, removable,
-  // survives a reflash) and is where chat history already lives. Prefer it; only
-  // fall back to internal SPIFFS if no card is present. (Do NOT format/prefer
-  // SPIFFS here — doing so orphaned the on-SD history.)
-  if (SD.cardType() != CARD_NONE || fmSdTryMount()) {
-    s_sd_mounted = true;
+  // T-Deck: the SD card is the established persistent history store.
+  if (sdAdoptLiveMount() || fmSdTryMount()) {
     SD.mkdir("/meshcomod");
     s_ui_data_fs = &SD;
     strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
@@ -43691,7 +43872,7 @@ static bool uiDataFsIsSdCard() {
   if (!uiDataFsReady()) return false;
 #if defined(HAS_TANMATSU) || defined(HAS_TDISPLAY_P4)
   return s_ui_data_fs == &SD_MMC;
-#elif defined(HAS_TDECK_GT911)
+#elif defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
   return s_ui_data_fs == &SD;
 #else
   return false;
@@ -43708,7 +43889,7 @@ static File uiDataOpen(const char* name, const char* mode) {
   if (!uiDataFsReady()) return File();
   char p[80]; snprintf(p, sizeof p, "%s%s", s_ui_data_root, name);
   File f = s_ui_data_fs->open(p, mode);
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
   // A failed WRITE open on the SD-backed history store is the wedge tell (reads
   // fail legitimately on first boot). Called from the loop task AND the core-0
   // history worker — sdNoteIoFailure is a volatile stamp, safe from both.
@@ -44333,7 +44514,7 @@ static bool uiMsgsWriteResult(bool ok) {
     s_msgs_write_fail_ms = m ? m : 1;
     s_msgs_write_fail_epoch = ep;
     if (s_msgs_write_fails < 0xFFFFu) s_msgs_write_fails = s_msgs_write_fails + 1;
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
     if (s_ui_data_fs == &SD) sdNoteIoFailure();
 #endif
   }
@@ -45730,7 +45911,14 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   if (_sensors && _node_prefs && _node_prefs->gps_enabled) {
     _sensors->setSettingValue("gps", "1");
   }
+#if defined(TLORA_PAGER)
+  // T-Deck's portable preference has no matching Pager toggle (CAP_SD=0).
+  // Ignore it here: the Pager still uses SD as its automatic cache fallback,
+  // but a card moved from a T-Deck cannot silently disable all online fetches.
+  s_tiles_from_sd = false;
+#else
   s_tiles_from_sd = touchPrefsGetTilesFromSd();   // map tile source: server (default) vs microSD
+#endif
   s_map_night = touchPrefsGetMapNight();          // map night mode (render-time tile invert)
   s_map_show_coords   = touchPrefsGetMapShowCoords();     // per-element map text/marker visibility
   s_map_show_tilexyz  = touchPrefsGetMapShowTileXYZ();
@@ -45777,6 +45965,13 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     setenv("TZ", tz, 1);
     tzset();
   }
+
+#if defined(TLORA_PAGER)
+  // Boot storage setup may have mounted SD before UITask starts. Synchronize
+  // the UI's lifecycle state before tile-backend selection and before the
+  // first loop tick can run health/remount logic.
+  sdAdoptLiveMount();
+#endif
 
   // Mount the dedicated tiles LittleFS partition. formatOnFail=true so a
   // pristine partition (all-0xFF after the partition-table upgrade) gets
@@ -45836,8 +46031,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   // fmSdTryMount() unconditionally would SD.end()+remount the card mid-boot and
   // can fail while DataStore holds the volume — which left the map stuck on the
   // storage error. Only walk the mount ladder if the card isn't already up.
-  else if (SD.cardType() != CARD_NONE || fmSdTryMount()) {
-    s_sd_mounted = true;     // trust the live mount; skip future remount ladders
+  else if (sdAdoptLiveMount() || fmSdTryMount()) {
     s_tile_fs = &SD;
     s_tile_root[0] = '\0';   // cache to the SD ROOT /tiles/<z>/<x>/<y>.jpg — the same place
                              // the offline library + microSD-tile mode use, so the Wi-Fi cache
@@ -45853,8 +46047,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   // dedicated "tiles" partition — so the LittleFS mount above fails and the map showed
   // "Reflash the tiles partition". Fall back to the microSD card like the T-Deck: cache
   // Wi-Fi tiles to the SD ROOT /tiles/<z>/<x>/<y>.jpg (merges with any offline /maps library).
-  else if (SD.cardType() != CARD_NONE || fmSdTryMount()) {
-    s_sd_mounted     = true;
+  else if (fmSdTryMount()) {
     s_tile_fs        = &SD;
     s_tile_root[0]   = '\0';
     s_tiles_fs_ready = true;
@@ -45917,8 +46110,7 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   s_tile_fs_default = s_tile_fs;
   strncpy(s_tile_root_default, s_tile_root, sizeof s_tile_root_default - 1);
 #if CAP_SD
-  if (s_tiles_from_sd && (SD.cardType() != CARD_NONE || fmSdTryMount())) {
-    s_sd_mounted = true;
+  if (s_tiles_from_sd && (sdAdoptLiveMount() || fmSdTryMount())) {
     s_tile_fs = &SD;
     s_tile_root[0] = '\0';
     WIRE_DBG("[TILE] microSD-tile mode -> caching Wi-Fi tiles on SD /tiles (merges with library)");
@@ -46096,6 +46288,12 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _msgs_dirty = false;
   _next_msgs_flush_ms = 0;
   loadHistoryFromStorage();
+#if defined(TLORA_PAGER)
+  // From here on, the loaded ring and its filesystem are one atomic history
+  // generation. If no backing store was available, wait for a reboot rather
+  // than adopting an inserted card whose on-disk history was never loaded.
+  s_ui_data_boot_finalized = true;
+#endif
   _next_mesh_thread_refresh = millis() + 2000;
   refreshThreadsFromMesh();
   _touch_screen = TouchUiScreen::Home;
@@ -47899,20 +48097,64 @@ static inline void uiCp(const char* next) {
 }
 
 #if CAP_SD || defined(TLORA_PAGER)
+// A mount lifecycle change invalidates every open FAT handle, so it must wait
+// until all UI-side and worker-side SD consumers are quiescent. SPI transaction
+// locking arbitrates individual transfers; this predicate arbitrates VFS lifetime.
+static bool sdRuntimeLifecycleBusy() {
+  bool busy = s_hist_flush_busy || s_hist_flush_req || s_sdinfo_request ||
+              s_sdinfo_busy ||
+              touchPrefsIoBusy();
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+  busy = busy || s_notify_playing ||
+         (s_tile_fs == &SD && s_tile_fetch_pending > 0);
+#endif
+  return busy;
+}
+
 // Runtime SD wedge detect + recover. Some writer saw an SD write fail while the
 // card was supposedly mounted (sdNoteIoFailure) — verify with real I/O and,
-// if the card stopped answering, drop the mount and re-run the full mount
-// ladder (SD.end() + staged SD.begin): exactly what the next reboot would do,
-// minus the reboot. Without this the firmware is blind to a wedged card:
+// if the card stopped answering, drop and remount it once all SD consumers are
+// quiescent. Without this the firmware is blind to a wedged card:
 // SD.cardType() keeps returning its cached mount-time type, s_sd_mounted stays
 // true so fmSdTryMount() no-ops, and every SD feature fails silently until the
 // user power-cycles (the "SD stops working until reboot" report).
 static void sdHealthTick() {
   static uint32_t s_next_probe_ms    = 0;
   static uint32_t s_next_bg_probe_ms = 0;
+#if defined(TLORA_PAGER)
+  static uint32_t s_next_detect_ms   = 0;
+  static uint32_t s_absent_first_ms  = 0;
+  static uint8_t  s_absent_samples   = 0;
+#endif
   const uint32_t now = (uint32_t)millis();
+#if defined(TLORA_PAGER)
+  if (!s_sd_mounted && !sdRuntimeLifecycleBusy() && sdAdoptLiveMount()) {
+    s_sd_data_warn_next_ms = 0;
+    if (!s_ui_data_fs) uiDataFsReady();
+    if (s_ui_data_fs == &SD) {
+      SD.mkdir("/meshcomod");
+      uiDataEnsureDirs();
+      if (g_lv.task) g_lv.task->flushHistorySoon();
+    }
+    mapNoteStorageChanged();
+    return;
+  }
+#endif
   if (!s_sd_mounted) {
+#if defined(TLORA_PAGER)
+    // Another loop-side owner (notably the open File Manager) may have won the
+    // quiescent unmount race after card-detect marked removal pending.
+    s_pager_sd_removal_pending = false;
+#endif
     s_sd_fail_note_ms = 0;
+#if defined(TLORA_PAGER)
+    extern bool g_contacts_on_sd;
+    if (g_contacts_on_sd && !touchSleep::isSleeping() &&
+        (!s_sd_data_warn_next_ms || (int32_t)(now - s_sd_data_warn_next_ms) >= 0)) {
+      s_sd_data_warn_next_ms = sdDataWarnDeadline(now);
+      if (g_lv.task) g_lv.task->showAlert(sdRemovedAlertText(), 5000);
+    }
+#endif
     // Reinsert watch. After a failed remount ("SD card lost") the SD VFS is
     // unregistered and NOTHING outside the file manager ever re-runs a mount
     // — a reinserted card then LOOKED recovered (battery quietly falls back
@@ -47924,41 +48166,96 @@ static void sdHealthTick() {
     if (touchSleep::isSleeping()) return;
     if ((int32_t)(now - s_next_bg_probe_ms) < 0) return;
     s_next_bg_probe_ms = now + 30000;
+    if (s_fm_list) return;               // FM open: its 2 s poll owns remounting
+    if (sdRuntimeLifecycleBusy()) return;
 #if defined(TLORA_PAGER)
-    if (!pagerSdCardPresent()) return;   // card-detect says the slot is empty
+    if (!board.sdCardPresent()) return;  // card-detect says the slot is empty
 #endif
-    if (s_fm_list) return;               // FM open: its 2 s poll owns remounting (full ladder)
     SPIClass* spi = sdSharedSPI();
     if (!spi) return;
+#if defined(TLORA_PAGER)
+    // The Pager shares this SPIClass with display + radio: one 4 MHz attempt,
+    // with every other CS parked HIGH and no SD.end() of a potentially live bus.
+    const bool begin_ok = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6);
+    const bool remounted = begin_ok && SD.cardType() != CARD_NONE;
+#else
     SD.end();
-    if (SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6) && SD.cardType() != CARD_NONE) {
+    const bool remounted = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6) &&
+                           SD.cardType() != CARD_NONE;
+#endif
+    if (remounted) {
       s_sd_mounted        = true;
       s_sd_size           = SD.cardSize();
       s_sd_retry_after_ms = 0;
+#if defined(TLORA_PAGER)
+      s_sd_data_warn_next_ms = 0;
+#endif
       markSdIo();
       if (g_lv.task) g_lv.task->showAlert(TR("SD card remounted"), 1800);
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
       // Land the RAM ring on the card promptly, not up to 30+ s later: every
       // message received while the card was out is only in RAM. Armed as an
       // OFF-THREAD flush — a synchronous write here froze the UI for >30 s on
       // a card that mounts fine but times out on large writes. mkdir first —
       // a fresh replacement card has no /meshcomod yet, and without it every
       // history flush fails silently.
-      SD.mkdir("/meshcomod");
-      uiDataEnsureDirs();   // segment dir too — a fresh replacement card has neither
-      if (g_lv.task) g_lv.task->flushHistorySoon();
+      if (!s_ui_data_fs) uiDataFsReady();
+      if (s_ui_data_fs == &SD) {
+        SD.mkdir("/meshcomod");
+        uiDataEnsureDirs();   // segment dir too — a fresh replacement card has neither
+        if (g_lv.task) g_lv.task->flushHistorySoon();
+      }
 #endif
       mapNoteStorageChanged();   // the map layer has to be told too, or it stays blank
     } else {
+#if defined(TLORA_PAGER)
+      if (begin_ok) SD.end();             // release only our failed, quiescent mount
+      sdPagerParkCs();
+#else
       SD.end();                          // leave cardType() honestly CARD_NONE
+#endif
     }
     return;
   }
   if (s_sd_format_pending) return;                        // format owns the card right now
-  // Hold off while the core-0 worker is (or may be about to be) on the card —
-  // SD.end() under an open worker file handle is the crash we must not add.
+#if defined(TLORA_PAGER)
+  // Card detect is pure I2C, so it must keep running even while an SD worker is
+  // busy. Once removal is confirmed, stop new SD tile jobs immediately; the
+  // worker discards its queued jobs and the normal lifecycle gate waits only
+  // for the genuinely in-flight operation before SD.end().
+  if (!s_pager_sd_removal_pending && (int32_t)(now - s_next_detect_ms) >= 0) {
+    s_next_detect_ms = now + 500;
+    const TLoraPagerBoard::SdCardState state = board.sdCardState();
+    if (state != TLoraPagerBoard::SdCardState::Absent) {
+      // Present resets the debounce. Unknown also resets it so an I2C fault can
+      // never be accumulated into a destructive VFS teardown.
+      s_absent_samples = 0;
+      s_absent_first_ms = 0;
+    } else if (!s_absent_samples || (uint32_t)(now - s_absent_first_ms) > 1100) {
+      s_absent_samples = 1;
+      s_absent_first_ms = now;
+    } else if (++s_absent_samples >= 2) {
+      s_absent_samples = 0;
+      s_absent_first_ms = 0;
+      s_pager_sd_removal_pending = true;
+      sdNoteIoFailure();
+    }
+  }
+  if (s_pager_sd_removal_pending) {
+    if (sdRuntimeLifecycleBusy()) return;
+    fmSdUnmount();
+    s_pager_sd_removal_pending = false;
+    mapNoteStorageChanged();
+    s_sd_data_warn_next_ms = sdDataWarnDeadline(now);
+    if (!touchSleep::isSleeping() && g_lv.task)
+      g_lv.task->showAlert(sdRemovedAlertText(), 5000);
+    if (s_fm_list && (s_fm_fs == &SD || !s_fm_fs)) fmShowRoots();
+    return;
+  }
+#endif
+  // SD.end() under any open worker/UI file handle invalidates that handle.
   // On a truly wedged card the worker's own ops fail fast, so this clears.
-  if (s_hist_flush_busy || s_hist_flush_req || s_sdinfo_request || touchPrefsIoBusy()) return;
+  if (sdRuntimeLifecycleBusy()) return;
 #if defined(HAS_TDECK_GT911) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
   if (s_sdfw_request) return;     // worker streaming a firmware download to /BINS (T-Deck only)
 #endif
@@ -47985,18 +48282,29 @@ static void sdHealthTick() {
   if (sdProbeAlive()) return;     // transient failure (card full, bad path, ...) — not a wedge
   fmSdUnmount();                  // SD.end() so a fresh begin re-runs the full card handshake
   if (fmSdTryMount()) {
+#if defined(TLORA_PAGER)
+    s_sd_data_warn_next_ms = 0;
+#endif
     if (g_lv.task) g_lv.task->showAlert(TR("SD card remounted"), 1800);
-#if defined(HAS_TDECK_GT911)
-    SD.mkdir("/meshcomod");                            // fresh replacement card: recreate the data root
-    uiDataEnsureDirs();                                // segment dir too
-    if (g_lv.task) g_lv.task->flushHistorySoon();      // land the RAM ring promptly (off-thread — no UI stall)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+    if (!s_ui_data_fs) uiDataFsReady();
+    if (s_ui_data_fs == &SD) {
+      SD.mkdir("/meshcomod");                          // fresh replacement card: recreate the data root
+      uiDataEnsureDirs();                              // segment dir too
+      if (g_lv.task) g_lv.task->flushHistorySoon();    // land the RAM ring promptly (off-thread — no UI stall)
+    }
 #endif
     mapNoteStorageChanged();
   } else {
-    // Ladder failed — card needs a real power cycle (reinsert). s_sd_mounted is
+    // Remount failed — card needs a real power cycle (reinsert). s_sd_mounted is
     // now false and SD.cardType() reads CARD_NONE, so features degrade honestly
     // instead of silently failing, and the usual remount paths keep retrying.
+#if defined(TLORA_PAGER)
+    s_sd_data_warn_next_ms = sdDataWarnDeadline(now);
+    if (g_lv.task) g_lv.task->showAlert(sdRemovedAlertText(), 5000);
+#else
     if (g_lv.task) g_lv.task->showAlert(TR("SD card lost - reinsert to recover"), 2600);
+#endif
     mapNoteStorageChanged();   // drop tiles read off the card that just went away
   }
 }
@@ -48439,8 +48747,8 @@ void UITask::loop() {
 #if CAP_SD || defined(TLORA_PAGER)
   sdHealthTick();   // wedge detect + remount, driven by writer-flagged failures (any task)
   // microSD insert/remove detection — only while the file manager is open, so
-  // there's no idle SPI traffic. SD.begin runs on this loop task (never
-  // concurrent with the radio's SPI), and reuses the radio's already-begun bus.
+  // there's no idle SPI traffic. Lifecycle changes run on this loop task; each
+  // device transfer uses the shared SPIClass's transaction arbitration.
   if (s_fm_list) {
     static unsigned long s_sd_poll_next = 0;
     if (now >= s_sd_poll_next) {
@@ -48448,27 +48756,33 @@ void UITask::loop() {
       if (!s_sd_mounted) {
         // Only re-probe after the backoff window — repeatedly re-initing an
         // unmountable card spikes current / churns the bus and can reset the board.
-        if (now >= s_sd_retry_after_ms && fmSdTryMount()) {
+        if (!sdRuntimeLifecycleBusy() && now >= s_sd_retry_after_ms && fmSdTryMount()) {
           showAlert(TR("SD card inserted"), 1500);
-#if defined(HAS_TDECK_GT911)
-          SD.mkdir("/meshcomod");   // fresh replacement card: recreate the data root
-          uiDataEnsureDirs();        // segment dir too
-          flushHistorySoon();       // land the RAM ring promptly (off-thread — no UI stall)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+          if (!s_ui_data_fs) uiDataFsReady();
+          if (s_ui_data_fs == &SD) {
+            SD.mkdir("/meshcomod"); // fresh replacement card: recreate the data root
+            uiDataEnsureDirs();      // segment dir too
+            flushHistorySoon();     // land the RAM ring promptly (off-thread — no UI stall)
+          }
 #endif
           mapNoteStorageChanged();
           if (!s_fm_fs) fmShowRoots();          // refresh roots so it appears
         }
-      } else if (!s_hist_flush_busy && !s_hist_flush_req && !sdProbeAlive()) {
+      } else if (!sdRuntimeLifecycleBusy() && !sdProbeAlive()) {
         // Real-I/O probe, NOT `SD.cardType() == CARD_NONE`: cardType() is cached
         // at mount and only SD.end() ever resets it, so the old check could never
         // fire — neither a yanked card nor a wedged one was ever detected here.
-        // Never probe/unmount under an in-flight history flush: SD.end() while
-        // the flush holds its open temp file leaves a stale FIL, and every
-        // later write on it fails FR_INVALID_OBJECT -> EBADF ("bad file
-        // number") — recovery must not sabotage the very write it protects.
+        // Never probe/unmount while any SD consumer is active: SD.end() leaves
+        // its open FAT handle stale and recovery would sabotage that operation.
         fmSdUnmount();
         mapNoteStorageChanged();
+#if defined(TLORA_PAGER)
+        s_sd_data_warn_next_ms = sdDataWarnDeadline(now);
+        showAlert(sdRemovedAlertText(), 5000);
+#else
         showAlert(TR("SD card removed"), 1500);
+#endif
         if (s_fm_fs == &SD || !s_fm_fs) fmShowRoots();
       }
     }

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10883,6 +10883,7 @@ extern bool meshcomodMigrateSpiffsToSd(bool force);   // main.cpp
 extern bool meshcomodArmSdMigLatch();                  // durable in-progress guard
 extern void meshcomodClearSdMigLatch();               // main.cpp (GH #142/#148 boot safe-mode)
 extern bool g_sd_migration_blocked;
+extern bool g_full_data_on_sd;                         // boot chose SD for identity/prefs
 static bool sdRuntimeLifecycleBusy();
 static bool s_sd_restore_pending = false;
 
@@ -10908,6 +10909,7 @@ static void sdRestoreRun() {
   // snapshots must both be idle before the migration opens either filesystem.
   g_lv.task->persistHistoryNow();
   discoveredFlushNow();
+  the_mesh.flushContactsIfDirty();
   if (!touchPrefsFlush()) {
     g_sd_migration_blocked = true;
     g_lv.task->showAlert(TR("Copy blocked: internal data is busy"), 2600);
@@ -43814,6 +43816,17 @@ static bool uiDataFsReady() {
   if (s_ui_data_fs != nullptr) return true;   // cache SUCCESS only — a failed resolve MUST stay retryable
 #if defined(TLORA_PAGER)
   if (s_ui_data_boot_finalized) {
+    // A boot-adopted card owns the active identity/profile. Never fall back to
+    // another profile's internal history if that card becomes unavailable.
+    if (g_full_data_on_sd) {
+      if (fmSdTryMount()) {
+        SD.mkdir("/meshcomod");
+        s_ui_data_fs = &SD;
+        strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+        return true;
+      }
+      return false;
+    }
     // Never adopt unseen card history after the boot loader has finished, but
     // keep retrying the already-loaded internal backend if its first mount was
     // transiently unavailable. This avoids a RAM-only history session without
@@ -43847,6 +43860,16 @@ static bool uiDataFsReady() {
     return true;
   }
 #elif defined(TLORA_PAGER)
+  // Follow the boot loader's primary-profile decision. An established card may
+  // legitimately predate the migration marker; falling back to SPIFFS history
+  // in that case would expose and update another identity's conversations.
+  if (g_full_data_on_sd) {
+    if (!fmSdTryMount()) return false;
+    SD.mkdir("/meshcomod");
+    s_ui_data_fs = &SD;
+    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+    return true;
+  }
   // Prefer an existing card history. On upgrade, however, an empty card must
   // not hide a Pager history that already lives in SPIFFS; keep using that
   // established store instead of silently re-homing it without a migration.

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -27193,7 +27193,7 @@ static void openMapOptions() {
   lv_obj_set_pos(title, 0, 0);
   int y = 26;
 
-#if CAP_SD || defined(TLORA_PAGER)
+#if CAP_SD
   // Row: tile source — microSD (offline) vs the tile server. The important one,
   // so it sits at the very top.
   {
@@ -43893,40 +43893,16 @@ static bool uiDataFsReady() {
     strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
     return true;
   }
-  // A failed/incomplete reconciliation deliberately leaves the primary
-  // profile on internal flash. An older completion marker may still exist on
-  // the card, so it cannot be allowed to select SD history and recreate a
-  // split identity/history profile while the durable busy latch is armed.
-  if (g_sd_migration_blocked) {
-    if (SPIFFS.begin(false)) {
-      s_ui_data_fs = &SPIFFS;
-      s_ui_data_root[0] = '\0';
-      return true;
-    }
-    return false;
-  }
-  // Prefer an existing card history. On upgrade, however, an empty card must
-  // not hide a Pager history that already lives in SPIFFS; keep using that
-  // established store instead of silently re-homing it without a migration.
-  if (fmSdTryMount()) {
-    const bool sd_migration_complete = meshcomodSdMigrationComplete();
-    const bool sd_has_history = uiHistoryStoreExists(
-        SD, "/meshcomod", sd_migration_complete);
-    const bool spiffs_ready = SPIFFS.begin(false);
-    const bool spiffs_has_history =
-        spiffs_ready && uiHistoryStoreExists(SPIFFS, "");
-    if (spiffs_has_history &&
-        (!sd_migration_complete || !sd_has_history)) {
-      s_ui_data_fs = &SPIFFS;
-      s_ui_data_root[0] = '\0';
-      return true;
-    }
-    SD.mkdir("/meshcomod");
-    s_ui_data_fs = &SD;
-    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+  // The boot loader kept identity/preferences internal, either by user choice
+  // or because reconciliation failed closed. History must follow that same
+  // profile decision even when an inserted card carries a valid marker and
+  // history from another device. Never use foreign SD history as a fallback.
+  if (SPIFFS.begin(false)) {
+    s_ui_data_fs = &SPIFFS;
+    s_ui_data_root[0] = '\0';
     return true;
   }
-  if (SPIFFS.begin(false)) { s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0'; return true; }
+  return false;
 #elif defined(HAS_TDECK_GT911)
   // T-Deck: the SD card is the established persistent history store.
   if (sdAdoptLiveMount() || fmSdTryMount()) {

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -35130,14 +35130,12 @@ static void doFactoryReset() {
   s_sd_retry_after_ms = 0;         // explicit reset request bypasses mount backoff
   const bool sd_wiped = factoryWipeSdData();   // keeps root-level /tiles and /maps
 #if defined(TLORA_PAGER)
-  // Never erase internal identity/NVS while a positively detected or still-
-  // mounted card may hold the old /meshcomod identity. An UNKNOWN detect with
-  // no live card falls back to CARD_NONE so a failed XL9555 does not permanently
-  // disable the Pager's only factory-reset path.
+  // Never erase internal identity/NVS unless the card data was verifiably wiped
+  // or the slot is positively empty. UNKNOWN is not absence: a transient XL9555
+  // read failure can coincide with an inserted but temporarily unreadable card.
   const TLoraPagerBoard::SdCardState sd_state = board.sdCardState();
   const bool card_may_still_hold_data =
-      sd_state == TLoraPagerBoard::SdCardState::Present ||
-      (sd_state == TLoraPagerBoard::SdCardState::Unknown && SD.cardType() != CARD_NONE);
+      sd_state != TLoraPagerBoard::SdCardState::Absent;
   if (!sd_wiped && card_may_still_hold_data) {
     wdtHeavyEnd();
     lv_obj_del(ov);
@@ -43712,8 +43710,11 @@ static bool    s_ui_data_boot_finalized = false;
 // to SPIFFS can fill the small internal partition.
 #if defined(TLORA_PAGER)
 static bool uiHistoryStoreExists(fs::FS& fs, const char* root) {
+  // Thread metadata by itself is not a message store. It can land before a
+  // larger message file fails during SPIFFS -> SD migration; treating that one
+  // small file as authoritative would hide the complete SPIFFS history.
   const char* files[] = {
-    k_ui_threads_path, k_ui_msgs_path, k_ui_history_path, k_ui_seg_ok,
+    k_ui_msgs_path, k_ui_history_path, k_ui_seg_ok,
   };
   char path[64];
   for (const char* file : files) {

--- a/src/ui-touch/device_caps.h
+++ b/src/ui-touch/device_caps.h
@@ -39,17 +39,12 @@
   #define CAP_TOUCH        0   // no touchscreen — keyboard + rotary encoder nav only
   #define CAP_ROTATABLE    0   // fixed 480x222 landscape via hardware MADCTL rotation
   #define CAP_LARGE_SCREEN 0   // native 480x222, no UI upscaling
-  // CAP_SD/CAP_FILESYSTEM are 0 despite the hardware having a microSD slot:
-  // the code these caps gate (fmSdTryMount(), the #include <SD.h> block, the
-  // file manager's SD-vs-FFat backend selection) is still hardcoded to
-  // HAS_TDECK_GT911/HAS_TANMATSU specifically, never migrated to be CAP_SD-
-  // generic — turning these on here just hits "SD"/"CARD_NONE"/"fmSdTryMount"
-  // SD support shipped after this note was written: fmSdTryMount has a pager branch
-  // (TFT_eSPI shared SPIClass + XL9555 card-detect) and the tile cache falls back to the
-  // card under Launcher. Flags flipped for #193 so the Files app + "Store data on SD"
-  // machinery light up like the T-Deck's.
-  #define CAP_SD           1
-  #define CAP_FILESYSTEM   1
+  // Keep these structural caps at 0: they still gate several T-Deck-specific
+  // UI/features. Pager storage is wired explicitly at its audited call sites
+  // (boot DataStore, history, tiles, file manager and WAV playback) using its
+  // shared-SPI mount helper; formatting remains deliberately unavailable.
+  #define CAP_SD           0
+  #define CAP_FILESYSTEM   0
   #define CAP_GPS          1   // u-blox MIA-M10Q
   #define CAP_OTA          1   // dual-OTA partition layout, same shape as the T-Deck
   #define CAP_LOCK_SCREEN  1

--- a/src/ui-touch/device_caps.h
+++ b/src/ui-touch/device_caps.h
@@ -41,8 +41,9 @@
   #define CAP_LARGE_SCREEN 0   // native 480x222, no UI upscaling
   // Keep these structural caps at 0: they still gate several T-Deck-specific
   // UI/features. Pager storage is wired explicitly at its audited call sites
-  // (boot DataStore, history, tiles, file manager and WAV playback) using its
-  // shared-SPI mount helper; formatting remains deliberately unavailable.
+  // (boot DataStore, history, tiles, file manager/WAV, telemetry/logging,
+  // backups and crash export) using its shared-SPI mount helper; formatting
+  // remains deliberately unavailable.
   #define CAP_SD           0
   #define CAP_FILESYSTEM   0
   #define CAP_GPS          1   // u-blox MIA-M10Q

--- a/src/ui-touch/device_caps.h
+++ b/src/ui-touch/device_caps.h
@@ -39,13 +39,8 @@
   #define CAP_TOUCH        0   // no touchscreen — keyboard + rotary encoder nav only
   #define CAP_ROTATABLE    0   // fixed 480x222 landscape via hardware MADCTL rotation
   #define CAP_LARGE_SCREEN 0   // native 480x222, no UI upscaling
-  // Keep these structural caps at 0: they still gate several T-Deck-specific
-  // UI/features. Pager storage is wired explicitly at its audited call sites
-  // (boot DataStore, history, tiles, file manager/WAV, telemetry/logging,
-  // backups and crash export) using its shared-SPI mount helper; formatting
-  // remains deliberately unavailable.
-  #define CAP_SD           0
-  #define CAP_FILESYSTEM   0
+  #define CAP_SD           1   // microSD on the shared display/radio SPI bus
+  #define CAP_FILESYSTEM   1   // browsable filesystem (the SD card)
   #define CAP_GPS          1   // u-blox MIA-M10Q
   #define CAP_OTA          1   // dual-OTA partition layout, same shape as the T-Deck
   #define CAP_LOCK_SCREEN  1
@@ -227,12 +222,8 @@
 // Per-event WAV notification sounds + the file-browsing sound picker. This is
 // deliberately NOT the same thing as CAP_SD/CAP_FILESYSTEM: it only means
 // "can browse and play WAV files for notifications." Both the T-Deck and the
-// pager can now pick a WAV from a real SD card too (their sound pickers write
-// an "sd:"-prefixed pref, UITask.cpp's wavOpen()/fmOpenAudio()) -- but the
-// pager's CAP_SD/CAP_FILESYSTEM stay 0 (see the comment on those above): that
-// SD support was added by widening the specific file-manager/WAV-picker call
-// sites individually (`|| defined(TLORA_PAGER)`), not by flipping the macros,
-// since CAP_SD also gates ~30 unrelated, still-pager-deferred features.
+// Pager provide that audio path; other boards may expose a filesystem without
+// having compatible notification-sound hardware.
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
   #define CAP_SOUND_FILES 1
 #else

--- a/variants/lilygo_tlora_pager/TLoraPagerBoard.cpp
+++ b/variants/lilygo_tlora_pager/TLoraPagerBoard.cpp
@@ -26,7 +26,9 @@ void TLoraPagerBoard::begin() {
     digitalWrite(pin, HIGH);
   }
 
+  if (!expander_mutex_) expander_mutex_ = xSemaphoreCreateMutex();
   const bool expander_ok = io_expander.begin(Wire, PAGER_XL9555_ADDR);
+  expander_ready_ = expander_ok;
   // Not just a nicety: every power rail AND the display's hardware reset hang
   // off this chip — if the probe fails silently, the symptom downstream is a
   // black screen with an otherwise clean boot log.
@@ -91,4 +93,42 @@ void TLoraPagerBoard::begin() {
     rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
     rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
   }
+}
+
+TLoraPagerBoard::SdCardState TLoraPagerBoard::sdCardState() {
+  // If the expander probe failed, don't turn an unreadable detect input into a
+  // permanent "empty slot" result. The non-formatting SD.begin() probe is the
+  // safe fallback arbiter (and will simply fail if the SD rail is unavailable).
+  if (!expander_ready_ || !expander_mutex_) return SdCardState::Unknown;
+  if (xSemaphoreTake(expander_mutex_, pdMS_TO_TICKS(50)) != pdTRUE)
+    return SdCardState::Unknown;
+  // LilyGo's pager implementation treats the XL9555 SD_DET input as
+  // active-low: HIGH is an empty slot, LOW is a seated card. Read the whole
+  // port so SensorLib's -1 I2C error remains distinguishable; digitalRead()
+  // narrows that error to 0xFF and would falsely report a live card removed.
+  const int port = io_expander.readPort(ExtensionIOXL9555::PORT1);
+  xSemaphoreGive(expander_mutex_);
+  if (port < 0) return SdCardState::Unknown;
+  return (port & (1 << (PAGER_EXPAND_SD_DET - 8))) == 0
+      ? SdCardState::Present : SdCardState::Absent;
+}
+
+bool TLoraPagerBoard::sdCardPresent() {
+  // Unknown is deliberately fail-present for normal operation: never tear down
+  // a live VFS because card-detect I2C was temporarily unavailable. A real,
+  // non-formatting SD transaction remains the final mount/alive arbiter.
+  return sdCardState() != SdCardState::Absent;
+}
+
+void TLoraPagerBoard::setAmpEnabled(bool on) {
+  if (!expander_ready_) return;
+  if (!expander_mutex_) {
+    io_expander.digitalWrite(PAGER_EXPAND_AMP_EN, on ? HIGH : LOW);
+    return;
+  }
+  // Audio must never pin the SD lifecycle gate forever if the I2C expander is
+  // unhealthy. A missed amp toggle is preferable to wedging the notify task.
+  if (xSemaphoreTake(expander_mutex_, pdMS_TO_TICKS(50)) != pdTRUE) return;
+  io_expander.digitalWrite(PAGER_EXPAND_AMP_EN, on ? HIGH : LOW);
+  xSemaphoreGive(expander_mutex_);
 }

--- a/variants/lilygo_tlora_pager/TLoraPagerBoard.h
+++ b/variants/lilygo_tlora_pager/TLoraPagerBoard.h
@@ -10,6 +10,8 @@
 
 #include <Arduino.h>
 #include <Wire.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 #include <helpers/ESP32Board.h>
 #include <driver/rtc_io.h>
 #include <ExtensionIOXL9555.hpp>
@@ -54,7 +56,11 @@
 
 class TLoraPagerBoard : public ESP32Board {
 public:
+  enum class SdCardState : uint8_t { Absent, Present, Unknown };
+
   void begin();
+  SdCardState sdCardState();
+  bool sdCardPresent();
 
   void enterDeepSleep(uint32_t secs, int pin_wake_btn) {
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
@@ -94,9 +100,7 @@ public:
   // for bus-integrity reasons unrelated to audio -- see begin()'s comment):
   // this is the runtime toggle the sound code brackets each chime/WAV with,
   // so the amp is only live while something is actually playing.
-  void setAmpEnabled(bool on) {
-    io_expander.digitalWrite(PAGER_EXPAND_AMP_EN, on ? HIGH : LOW);
-  }
+  void setAmpEnabled(bool on);
 
   // TODO: BQ25896 charger (XPowersLib) bring-up is out of scope for now — the
   // BQ27220 gauge alone covers battery %/mV for the UI. Add charge-status/
@@ -104,4 +108,8 @@ public:
 
   ExtensionIOXL9555 io_expander;
   GaugeBQ27220 gauge;
+
+private:
+  bool expander_ready_ = false;
+  SemaphoreHandle_t expander_mutex_ = nullptr;
 };

--- a/variants/lilygo_tlora_pager/target.cpp
+++ b/variants/lilygo_tlora_pager/target.cpp
@@ -22,6 +22,10 @@ RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BU
 
 WRAPPER_CLASS radio_driver(radio, board);
 
+SPIClass* tloraPagerSharedSPI() {
+  return &TFT_eSPI::getSPIinstance();
+}
+
 ESP32RTCClock fallback_clock;
 ClockFloorRTC        rtc_clock(fallback_clock);
 MicroNMEALocationProvider gps(Serial1, &rtc_clock);
@@ -125,10 +129,3 @@ mesh::LocalIdentity radio_new_identity() {
   RadioNoiseListener rng(radio);
   return mesh::LocalIdentity(&rng); // create new random identity
 }
-
-// Shared-SPI accessor for main.cpp's boot-time SD storage mount (#193): the micro-SD rides the
-// SAME SPIClass the display/radio already own (see the bus-sharing note at the top of this file).
-// UITask's runtime mount uses TFT_eSPI::getSPIinstance() directly; main.cpp cannot cheaply
-// include TFT_eSPI, so it links this instead.
-#include <TFT_eSPI.h>
-SPIClass* tloraPagerSharedSPI() { return &TFT_eSPI::getSPIinstance(); }

--- a/variants/lilygo_tlora_pager/target.h
+++ b/variants/lilygo_tlora_pager/target.h
@@ -35,4 +35,5 @@ extern EnvironmentSensorManager sensors;
 #endif
 
 bool radio_init();
+SPIClass* tloraPagerSharedSPI();
 mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
## Summary

This fixes the T-Pager microSD boot hang by giving the display, SX1262/LR1121 radio, and SD card one shared-SPI ownership model and one coherent SD/VFS lifecycle.

- reuse the `SPIClass` already owned by `TFT_eSPI` for display, radio, and SD
- park every inactive shared-bus chip select before mounting the card
- adopt the boot-time Arduino `SD` mount instead of tearing it down from the UI runtime
- prevent mount/unmount while history, preferences, tiles, SD-info, or notification workers still use the VFS
- use the XL9555 active-low card-detect input with bounded I2C locking and fail-safe `Unknown` handling
- keep identity, preferences, channels, contacts, and history on the same profile backend selected at boot
- make first-time SPIFFS-to-SD migration atomic, resumable, identity-last, and fail-closed
- enable the audited Pager storage capabilities with `CAP_SD=1` and `CAP_FILESYSTEM=1`
- keep destructive SD formatting unavailable on Pager

This is the lifecycle/arbitration completion of the Pager SD support introduced by #193. The non-Pager slow-card retry and clock-negotiation behavior from #194 remains unchanged.

## Failure mechanism

The failing build booted normally without a card but stopped at the boot logo when a card was inserted. The failure was a mount-lifetime mismatch, not an unsupported slot or a clock that needed more retries:

1. `main.cpp` mounted the global Arduino `SD` object during boot and handed that live FAT/VFS to DataStore, preferences, contacts/channels, history, and migration code.
2. `UITask.cpp` independently began with its local mount state unset.
3. Its first storage-health/file-manager path treated the already-mounted object as a cold card and entered the generic retry ladder.
4. That ladder called `SD.end()` before retrying `SD.begin()`.
5. `SD.end()` unregistered the same global VFS while boot consumers still held filesystem references or open files beneath it.

With no card, there was no live SD VFS to invalidate. With a card, the UI runtime destroyed storage lifetime underneath the boot sequence. Delays or additional retries could not make that safe.

The Pager now adopts an existing live mount, never uses the generic teardown/retry ladder, and only changes VFS lifetime after every known consumer is quiescent.

## Shared hardware contract

The T-Pager routes display, LoRa, SD, and NFC over SCK 35 / MOSI 34 / MISO 33 with independent selects:

| Device | Select/control |
| --- | ---: |
| display | GPIO 38 |
| SX1262/LR1121 | GPIO 36 |
| microSD | GPIO 21 |
| NFC | GPIO 39 |
| SD detect | XL9555 channel 10, active-low |

There is one bus owner: `TFT_eSPI::getSPIinstance()`. RadioLib and Arduino SD receive that same object, and each peripheral uses SPI transactions for transfers. VFS lifetime is gated separately because transaction locking alone cannot protect an open `File` from `SD.end()`.

This follows LilyGoLib's Pager sequencing at [`a6cd82f`](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/src/LilyGo_LoRa_Pager.cpp):

- [`initShareSPIPins()` parks NFC, LoRa, SD, and reset selects high](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/src/LilyGo_LoRa_Pager.cpp#L180-L195)
- [the shared SPI bus is initialized once before peripheral use](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/src/LilyGo_LoRa_Pager.cpp#L330-L332)
- [`installSD()` checks SD detect, parks shared pins, and mounts at 4 MHz](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/src/LilyGo_LoRa_Pager.cpp#L466-L486)
- [`uninstallSD()` and readiness checks serialize access](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/src/LilyGo_LoRa_Pager.cpp#L489-L503)

Wadamesh has concurrent filesystem owners that the vendor example does not, so this PR adds the VFS-consumer gate on top of that electrical contract.

## Profile and migration safety

An SD card may contain the user's identity, private key, settings, channels, contacts, and message history. The migration rules therefore fail closed:

- an existing SD identity defines an established card profile, including cards created before the new completion marker
- automatic migration only targets an empty profile tree
- an interrupted identity-last migration resumes only when its private owner digest matches the current internal identity
- residual identity-less data without that matching owner marker is never mixed into the current profile
- each file lands through its own temporary file and atomic rename
- identity is copied after all settings/history files, and the completion marker commits last
- every new attempt invalidates an older completion marker before copying
- FAT failure leaves the durable migration breadcrumb armed and keeps the device on internal storage
- chat history follows the same authoritative backend decision as identity and preferences
- manual reconciliation flushes pending history, contacts, discovered nodes, and preferences before copying

No identity, key, or digest contents are logged or included in the diff.

## Capabilities and destructive operations

The Pager's audited storage paths now use the structural flags expected by the UI:

- `CAP_SD=1`
- `CAP_FILESYSTEM=1`

The previous claim that these flags would enable dozens of unaudited Pager features was stale: every filesystem-only site was already Pager-enabled, and the only newly exposed SD behavior is the existing map-source switch.

Known follow-up: the Pager map-source choice currently returns to server/cache mode after reboot. #221 persists that choice and further hardens backend switching; it is no longer required to prevent this PR from removing an existing feature.

SD formatting remains excluded by explicit board guards and is not implied by `CAP_SD`. On the card, Pager factory reset only removes wadamesh-owned `/meshcomod` data and preserves root-level map packs; it waits for active consumers and refuses to erase the internal profile when the card-side wipe cannot be verified.

## Verification

- `git diff --check origin/main...HEAD`
- `uvx --from platformio platformio run -e tlora_pager_sx1262_companion_radio_touch`
  - success on the capability-enabled #206 head
  - RAM: 101,560 / 327,680 bytes (31.0%)
  - flash: 3,435,745 / 4,063,232 bytes (84.6%)
- affected shared paths also built successfully for:
  - `LilyGo_TDeck_companion_radio_touch`
  - `heltec_v4_r8_tft_companion_radio_usb_tcp_touch`
- `PAGER_SD_DISABLED` is absent
- eight changed files; no display-layout or UI-size changes

## Hardware evidence

Testing used application-only flashes at `0x10000`. No bootloader, partition table, NVS, SPIFFS, coredump, backup, or SD image was written.

Observed on a physical SX1262 T-Pager:

- boot reaches the home UI with and without the existing card inserted
- the card's existing `/meshcomod` profile and chat history are adopted
- display, controls, tabs, Wi-Fi, BLE, and LoRa remain operational while SD is mounted
- Pager-originated public traffic and a real multi-hop ACK were observed with the card mounted
- repeated reset/boot with the card present no longer reproduces the original boot-logo hang
- the final capability-enabled integration build, including #210 and #230, mounted the card-backed preference store, associated Wi-Fi, initialized BLE, reached UI-ready, and ran beyond the prior watchdog interval without resetting

## Review

The implementation received an independent Claude Opus 5 `xhigh` review plus independent Codex review. Reproduced findings around partial migration, mixed-profile recovery, coredump gating, factory-wipe messaging, tile-worker lifetime, history backend selection, contact flushing, cross-core pending counters, stale markers, path truncation, and watchdog-state preservation were addressed and rebuilt.

The final capability delta was independently reviewed against the exact #206 head with no correctness findings. A fresh Claude rerun was intentionally skipped at the user's request.

Model: GPT-5.6 Sol | Harness: Codex in T3 Code
