### PR TITLE
fix(tpager): use the vendor TCXO voltage for SX1262

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -922,13 +922,13 @@ build_flags =
   -D SX126X_DIO2_AS_RF_SWITCH=true
   -D SX126X_CURRENT_LIMIT=140
   -D SX126X_RX_BOOSTED_GAIN=1
-  ; Deliberately NOT setting SX126X_DIO3_TCXO_VOLTAGE (unlike the T-Deck's
-  ; 1.8f) -- that IS a board-specific analog value (this board's actual TCXO
-  ; circuit), and trail-mate's own working reference for this exact PCB never
-  ; overrides it either, relying on CustomSX1262::std_init()'s built-in 1.6V
-  ; fallback (RadioLib's own SX1262::begin() default) -- which also already
-  ; auto-retries at 0.0f on an SPI-cmd failure if 1.6V doesn't suit this board's
-  ; real hardware. Revisit with a measured value if bring-up shows otherwise.
+  ; LilyGoLib's SX1262 transmit/receive examples for this exact Pager explicitly
+  ; drive the module's DIO3 TCXO supply at 3.0 V. The generic CustomSX1262
+  ; fallback is only 1.6 V; that can leave this board's oscillator outside its
+  ; specified supply range while still working at very short range. Pass the
+  ; board value into begin() so calibration and all later RX/TX use the correct
+  ; reference from the start.
+  -D SX126X_DIO3_TCXO_VOLTAGE=3.0f
   -D P_LORA_DIO_1=14
   -D P_LORA_NSS=36
   -D P_LORA_RESET=47


### PR DESCRIPTION
## Summary

- drive the T-Pager SX1262 module's DIO3-controlled TCXO supply at 3.0 V
- keep the change confined to the SX1262 Pager environment; LR1121 and every other board remain unchanged

## Why

The Pager environment currently falls through to `CustomSX1262::std_init()`'s generic 1.6 V default. That is enough for the radio to answer SPI commands and can appear healthy at desk range, but it is not the board value used by LilyGo for this module. The oscillator supply is part of the RF calibration reference, so the wrong value can present as weak or inconsistent receive/transmit performance rather than a clean initialization error.

This was initially suspected to be display/SD/radio SPI contention. Hardware A/B testing separated the two: removing the card did not restore the missing public-mesh ACKs, while changing only the TCXO supply did.

## LilyGo reference

LilyGoLib's examples for the exact Pager SX1262 explicitly call `radio.setTCXO(3.0)` after radio initialization:

- [SX126x Receive, lines 118-123](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/examples/radio/SX1262/SX126x_Receive/SX126x_Receive.ino#L118-L123)
- [SX126x Transmit, lines 116-121](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/examples/radio/SX1262/SX126x_Transmit/SX126x_Transmit.ino#L116-L121)
- [SX126x PingPong, lines 113-118](https://github.com/Xinyuan-LilyGO/LilyGoLib/blob/a6cd82fae25b0e9c186787ec52f80f832b988a00/examples/radio/SX1262/SX126x_PingPong/SX126x_PingPong.ino#L113-L118)

The build flag passes the same board value into the initial `begin()` path so calibration and every later RX/TX operation share the correct reference from startup.

## Hardware evidence

- before: desk-range packets could work, but Pager-originated public traffic and ACKs were unreliable even with the SD card removed and RX boosted gain tested both ways
- after: Pager and T-Deck side-by-side diagnostics reached the public feed at effectively identical reach (`168x / 56 observers` versus `167x / 56 observers`)
- reciprocal desk traffic was approximately 12 dB SNR and the Pager received a real six-hop public-channel ACK
- the result remained stable with the SD card inserted, separating this RF fix from the SD lifecycle work in #206

## Verification

- `git diff --check origin/main...HEAD`
- `uvx --from platformio platformio run -e tlora_pager_sx1262_companion_radio_touch`
  - success
  - RAM: 101,192 / 327,680 bytes (30.9%)
  - flash: 3,420,397 / 4,063,232 bytes (84.2%)

Model: GPT-5.6 Sol | Harness: Codex in T3 Code
