### PR TITLE
fix(tpager): stabilize Wi-Fi and BLE coexistence

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -640,7 +640,7 @@ framework = arduino
 board = lilygo-t-lora-pager
 monitor_speed = 115200
 board_build.partitions = variants/lilygo_tlora_pager/partitions_tlora_pager_touch.csv
-extra_scripts = pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_nimble_freertos_timer.py, merge-bin.py
 
 build_flags =
   -Wno-deprecated-declarations -Wno-unused-parameter -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1
@@ -865,7 +865,7 @@ framework = arduino
 board = lilygo-t-lora-pager
 monitor_speed = 115200
 board_build.partitions = variants/lilygo_tlora_pager/partitions_tlora_pager_touch.csv
-extra_scripts = pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_nimble_freertos_timer.py, merge-bin.py
 
 build_flags =
   -Wno-deprecated-declarations -Wno-unused-parameter -DNDEBUG -DRADIOLIB_STATIC_ONLY=1 -DRADIOLIB_GODMODE=1

--- a/scripts/build/patch_nimble_freertos_timer.py
+++ b/scripts/build/patch_nimble_freertos_timer.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# NimBLE-Arduino 1.4.3 clears a FreeRTOS callout immediately after
+# xTimerDelete(), but xTimerDelete() only queues the deletion. If the timer has
+# already expired, the timer daemon can still run the callback against the
+# cleared callout and call address zero. T-Pager exposes this when Wi-Fi link
+# recovery tears NimBLE down dynamically.
+#
+# Keep the host timer alive until nimble_port_stop() has finished, drain every
+# callout deletion before clearing its callback state, and keep the host event
+# queue alive until those callouts are gone. The barrier is FIFO on the same
+# timer command queue, so any already-due callback runs while both its callout
+# and destination event queue are still valid.
+#
+# Idempotent and deliberately scoped to environments that list this script.
+# All replacements are exact and fail closed if the pinned dependency drifts.
+Import("env")
+import os
+
+LIB_ROOT = os.path.join(env.subst("$PROJECT_LIBDEPS_DIR"), env.subst("$PIOENV"),
+                        "NimBLE-Arduino", "src", "nimble")
+
+HOST_PATH = os.path.join(LIB_ROOT, "nimble", "host", "src", "ble_hs.c")
+PORT_PATH = os.path.join(LIB_ROOT, "porting", "nimble", "src",
+                         "nimble_port.c")
+NPL_PATH = os.path.join(LIB_ROOT, "porting", "npl", "freertos", "src",
+                        "npl_os_freertos.c")
+
+HOST_MARKER = "wadamesh-nimble-defer-host-timer-delete"
+HOST_OLD = """    if (!ble_hs_is_enabled()) {
+        ble_npl_callout_stop(&ble_hs_timer);
+        ble_npl_callout_deinit(&ble_hs_timer);
+    } else {"""
+HOST_NEW = """    if (!ble_hs_is_enabled()) {
+        /* wadamesh-nimble-defer-host-timer-delete: nimble_port_stop() can
+         * reach this while the FreeRTOS timer daemon still owns an expiry.
+         * Stop here; ble_hs_deinit() destroys the callout after the host exits.
+         */
+        ble_npl_callout_stop(&ble_hs_timer);
+    } else {"""
+
+PORT_MARKER = "wadamesh-nimble-drain-callouts-before-eventq-delete"
+PORT_OLD = """    ble_npl_eventq_deinit(&g_eventq_dflt);
+#endif
+    ble_hs_deinit();
+
+#if !SOC_ESP_NIMBLE_CONTROLLER
+#if CONFIG_NIMBLE_STACK_USE_MEM_POOLS"""
+PORT_NEW = """#endif
+    /* wadamesh-nimble-drain-callouts-before-eventq-delete: host callouts can
+     * still deliver an already-expired event while their FreeRTOS timer delete
+     * is draining. Keep the destination queue valid until they are gone.
+     */
+    ble_hs_deinit();
+
+#if !SOC_ESP_NIMBLE_CONTROLLER
+    ble_npl_eventq_deinit(&g_eventq_dflt);
+#if CONFIG_NIMBLE_STACK_USE_MEM_POOLS"""
+
+NPL_MARKER = "wadamesh-nimble-timer-delete-barrier"
+NPL_OLD = """void
+npl_freertos_callout_deinit(struct ble_npl_callout *co)
+{
+    if (!co->handle) {
+        return;
+    }
+
+#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
+    if(esp_timer_stop(co->handle))
+\tESP_LOGW(LOG_TAG, \"Timer not stopped\");
+
+    if(esp_timer_delete(co->handle))
+\tESP_LOGW(LOG_TAG, \"Timer not deleted\");
+#else
+    xTimerDelete(co->handle, portMAX_DELAY);
+    ble_npl_event_deinit(&co->ev);
+#endif
+    memset(co, 0, sizeof(struct ble_npl_callout));
+}"""
+NPL_NEW = """#if !CONFIG_BT_NIMBLE_USE_ESP_TIMER
+static void
+npl_freertos_callout_delete_barrier(void *arg, uint32_t unused)
+{
+    (void)unused;
+    xSemaphoreGive((SemaphoreHandle_t)arg);
+}
+#endif
+
+void
+npl_freertos_callout_deinit(struct ble_npl_callout *co)
+{
+    if (!co->handle) {
+        return;
+    }
+
+#if CONFIG_BT_NIMBLE_USE_ESP_TIMER
+    if(esp_timer_stop(co->handle))
+\tESP_LOGW(LOG_TAG, \"Timer not stopped\");
+
+    if(esp_timer_delete(co->handle))
+\tESP_LOGW(LOG_TAG, \"Timer not deleted\");
+#else
+    /* wadamesh-nimble-timer-delete-barrier: xTimerDelete() is asynchronous.
+     * Queue a no-allocation barrier behind it and wait before invalidating the
+     * callback state the timer daemon may still be using.
+     */
+    StaticSemaphore_t barrier_storage;
+    SemaphoreHandle_t barrier = xSemaphoreCreateBinaryStatic(&barrier_storage);
+    BaseType_t deleted = barrier
+        ? xTimerDelete(co->handle, portMAX_DELAY)
+        : pdFAIL;
+    BaseType_t queued = deleted == pdPASS
+        ? xTimerPendFunctionCall(npl_freertos_callout_delete_barrier,
+                                 barrier, 0, portMAX_DELAY)
+        : pdFAIL;
+    BaseType_t drained = queued == pdPASS
+        ? xSemaphoreTake(barrier, portMAX_DELAY)
+        : pdFAIL;
+    if (drained != pdPASS) {
+        assert(false);
+        return;
+    }
+    if (co->evq && co->ev.queued) {
+        npl_freertos_eventq_remove(co->evq, &co->ev);
+    }
+    ble_npl_event_deinit(&co->ev);
+#endif
+    memset(co, 0, sizeof(struct ble_npl_callout));
+}"""
+
+
+def patch_exact(path, marker, old, new):
+    if not os.path.isfile(path):
+        raise RuntimeError("NimBLE patch target is missing: %s" % path)
+    with open(path) as source_file:
+        source = source_file.read()
+    if marker in source:
+        print("[patch_nimble_freertos_timer] already patched: %s" % os.path.basename(path))
+        return
+    if old not in source:
+        raise RuntimeError("NimBLE 1.4.3 patch context drifted: %s" % path)
+    with open(path, "w") as source_file:
+        source_file.write(source.replace(old, new, 1))
+    print("[patch_nimble_freertos_timer] patched: %s" % os.path.basename(path))
+
+
+patch_exact(HOST_PATH, HOST_MARKER, HOST_OLD, HOST_NEW)
+patch_exact(PORT_PATH, PORT_MARKER, PORT_OLD, PORT_NEW)
+patch_exact(NPL_PATH, NPL_MARKER, NPL_OLD, NPL_NEW)

--- a/src/LvglPsramAlloc.cpp
+++ b/src/LvglPsramAlloc.cpp
@@ -40,9 +40,19 @@ extern "C" void* lvglPsramRealloc(void* ptr, size_t size) {
   if (!ptr) {
     return lvglPsramAlloc(size);
   }
-  // Plain realloc preserves whatever heap the original block was on (PSRAM
-  // stays in PSRAM, DRAM stays in DRAM). Migrating between heaps on realloc
-  // would need to know the original size to memcpy safely; not worth the
-  // complexity for LVGL's usage pattern.
+#if defined(ESP32)
+  // ESP-IDF documents plain realloc(ptr, size) as
+  // heap_caps_realloc(ptr, size, MALLOC_CAP_8BIT). That generic capability can
+  // move a PSRAM-backed LVGL block into the higher-priority internal heap. The
+  // UI performs many small text/style reallocations while building its tree,
+  // so the old implementation silently migrated roughly 60 KB back into the
+  // DRAM needed by Wi-Fi/BLE connection and security work. Preserve the PSRAM
+  // requirement explicitly. heap_caps_realloc handles copying even when ptr
+  // came from the internal fallback in lvglPsramAlloc().
+  void* p = heap_caps_realloc(ptr, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (p) return p;
+#endif
+  // PSRAM absent or exhausted: retain the original fallback semantics. A failed
+  // heap_caps_realloc leaves ptr valid, so the ordinary realloc remains safe.
   return realloc(ptr, size);
 }

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -725,7 +725,7 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
       } else if (wifiConfigPagerWifiBlocksBle()) {
         pushMeshcomodReply("OK\nble: pending (Wi-Fi handoff)");
       } else if (wifiConfigGetBleEnabled()) {
-        pushMeshcomodReply("ble: pending (restart required)");
+        pushMeshcomodReply("ble: pending (retry from Settings)");
 #endif
       } else {
         pushMeshcomodReply("error: Bluetooth could not start");
@@ -932,14 +932,35 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
       pushMeshcomodReply("error: wifi radio off — send wifi on first");
       return true;
     }
+    if (wifiScanIsActive()) {
+      pushMeshcomodReply("wifi: scan already in progress");
+      return true;
+    }
     // Ensure STA is fully up before scan; disconnected STA needs a bit more settle time.
     wifi_mode_t mode = WiFi.getMode();
+#if defined(TLORA_PAGER)
+    // Never cold-initialize Wi-Fi from a command handler while NimBLE is
+    // resident. The main loop performs the ordered live handoff; a subsequent
+    // command can scan once that short transition has completed.
+    if ((mode & WIFI_MODE_STA) == 0) {
+      wifiConfigRequestApply();
+      pushMeshcomodReply("wifi: starting; retry scan shortly");
+      return true;
+    }
+    if (wifiConfigPagerWifiBlocksBle()) {
+      pushMeshcomodReply("wifi: association in progress; retry scan shortly");
+      return true;
+    }
+    delay(40);
+#else
     if ((mode & WIFI_MODE_STA) == 0) {
       WiFi.mode(WIFI_STA);
       delay(180);
     } else {
       delay(40);
     }
+#endif
+    wifiScanSetActive(true);
     s_meshcomod_scan_count = 0;
     // Watchdog-safe: one bounded, yielding async pass (see wifiScanWatchdogSafe).
     // This handler runs on the main/loop task, so the old twin synchronous scans
@@ -948,6 +969,7 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
     if (found <= 0) {
       pushMeshcomodReply("scan: no networks (2.4GHz only)");
       WiFi.scanDelete();
+      wifiScanSetActive(false);
       return true;
     }
     String scanMsg = "scan results:";
@@ -992,6 +1014,7 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
       pushMeshcomodReply(scanMsg.c_str());
     }
     WiFi.scanDelete();
+    wifiScanSetActive(false);
     return true;
   }
   if (strncasecmp(p, "use", 3) == 0 && (p[3] == '\0' || p[3] == ' ' || p[3] == '\t')) {

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -642,6 +642,10 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
           snprintf(ble, sizeof(ble), "on (%s)", peer);
         else
           snprintf(ble, sizeof(ble), "on");
+#if defined(TLORA_PAGER)
+      } else if (wifiConfigGetBleEnabled()) {
+        snprintf(ble, sizeof(ble), "pending");
+#endif
       } else {
         snprintf(ble, sizeof(ble), "off");
       }
@@ -708,8 +712,24 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
     p += 3;
     while (*p == ' ' || *p == '\t') p++;
     if (strncasecmp(p, "on", 2) == 0 && (p[2] == '\0' || p[2] == ' ' || p[2] == '\t')) {
+#if defined(TLORA_PAGER)
+      // Record the request before asking the transport. A cold start may be
+      // intentionally refused while WPA owns the Pager coexistence handoff;
+      // main.cpp observes this preference and restores BLE on success/timeout.
+      wifiConfigSetBleEnabled(true);
+#endif
       _serial->enableBle();
-      pushMeshcomodReply("OK\nble: on");
+      if (_serial->isBleEnabled()) {
+        pushMeshcomodReply("OK\nble: on");
+#if defined(TLORA_PAGER)
+      } else if (wifiConfigPagerWifiBlocksBle()) {
+        pushMeshcomodReply("OK\nble: pending (Wi-Fi handoff)");
+      } else if (wifiConfigGetBleEnabled()) {
+        pushMeshcomodReply("ble: pending (restart required)");
+#endif
+      } else {
+        pushMeshcomodReply("error: Bluetooth could not start");
+      }
       return true;
     }
     if (strncasecmp(p, "off", 3) == 0 && (p[3] == '\0' || p[3] == ' ' || p[3] == '\t')) {
@@ -730,6 +750,10 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
         } else {
           pushMeshcomodReply("ble: on");
         }
+#if defined(TLORA_PAGER)
+      } else if (wifiConfigGetBleEnabled()) {
+        pushMeshcomodReply("ble: pending");
+#endif
       } else {
         pushMeshcomodReply("ble: off");
       }

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -203,9 +203,10 @@ void MultiTransportCompanionInterface::enableBle() {
     // The Pager must finish Wi-Fi association before NimBLE. Once connected,
     // a deferred cold start preserves that order and the heap guard below
     // decides whether post-UI allocation is still safe. Refuse only while the
-    // STA is absent or actively associating; UITask can reboot that path.
+    // STA is absent or actively associating; UITask keeps the saved request
+    // pending and tells the user that BLE resumes after association.
     if (WiFi.getMode() != WIFI_MODE_NULL && WiFi.status() != WL_CONNECTED) {
-      Serial.println("[ble] cold start deferred to ordered T-Pager reboot");
+      Serial.println("[ble] cold start deferred until T-Pager Wi-Fi associates");
       return;
     }
 #endif

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -282,18 +282,34 @@ void MultiTransportCompanionInterface::disableBle() {
 }
 
 #if defined(TLORA_PAGER)
-void MultiTransportCompanionInterface::suspendBleForWifiReconnect() {
-  // Preserve wifiConfig's BLE preference: this is a short ownership handoff,
-  // not a user-visible toggle. SerialBLEInterface::begin() replaces the cached
-  // server pointers after deinit(true), matching the cold enable path above.
+bool MultiTransportCompanionInterface::suspendBleForWifiReconnect() {
+  // Preserve both the user's BLE preference and NimBLE's live bond/GATT state.
+  // Recreating the controller/server here made an already-bonded phone fall
+  // into repeat pairing after every Wi-Fi handoff; NimBLE then discarded its
+  // side of the bond while the phone retained the old LTK. Stopping advertising
+  // and disconnecting the peer removes BLE traffic from the association window
+  // without invalidating that long-term security state.
   if (_ble_begun) {
     if (_ble_enabled) _ble.disable();
-    bleDetachServerCallbacks();
-    NimBLEDevice::deinit(true);
-    _ble_begun = false;
+    // ble_gap_terminate() is asynchronous. Do not start WPA while the old BLE
+    // link is still on air; that recreates the exact overlap this handoff is
+    // meant to prevent. Wait for the NimBLE host's connection table to drain,
+    // with a bounded failure so a wedged peer cannot stall the main loop/WDT.
+    NimBLEServer* server = NimBLEDevice::getServer();
+    const uint32_t started = millis();
+    while (server && server->getConnectedCount() != 0 &&
+           (uint32_t)(millis() - started) < 1000u) {
+      delay(1);
+    }
+    if (server && server->getConnectedCount() != 0) {
+      Serial.println("[ble] disconnect timed out; Wi-Fi handoff cancelled");
+      _ble_enabled = false;
+      return false;
+    }
   }
   _ble_enabled = false;
   if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(false);
+  return true;
 }
 #endif
 

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -244,6 +244,22 @@ void MultiTransportCompanionInterface::enableBle() {
 #endif
 }
 
+#ifdef BLE_PIN_CODE
+// NimBLEDevice::deinit(true) deletes the NimBLEServer, and ~NimBLEServer() does
+//   if (m_deleteCallbacks && m_pServerCallbacks != &defaultCallbacks)
+//     delete m_pServerCallbacks;
+// SerialBLEInterface::begin() registers itself with pServer->setCallbacks(this),
+// whose deleteCallbacks parameter defaults to true. Our SerialBLEInterface is the
+// by-value member _ble of this object, and this object is placement-new'd into a
+// single heap block in main.cpp — so that delete would call operator delete on an
+// INTERIOR pointer and corrupt the heap. setCallbacks(nullptr) installs NimBLE's
+// static defaultCallbacks sentinel, which the destructor above explicitly skips.
+// (NimBLECharacteristic never deletes its callbacks, so only the server matters.)
+static void bleDetachServerCallbacks() {
+  if (NimBLEServer* server = NimBLEDevice::getServer()) server->setCallbacks(nullptr);
+}
+#endif
+
 void MultiTransportCompanionInterface::disableBle() {
   _ble_enabled = false;
   wifiConfigSetBleEnabled(false);   // persist so BT stays off across reboot
@@ -258,6 +274,7 @@ void MultiTransportCompanionInterface::disableBle() {
   // behavior.
 #if defined(TLORA_PAGER)
   if (_ble_begun) {
+    bleDetachServerCallbacks();
     NimBLEDevice::deinit(true);
     _ble_begun = false;
   }
@@ -272,6 +289,7 @@ void MultiTransportCompanionInterface::suspendBleForWifiReconnect() {
   // server pointers after deinit(true), matching the cold enable path above.
   if (_ble_begun) {
     if (_ble_enabled) _ble.disable();
+    bleDetachServerCallbacks();
     NimBLEDevice::deinit(true);
     _ble_begun = false;
   }
@@ -355,6 +373,7 @@ void MultiTransportCompanionInterface::prepareForHttpOta() {
   if (_ble_begun) {
     _ota_ble_was_enabled = _ble_enabled;
     if (_ble_enabled) _ble.disable();
+    bleDetachServerCallbacks();
     NimBLEDevice::deinit(true);
     _ble_begun = false;
     _ble_enabled = false;

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -184,15 +184,14 @@ void MultiTransportCompanionInterface::prepareBle(const char* prefix, char* name
   _ble_pin_code = pin_code;
 }
 
-void MultiTransportCompanionInterface::beginBle(const char* prefix, char* name, uint32_t pin_code,
-                                                 bool create_enabled) {
+void MultiTransportCompanionInterface::beginBle(const char* prefix, char* name, uint32_t pin_code) {
   prepareBle(prefix, name, pin_code);
   _ble.begin(prefix, name, pin_code);
   _ble_begun = true;
-  _ble_enabled = create_enabled;
+  _ble_enabled = true;
   _ota_ble_released = false;
   _ota_ble_was_enabled = false;
-  if (create_enabled) _ble.enable();
+  _ble.enable();
 }
 
 void MultiTransportCompanionInterface::enableBle() {

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -234,6 +234,13 @@ void MultiTransportCompanionInterface::enableBle() {
   _ble_enabled = true;
   wifiConfigSetBleEnabled(true);    // persist so it survives reboot
   _ble.enable();
+#if defined(TLORA_PAGER)
+  // A successful live enable means NimBLE is now resident. Do not let the
+  // Arduino Wi-Fi event path enter WPA automatically after a later link loss;
+  // main.cpp detects that state and reboots through the Wi-Fi-first boundary.
+  // Avoid touching Wi-Fi when it has never been initialised (BLE-only mode).
+  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(false);
+#endif
 }
 
 void MultiTransportCompanionInterface::disableBle() {

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -201,11 +201,11 @@ void MultiTransportCompanionInterface::enableBle() {
     // now, live, from the params stashed by prepareBle()/beginBle().
     if (_ble_prefix[0] == '\0' && _ble_name[0] == '\0') return;   // no params known
 #if defined(TLORA_PAGER)
-    // The Pager must claim Wi-Fi before NimBLE. A cold BLE start after Wi-Fi
-    // exists can both violate that ordering and consume the last contiguous
-    // internal block after LVGL is built. Refuse here; UITask persists the
-    // request and reboots through setup's proven Wi-Fi -> BLE -> UI sequence.
-    if (WiFi.getMode() != WIFI_MODE_NULL) {
+    // The Pager must finish Wi-Fi association before NimBLE. Once connected,
+    // a deferred cold start preserves that order and the heap guard below
+    // decides whether post-UI allocation is still safe. Refuse only while the
+    // STA is absent or actively associating; UITask can reboot that path.
+    if (WiFi.getMode() != WIFI_MODE_NULL && WiFi.status() != WL_CONNECTED) {
       Serial.println("[ble] cold start deferred to ordered T-Pager reboot");
       return;
     }
@@ -243,14 +243,16 @@ void MultiTransportCompanionInterface::disableBle() {
   // its cached server pointer. Never call disable() again after that teardown;
   // a later begin() replaces the cached pointers with a fresh GATT server.
   if (_ble_begun) _ble.disable();    // stop advertising + drop any connection
-  // If Wi-Fi is genuinely absent, fully release NimBLE so a later Wi-Fi enable
-  // has the contiguous internal heap esp_wifi_init needs. While Wi-Fi exists we
-  // keep the controller resident: tearing it out from under an active coex path
-  // is unsafe, and re-enabling the already-created stack needs no allocation.
+  // Pager only: if Wi-Fi is genuinely absent, fully release NimBLE so a later
+  // Wi-Fi enable has the contiguous internal heap esp_wifi_init needs. Other
+  // boards retain their established resident-stack disable/re-enable behavior.
+  // While Wi-Fi exists, keep the controller resident on every board.
+#if defined(TLORA_PAGER)
   if (_ble_begun && WiFi.getMode() == WIFI_MODE_NULL) {
     NimBLEDevice::deinit(true);
     _ble_begun = false;
   }
+#endif
 }
 
 bool MultiTransportCompanionInterface::getBlePeerAddress(char* buf, size_t len) const {

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -2,6 +2,7 @@
 #include <helpers/RepeaterTcpOtaEmit.h>
 #include "WifiRuntimeStore.h"   // persist BLE on/off (ble_en) across reboots
 #include "WebMirror.h"          // web UI mirror bridge (served over the WS server)
+#include <esp_heap_caps.h>
 #include <string.h>
 
 // Companion push code for the per-packet RX log (matches MyMesh.cpp). It is kept OFF
@@ -14,7 +15,7 @@ bool MultiTransportCompanionInterface::s_ble_rxlog_once = false;
 MultiTransportCompanionInterface::MultiTransportCompanionInterface()
   : _tcp_port(0), _ws_port(0), _tcp_started(false), _ws_started(false), _tcp_enabled(true), _isEnabled(false), _broadcast(false), _last_reply_target(REPLY_TARGET_USB), _ota_tcp_suspended(false), _ota_ws_suspended(false), _ota_ws_listen_paused(false)
 #ifdef BLE_PIN_CODE
-  , _ble_begun(false), _ble_enabled(false), _ota_ble_released(false), _ble_pin_code(0)
+  , _ble_begun(false), _ble_enabled(false), _ota_ble_released(false), _ota_ble_was_enabled(false), _ble_pin_code(0)
 #endif
 {
   for (size_t i = 0; i < sizeof(_client_ids) / sizeof(_client_ids[0]); i++)
@@ -183,13 +184,15 @@ void MultiTransportCompanionInterface::prepareBle(const char* prefix, char* name
   _ble_pin_code = pin_code;
 }
 
-void MultiTransportCompanionInterface::beginBle(const char* prefix, char* name, uint32_t pin_code) {
+void MultiTransportCompanionInterface::beginBle(const char* prefix, char* name, uint32_t pin_code,
+                                                 bool create_enabled) {
   prepareBle(prefix, name, pin_code);
   _ble.begin(prefix, name, pin_code);
   _ble_begun = true;
-  _ble_enabled = true;
+  _ble_enabled = create_enabled;
   _ota_ble_released = false;
-  _ble.enable();
+  _ota_ble_was_enabled = false;
+  if (create_enabled) _ble.enable();
 }
 
 void MultiTransportCompanionInterface::enableBle() {
@@ -197,6 +200,31 @@ void MultiTransportCompanionInterface::enableBle() {
     // Deferred at boot (heap guard) or toggled on from off: bring the stack up
     // now, live, from the params stashed by prepareBle()/beginBle().
     if (_ble_prefix[0] == '\0' && _ble_name[0] == '\0') return;   // no params known
+#if defined(TLORA_PAGER)
+    // The Pager must claim Wi-Fi before NimBLE. A cold BLE start after Wi-Fi
+    // exists can both violate that ordering and consume the last contiguous
+    // internal block after LVGL is built. Refuse here; UITask persists the
+    // request and reboots through setup's proven Wi-Fi -> BLE -> UI sequence.
+    if (WiFi.getMode() != WIFI_MODE_NULL) {
+      Serial.println("[ble] cold start deferred to ordered T-Pager reboot");
+      return;
+    }
+#endif
+    // Only a cold NimBLE start needs the coexistence reserve. Re-enabling an
+    // already-created stack below this threshold is allocation-free and must
+    // not be rejected (UITask used to gate both cases identically, trapping the
+    // user with BLE resident-but-off and neither radio enableable).
+    const size_t BLE_COEXIST_MIN_FREE  = 50u * 1024u;
+    const size_t BLE_COEXIST_MIN_BLOCK = 20u * 1024u;
+    const uint32_t internal_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+    const size_t internal_free = heap_caps_get_free_size(internal_caps);
+    const size_t internal_max  = heap_caps_get_largest_free_block(internal_caps);
+    if (internal_free < BLE_COEXIST_MIN_FREE ||
+        internal_max < BLE_COEXIST_MIN_BLOCK) {
+      Serial.printf("[ble] cold start refused: free=%u maxblk=%u\n",
+                    (unsigned)internal_free, (unsigned)internal_max);
+      return;
+    }
     char name[sizeof(_ble_name)];
     strncpy(name, _ble_name, sizeof(name) - 1);
     name[sizeof(name) - 1] = '\0';
@@ -211,11 +239,18 @@ void MultiTransportCompanionInterface::enableBle() {
 void MultiTransportCompanionInterface::disableBle() {
   _ble_enabled = false;
   wifiConfigSetBleEnabled(false);   // persist so BT stays off across reboot
-  _ble.disable();                    // stop advertising + drop any connection
-  // NOTE: we deliberately do NOT NimBLEDevice::deinit() here. Tearing the BT
-  // controller down while Wi-Fi+BLE coexistence is active crashes — the esp_coex
-  // layer still holds a reference to the controller — so "off" stops advertising
-  // but keeps the NimBLE host resident. Its RAM is only fully reclaimed on reboot.
+  // deinit(true) below deletes NimBLE's server, but SerialBLEInterface keeps
+  // its cached server pointer. Never call disable() again after that teardown;
+  // a later begin() replaces the cached pointers with a fresh GATT server.
+  if (_ble_begun) _ble.disable();    // stop advertising + drop any connection
+  // If Wi-Fi is genuinely absent, fully release NimBLE so a later Wi-Fi enable
+  // has the contiguous internal heap esp_wifi_init needs. While Wi-Fi exists we
+  // keep the controller resident: tearing it out from under an active coex path
+  // is unsafe, and re-enabling the already-created stack needs no allocation.
+  if (_ble_begun && WiFi.getMode() == WIFI_MODE_NULL) {
+    NimBLEDevice::deinit(true);
+    _ble_begun = false;
+  }
 }
 
 bool MultiTransportCompanionInterface::getBlePeerAddress(char* buf, size_t len) const {
@@ -241,7 +276,9 @@ void MultiTransportCompanionInterface::disable() {
   _isEnabled = false;
   _usb.disable();
 #ifdef BLE_PIN_CODE
-  _ble.disable();
+  // A prior disableBle() may have fully deinitialised NimBLE and left the
+  // wrapped SerialBLEInterface's cached server pointer dangling.
+  if (_ble_begun) _ble.disable();
 #endif
 }
 
@@ -288,8 +325,9 @@ void MultiTransportCompanionInterface::prepareForHttpOta() {
   }
 
 #ifdef BLE_PIN_CODE
-  if (_ble_begun && _ble_enabled) {
-    _ble.disable();
+  if (_ble_begun) {
+    _ota_ble_was_enabled = _ble_enabled;
+    if (_ble_enabled) _ble.disable();
     NimBLEDevice::deinit(true);
     _ble_begun = false;
     _ble_enabled = false;
@@ -320,9 +358,10 @@ void MultiTransportCompanionInterface::restoreAfterHttpOta() {
     ble_name[sizeof(ble_name) - 1] = '\0';
     _ble.begin(_ble_prefix, ble_name, _ble_pin_code);
     _ble_begun = true;
-    _ble_enabled = true;
-    _ble.enable();
+    _ble_enabled = _ota_ble_was_enabled;
+    if (_ble_enabled) _ble.enable();
     _ota_ble_released = false;
+    _ota_ble_was_enabled = false;
     meshcoreRepeaterTcpOtaEmitLine("OTA: restored BLE stack");
   }
 #endif

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -236,8 +236,9 @@ void MultiTransportCompanionInterface::enableBle() {
   _ble.enable();
 #if defined(TLORA_PAGER)
   // A successful live enable means NimBLE is now resident. Do not let the
-  // Arduino Wi-Fi event path enter WPA automatically after a later link loss;
-  // main.cpp detects that state and reboots through the Wi-Fi-first boundary.
+  // Arduino Wi-Fi event path enter WPA automatically after a later link loss.
+  // main.cpp first releases NimBLE, then explicitly re-associates and recreates
+  // BLE after GOT_IP so the same Wi-Fi-first ordering holds without a reboot.
   // Avoid touching Wi-Fi when it has never been initialised (BLE-only mode).
   if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(false);
 #endif
@@ -250,17 +251,34 @@ void MultiTransportCompanionInterface::disableBle() {
   // its cached server pointer. Never call disable() again after that teardown;
   // a later begin() replaces the cached pointers with a fresh GATT server.
   if (_ble_begun) _ble.disable();    // stop advertising + drop any connection
-  // Pager only: if Wi-Fi is genuinely absent, fully release NimBLE so a later
-  // Wi-Fi enable has the contiguous internal heap esp_wifi_init needs. Other
-  // boards retain their established resident-stack disable/re-enable behavior.
-  // While Wi-Fi exists, keep the controller resident on every board.
+  // Pager only: release NimBLE whenever the user turns Bluetooth off. This
+  // returns its internal heap and restores Wi-Fi's ordinary reconnect path;
+  // a later enable recreates the GATT server after Wi-Fi is already stable.
+  // Other boards retain their established resident-stack disable/re-enable
+  // behavior.
 #if defined(TLORA_PAGER)
-  if (_ble_begun && WiFi.getMode() == WIFI_MODE_NULL) {
+  if (_ble_begun) {
     NimBLEDevice::deinit(true);
     _ble_begun = false;
   }
+  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(true);
 #endif
 }
+
+#if defined(TLORA_PAGER)
+void MultiTransportCompanionInterface::suspendBleForWifiReconnect() {
+  // Preserve wifiConfig's BLE preference: this is a short ownership handoff,
+  // not a user-visible toggle. SerialBLEInterface::begin() replaces the cached
+  // server pointers after deinit(true), matching the cold enable path above.
+  if (_ble_begun) {
+    if (_ble_enabled) _ble.disable();
+    NimBLEDevice::deinit(true);
+    _ble_begun = false;
+  }
+  _ble_enabled = false;
+  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(true);
+}
+#endif
 
 bool MultiTransportCompanionInterface::getBlePeerAddress(char* buf, size_t len) const {
   if (!_ble_begun || !_ble_enabled) {

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -200,12 +200,10 @@ void MultiTransportCompanionInterface::enableBle() {
     // now, live, from the params stashed by prepareBle()/beginBle().
     if (_ble_prefix[0] == '\0' && _ble_name[0] == '\0') return;   // no params known
 #if defined(TLORA_PAGER)
-    // The Pager must finish Wi-Fi association before NimBLE. Once connected,
-    // a deferred cold start preserves that order and the heap guard below
-    // decides whether post-UI allocation is still safe. Refuse only while the
-    // STA is absent or actively associating; UITask keeps the saved request
-    // pending and tells the user that BLE resumes after association.
-    if (WiFi.getMode() != WIFI_MODE_NULL && WiFi.status() != WL_CONNECTED) {
+    // An idle STA may be kept up for on-device scans with no credentials, and
+    // a failed association explicitly falls back to BLE. Only the ordered WPA
+    // phase blocks a cold NimBLE start; main.cpp owns every phase transition.
+    if (wifiConfigPagerWifiBlocksBle()) {
       Serial.println("[ble] cold start deferred until T-Pager Wi-Fi associates");
       return;
     }

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -266,8 +266,9 @@ void MultiTransportCompanionInterface::disableBle() {
   // a later begin() replaces the cached pointers with a fresh GATT server.
   if (_ble_begun) _ble.disable();    // stop advertising + drop any connection
   // Pager only: release NimBLE whenever the user turns Bluetooth off. This
-  // returns its internal heap and restores Wi-Fi's ordinary reconnect path;
-  // a later enable recreates the GATT server after Wi-Fi is already stable.
+  // returns its internal heap; a later enable recreates the GATT server after
+  // Wi-Fi is already stable. Pager reconnects remain main-loop-owned so their
+  // WPA phase is always visible to the BLE ownership gate.
   // Other boards retain their established resident-stack disable/re-enable
   // behavior.
 #if defined(TLORA_PAGER)
@@ -276,7 +277,7 @@ void MultiTransportCompanionInterface::disableBle() {
     NimBLEDevice::deinit(true);
     _ble_begun = false;
   }
-  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(true);
+  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(false);
 #endif
 }
 
@@ -292,7 +293,7 @@ void MultiTransportCompanionInterface::suspendBleForWifiReconnect() {
     _ble_begun = false;
   }
   _ble_enabled = false;
-  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(true);
+  if (WiFi.getMode() != WIFI_MODE_NULL) WiFi.setAutoReconnect(false);
 }
 #endif
 

--- a/src/helpers/esp32/MultiTransportCompanionInterface.h
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.h
@@ -41,9 +41,9 @@ public:
   void enableBle() override;
   void disableBle() override;
 #if defined(TLORA_PAGER)
-  // Tear down the resident controller without changing the saved BLE intent.
-  // Wi-Fi can then re-associate before enableBle() recreates NimBLE.
-  void suspendBleForWifiReconnect();
+  // Quiesce BLE without changing the saved intent or destroying its bond/GATT
+  // state. Wi-Fi can then re-associate before enableBle() resumes advertising.
+  bool suspendBleForWifiReconnect();
 #endif
   bool isBleEnabled() const override { return _ble_enabled; }
   bool isBleStackBegun() const { return _ble_begun; }

--- a/src/helpers/esp32/MultiTransportCompanionInterface.h
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.h
@@ -43,6 +43,7 @@ public:
   void enableBle() override;
   void disableBle() override;
   bool isBleEnabled() const override { return _ble_enabled; }
+  bool isBleStackBegun() const { return _ble_begun; }
 #if defined(HAS_TDISPLAY_P4)
   // T-Display P4: the factory C6 ESP-AT firmware has its BLE advertising commands stubbed
   // (BLEADVDATA/ADVSTART all ERROR — Meck-P4 hit the same wall and ships Wi-Fi companion), and

--- a/src/helpers/esp32/MultiTransportCompanionInterface.h
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.h
@@ -31,7 +31,11 @@ public:
 
 #ifdef BLE_PIN_CODE
   // Call after begin() and the_mesh is ready (e.g. after startInterface). Enables BLE by default.
-  void beginBle(const char* prefix, char* name, uint32_t pin_code);
+  // create_enabled=false pre-creates the NimBLE host/GATT table but leaves
+  // advertising off and the user-visible/persisted state disabled. T-Pager
+  // uses this after Wi-Fi claims its heap so a later live toggle allocates
+  // nothing after the UI working set has filled internal DRAM.
+  void beginBle(const char* prefix, char* name, uint32_t pin_code, bool create_enabled = true);
   // Store the BLE name/pin WITHOUT bringing the stack up. Used at boot when the
   // heap guard defers co-initialising BLE alongside Wi-Fi: the params are kept so
   // a later enableBle() can lazily bring BLE up live (no reboot).
@@ -135,6 +139,7 @@ private:
   bool _ble_begun;    // beginBle() was called
   bool _ble_enabled;  // user has BLE on (toggle via UI)
   bool _ota_ble_released;
+  bool _ota_ble_was_enabled;
   char _ble_prefix[24];
   char _ble_name[48];
   uint32_t _ble_pin_code;

--- a/src/helpers/esp32/MultiTransportCompanionInterface.h
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.h
@@ -40,6 +40,11 @@ public:
   void prepareBle(const char* prefix, char* name, uint32_t pin_code);
   void enableBle() override;
   void disableBle() override;
+#if defined(TLORA_PAGER)
+  // Tear down the resident controller without changing the saved BLE intent.
+  // Wi-Fi can then re-associate before enableBle() recreates NimBLE.
+  void suspendBleForWifiReconnect();
+#endif
   bool isBleEnabled() const override { return _ble_enabled; }
   bool isBleStackBegun() const { return _ble_begun; }
 #if defined(HAS_TDISPLAY_P4)

--- a/src/helpers/esp32/MultiTransportCompanionInterface.h
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.h
@@ -30,12 +30,10 @@ public:
   void stopTcpServer();   // stop TCP server and disconnect clients; prevents startTcpServer until enableTcp()
 
 #ifdef BLE_PIN_CODE
-  // Call after begin() and the_mesh is ready (e.g. after startInterface). Enables BLE by default.
-  // create_enabled=false pre-creates the NimBLE host/GATT table but leaves
-  // advertising off and the user-visible/persisted state disabled. T-Pager
-  // uses this after Wi-Fi claims its heap so a later live toggle allocates
-  // nothing after the UI working set has filled internal DRAM.
-  void beginBle(const char* prefix, char* name, uint32_t pin_code, bool create_enabled = true);
+  // Call after begin() and the_mesh is ready (e.g. after startInterface).
+  // Creates and enables BLE; BLE-off Pager boots deliberately avoid a dormant
+  // NimBLE allocation so Wi-Fi retains its normal reconnect path.
+  void beginBle(const char* prefix, char* name, uint32_t pin_code);
   // Store the BLE name/pin WITHOUT bringing the stack up. Used at boot when the
   // heap guard defers co-initialising BLE alongside Wi-Fi: the params are kept so
   // a later enableBle() can lazily bring BLE up live (no reboot).

--- a/src/helpers/esp32/WifiRuntimeStore.cpp
+++ b/src/helpers/esp32/WifiRuntimeStore.cpp
@@ -21,6 +21,9 @@ static const char *WIFI_CONFIG_BLE_EN_KEY = "ble_en";   // BLE radio on/off (def
 static SdNvsPrefs s_prefs;
 static bool s_begun = false;
 static volatile bool s_wifi_apply_requested = false;
+#if defined(TLORA_PAGER)
+static volatile PagerWifiBlePhase s_pager_wifi_ble_phase = PagerWifiBlePhase::Idle;
+#endif
 
 void wifiConfigBegin() {
   if (s_begun) return;
@@ -139,6 +142,24 @@ void wifiConfigSetBleEnabled(bool enabled) {
   s_prefs.end();
   s_begun = s_prefs.begin(WIFI_CONFIG_NAMESPACE, true);
 }
+
+#if defined(TLORA_PAGER)
+void wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase phase) {
+  s_pager_wifi_ble_phase = phase;
+}
+
+PagerWifiBlePhase wifiConfigGetPagerWifiBlePhase() {
+  return s_pager_wifi_ble_phase;
+}
+
+bool wifiConfigPagerWifiBlocksBle() {
+  return s_pager_wifi_ble_phase == PagerWifiBlePhase::Associating;
+}
+
+bool wifiConfigPagerBleFallbackActive() {
+  return s_pager_wifi_ble_phase == PagerWifiBlePhase::BleFallback;
+}
+#endif
 
 bool wifiConfigGetWifiChosen() {
   if (!s_begun) wifiConfigBegin();

--- a/src/helpers/esp32/WifiRuntimeStore.cpp
+++ b/src/helpers/esp32/WifiRuntimeStore.cpp
@@ -207,6 +207,14 @@ void wifiScanSetActive(bool active) { s_wifi_scan_active = active; }
 bool wifiScanIsActive() { return s_wifi_scan_active; }
 
 void wifiConfigApply() {
+#if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
+  // The Pager must release a resident NimBLE controller before starting WPA.
+  // Funnel every legacy/CLI apply through main.cpp, which owns that ordering,
+  // the bounded handoff deadline, and BLE restoration. Calling WiFi.begin()
+  // directly here would bypass the coexistence state machine.
+  wifiConfigRequestApply();
+  return;
+#endif
 #if defined(HAS_TANMATSU)
   printf("[WIFI] apply radio_en=%d hasRuntime=%d mode=%d status=%d\n",
          (int)wifiConfigGetRadioEnabled(), (int)wifiConfigHasRuntime(),

--- a/src/helpers/esp32/WifiRuntimeStore.cpp
+++ b/src/helpers/esp32/WifiRuntimeStore.cpp
@@ -207,11 +207,10 @@ void wifiScanSetActive(bool active) { s_wifi_scan_active = active; }
 bool wifiScanIsActive() { return s_wifi_scan_active; }
 
 void wifiConfigApply() {
-#if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
-  // The Pager must release a resident NimBLE controller before starting WPA.
-  // Funnel every legacy/CLI apply through main.cpp, which owns that ordering,
-  // the bounded handoff deadline, and BLE restoration. Calling WiFi.begin()
-  // directly here would bypass the coexistence state machine.
+#if defined(MULTI_TRANSPORT_COMPANION) && !defined(HAS_TANMATSU)
+  // Multi-transport targets serialize apply and worker scans in main.cpp. The
+  // Pager additionally releases/recreates NimBLE around WPA. Calling
+  // disconnect()/begin() directly here bypasses both ownership contracts.
   wifiConfigRequestApply();
   return;
 #endif

--- a/src/helpers/esp32/WifiRuntimeStore.h
+++ b/src/helpers/esp32/WifiRuntimeStore.h
@@ -4,6 +4,7 @@
 #if defined(ESP32)
 
 #include <stddef.h>
+#include <stdint.h>
 
 #define WIFI_CONFIG_SSID_MAX 32
 #define WIFI_CONFIG_PWD_MAX 64
@@ -26,6 +27,22 @@ void wifiConfigSetRadioEnabled(bool enabled);
 bool wifiConfigGetBleEnabled();
 void wifiConfigSetBleEnabled(bool enabled);
 
+#if defined(TLORA_PAGER)
+/* Pager coexistence ownership. Wi-Fi intent alone cannot answer whether a
+ * cold NimBLE start is safe: touch builds keep the STA scannable even with no
+ * SSID. Only an active WPA association owns the ordering boundary. */
+enum class PagerWifiBlePhase : uint8_t {
+  Idle,
+  Associating,
+  Connected,
+  BleFallback,
+};
+void wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase phase);
+PagerWifiBlePhase wifiConfigGetPagerWifiBlePhase();
+bool wifiConfigPagerWifiBlocksBle();
+bool wifiConfigPagerBleFallbackActive();
+#endif
+
 /* "Wi-Fi chosen" sticky flag: set whenever the radio is explicitly enabled
  * (setRadioEnabled(true)). Historically gated whether the touch build brought
  * Wi-Fi up with no creds; now vestigial — touch defaults to Wi-Fi whenever the
@@ -33,11 +50,10 @@ void wifiConfigSetBleEnabled(bool enabled);
 bool wifiConfigGetWifiChosen();
 void wifiConfigSetWifiChosen(bool chosen);
 
-/* The actual BLE-vs-Wi-Fi transport decision used at boot and in the main loop.
- * True = bring Wi-Fi up (STA). Non-touch rule = radio enabled AND creds present.
- * On the touch build Wi-Fi is the primary transport: radio-enabled (the fresh
- * default) is enough — Wi-Fi comes up scannable even with no creds, so a brand
- * new device lands on Wi-Fi with BLE off. BLE is opt-in (clears radio_en). */
+/* Wi-Fi intent used at boot and in the main loop. True = bring Wi-Fi up (STA).
+ * Non-touch rule = radio enabled AND creds present. On touch builds, radio-on
+ * is enough to keep the STA scannable without credentials. Pager BLE ordering
+ * must use PagerWifiBlePhase rather than treating this intent as association. */
 bool wifiConfigWantsWifi();
 
 /* Request an immediate (re)apply of current Wi-Fi settings from the main loop.

--- a/src/helpers/esp32/WifiRuntimeStore.h
+++ b/src/helpers/esp32/WifiRuntimeStore.h
@@ -30,7 +30,8 @@ void wifiConfigSetBleEnabled(bool enabled);
 #if defined(TLORA_PAGER)
 /* Pager coexistence ownership. Wi-Fi intent alone cannot answer whether a
  * cold NimBLE start is safe: touch builds keep the STA scannable even with no
- * SSID. Only an active WPA association owns the ordering boundary. */
+ * SSID. Cold STA allocation and active WPA association own the short ordering
+ * boundary; an initialized idle STA can coexist with NimBLE. */
 enum class PagerWifiBlePhase : uint8_t {
   Idle,
   Associating,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,10 +105,20 @@ static uint32_t _atoi(const char* sp) {
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA),
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
     }
-    // Claim Wi-Fi's coexistence resources first. If association cannot finish
-    // during setup, keep NimBLE uninitialised; a later successful association
-    // may cold-start BLE only after Wi-Fi is already stable.
+    // Claim Wi-Fi's coexistence resources first. A real WPA association owns a
+    // bounded ordering window; idle/scannable Wi-Fi and a failed association
+    // both allow BLE to run.
     static bool s_pager_ble_after_wifi = false;
+    static uint32_t s_pager_wifi_ble_deadline_ms = 0;
+    static const uint32_t PAGER_WIFI_BLE_HANDOFF_MS = 6000;
+
+    static void pagerWifiEnterBleFallback(const char* reason) {
+      WiFi.setAutoReconnect(false);
+      WiFi.mode(WIFI_OFF);
+      wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::BleFallback);
+      s_pager_wifi_ble_deadline_ms = 0;
+      Serial.printf("[wifi] BLE fallback: %s\n", reason ? reason : "association stopped");
+    }
     #endif
   #elif defined(WIFI_SSID)
     #include <helpers/esp32/SerialWifiInterface.h>
@@ -705,6 +715,9 @@ void setup() {
   bool want_wifi = wifiConfigWantsWifi();
 #if defined(TLORA_PAGER)
   bool pager_wifi_ready_for_ble = false;
+  const bool pager_want_ble = wifiConfigGetBleEnabled();
+  const bool pager_has_wifi_credentials = wifiConfigHasRuntime();
+  wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
 #endif
   /* Wi-Fi + BLE now COEXIST (NimBLE host is light enough — the old Bluedroid
    * heap clash is gone). Bring Wi-Fi up FIRST: esp_wifi_init grabs a big
@@ -725,12 +738,13 @@ void setup() {
      * first and wait on the state transition (not a fixed delay), while
      * internal heap is still plentiful; BLE starts below only after the link
      * is established. T-Deck does not reproduce this ordering constraint. */
-    if (wifiConfigHasRuntime()) {
+    if (pager_has_wifi_credentials) {
       char ssid[WIFI_CONFIG_SSID_MAX];
       char pwd[WIFI_CONFIG_PWD_MAX];
       wifiConfigGetSsid(ssid, sizeof(ssid));
       wifiConfigGetPwd(pwd, sizeof(pwd));
       if (ssid[0]) {
+        wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Associating);
         const uint32_t assoc_start_ms = millis();
         WiFi.begin(ssid, pwd[0] ? pwd : nullptr);
         while (WiFi.status() != WL_CONNECTED &&
@@ -738,11 +752,24 @@ void setup() {
           delay(20);
         }
         pager_wifi_ready_for_ble = WiFi.status() == WL_CONNECTED;
+        if (pager_wifi_ready_for_ble) {
+          wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Connected);
+        } else if (pager_want_ble) {
+          // Do not strand BLE behind an unavailable AP. Stop authentication so
+          // NimBLE cannot race a background WPA retry, then leave Wi-Fi retry
+          // paused until an explicit Apply/toggle requests another handoff.
+          pagerWifiEnterBleFallback("boot association timed out");
+        }
         Serial.printf("[boot] Pager Wi-Fi pre-BLE association: %s (%lums)\n",
-                      pager_wifi_ready_for_ble ? "ready" : "deferred",
+                      pager_wifi_ready_for_ble ? "ready" :
+                        (pager_want_ble ? "BLE fallback" : "still associating"),
                       (unsigned long)(millis() - assoc_start_ms));
         pagerLogInternalHeap("after Wi-Fi association");
       }
+    } else {
+      // Keep STA available for the setup wizard's scan, but with no credentials
+      // there is no association to order ahead of BLE.
+      WiFi.setAutoReconnect(false);
     }
 #endif
   }
@@ -761,12 +788,12 @@ void setup() {
   serial_interface.prepareBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name, the_mesh.getBLEPin());
 #if defined(TLORA_PAGER)
   {
-    const bool want_ble = wifiConfigGetBleEnabled();
+    const bool want_ble = pager_want_ble;
     /* Serialise the Pager's first association before BLE init. Once associated,
      * the two radios coexist normally. Do not create a disabled NimBLE stack
      * for Wi-Fi-only users: keeping Wi-Fi's normal auto-reconnect path avoids a
      * needless device reboot when no Bluetooth controller is resident. */
-    if (!want_wifi || pager_wifi_ready_for_ble) {
+    if (!wifiConfigPagerWifiBlocksBle()) {
       if (want_ble) {
         // Use the same contiguous-heap guard as every other cold NimBLE start.
         // Boot normally has the most headroom, but a future driver allocation
@@ -776,20 +803,15 @@ void setup() {
           Serial.printf("[boot] BLE stack ready (enabled=1 wifi=%d)\n", (int)want_wifi);
           pagerLogInternalHeap("after BLE init");
         } else {
-          // Leave the same pending state the association-timeout branch below
-          // leaves, so the GOT_IP retry picks this up too. Note it cannot fire
-          // in the !want_wifi case: Wi-Fi never associates, so a BLE-only boot
-          // that loses the heap guard stays deferred until the user toggles
-          // Bluetooth (which reboots into a clean allocation order).
+          // A future association edge or explicit Bluetooth retry can consume
+          // the request. This is a heap refusal, not Wi-Fi ownership.
           s_pager_ble_after_wifi = true;
           Serial.println("[boot] BLE cold start deferred: insufficient contiguous heap");
         }
       }
     } else {
-      // No credentials yet, or the saved association timed out. Leave NimBLE
-      // completely absent so all credential/apply and retry paths remain safe.
-      // If BLE is requested, a late Wi-Fi success may allocate it only after
-      // association, subject to the same internal-heap guard as a UI cold start.
+      // Only an active association reaches here. Both success and the bounded
+      // fallback consume this pending request.
       s_pager_ble_after_wifi = want_ble;
       Serial.printf("[boot] BLE init deferred until ordered Wi-Fi association (enable=%d)\n",
                     (int)want_ble);
@@ -918,6 +940,14 @@ void loop() {
    * Pager setup separately guarantees that Wi-Fi claims its coexistence
    * resources before a cold BLE start. */
   bool wifi_radio_en = wifiConfigWantsWifi();
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+  // BLE fallback pauses automatic association so a missing AP cannot make the
+  // advertised GATT service disappear every retry interval. Turning Bluetooth
+  // off releases that preference: Wi-Fi may resume its ordinary retry loop.
+  if (wifiConfigPagerBleFallbackActive() && !wifiConfigGetBleEnabled()) {
+    wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
+  }
+#endif
   if (!wifi_radio_inited) {
     wifi_radio_inited = true;
     wifi_radio_prev = wifi_radio_en;
@@ -929,6 +959,8 @@ void loop() {
       WiFi.mode(WIFI_OFF);
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
       pager_wifi_was_connected = false;
+      s_pager_wifi_ble_deadline_ms = 0;
+      wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
       const bool ble_waiting = s_pager_ble_after_wifi ||
                                (wifiConfigGetBleEnabled() &&
                                 !serial_interface.isBleStackBegun());
@@ -958,11 +990,18 @@ void loop() {
     // Credential changes need the same Wi-Fi-before-BLE order as boot. Release
     // the resident controller without changing the saved BLE intent, apply the
     // credentials live, then recreate BLE after the new link reaches GOT_IP.
-    if (wifi_radio_en && wifiConfigHasRuntime() &&
-        serial_interface.isBleStackBegun()) {
+    if (wifi_radio_en && wifiConfigHasRuntime()) {
       s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
-      serial_interface.suspendBleForWifiReconnect();
-      Serial.println("[wifi] BLE released for ordered T-Pager association");
+      s_pager_wifi_ble_deadline_ms = s_pager_ble_after_wifi
+          ? millis() + PAGER_WIFI_BLE_HANDOFF_MS : 0;
+      wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Associating);
+      if (serial_interface.isBleStackBegun()) {
+        serial_interface.suspendBleForWifiReconnect();
+        Serial.println("[wifi] BLE released for ordered T-Pager association");
+      }
+    } else {
+      s_pager_wifi_ble_deadline_ms = 0;
+      wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
     }
     if (wifi_radio_en && !serial_interface.isBleStackBegun()) {
       WiFi.setAutoReconnect(true);
@@ -985,7 +1024,11 @@ void loop() {
     wifi_started = false;
     last_wifi_retry_ms = 0;
   }
-  if (wifi_radio_en) {
+  bool wifi_state_machine_active = wifi_radio_en;
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+  wifi_state_machine_active = wifi_state_machine_active && !wifiConfigPagerBleFallbackActive();
+#endif
+  if (wifi_state_machine_active) {
     if (!wifi_started) {
       wifi_started = true;
       WiFi.mode(WIFI_STA);
@@ -995,9 +1038,16 @@ void loop() {
         wifiConfigGetSsid(ssid, sizeof(ssid));
         wifiConfigGetPwd(pwd, sizeof(pwd));
         if (strlen(ssid) > 0 && WiFi.status() != WL_CONNECTED) {
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+          wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Associating);
+#endif
           WiFi.begin(ssid, pwd[0] ? pwd : nullptr);
         }
         last_wifi_retry_ms = millis();
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+      } else {
+        wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
+#endif
       }
     }
     // Automatic WiFi recovery for TCP mode: retry connection periodically if link drops.
@@ -1008,12 +1058,15 @@ void loop() {
       if ((uint32_t)(now - last_wifi_retry_ms) >= WIFI_RETRY_INTERVAL_MS) {
         last_wifi_retry_ms = now;
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+        s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
+        s_pager_wifi_ble_deadline_ms = s_pager_ble_after_wifi
+            ? now + PAGER_WIFI_BLE_HANDOFF_MS : 0;
+        wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Associating);
         if (serial_interface.isBleStackBegun()) {
           // Auto-reconnect is disabled once NimBLE exists. Release the BLE
           // controller first, then use the ordinary retry below; GOT_IP recreates
           // BLE once Wi-Fi owns the coexistence path again. This bounds an AP
           // outage to transport reconnects instead of a device reboot loop.
-          s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
           serial_interface.suspendBleForWifiReconnect();
           Serial.println("[wifi] BLE released after link loss; re-associating");
         }
@@ -1038,6 +1091,8 @@ void loop() {
     static uint32_t sntp_kick_ms = 0;
     if (WiFi.status() == WL_CONNECTED) {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+      wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Connected);
+      s_pager_wifi_ble_deadline_ms = 0;
       const bool became_connected = !pager_wifi_was_connected;
       pager_wifi_was_connected = true;
       const bool ble_waiting = s_pager_ble_after_wifi ||
@@ -1094,10 +1149,35 @@ void loop() {
     } else {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
       pager_wifi_was_connected = false;
+      if (wifiConfigGetPagerWifiBlePhase() == PagerWifiBlePhase::Connected)
+        wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
 #endif
       // Link dropped: allow re-sync on next reconnect.
       if (sntp_kicked && !sntp_pushed) sntp_kicked = false;
     }
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+    if (s_pager_wifi_ble_deadline_ms != 0 &&
+        (int32_t)(millis() - s_pager_wifi_ble_deadline_ms) >= 0) {
+      s_pager_wifi_ble_deadline_ms = 0;
+      if (s_pager_ble_after_wifi && wifiConfigGetBleEnabled() &&
+          WiFi.status() != WL_CONNECTED) {
+        s_pager_ble_after_wifi = false;
+        pager_wifi_was_connected = false;
+        wifi_started = false;
+        pagerWifiEnterBleFallback("association timed out; Bluetooth restored");
+        serial_interface.enableBle();
+        if (serial_interface.isBleEnabled()) {
+          Serial.println("[wifi] BLE restored after failed T-Pager association");
+          ui_task.showAlert(TR("Wi-Fi unavailable; Bluetooth restored"), 2200);
+        } else {
+          Serial.println("[wifi] BLE restore failed after T-Pager association timeout");
+          ui_task.showAlert(TR("Bluetooth unavailable; retry from Settings"), 2600);
+        }
+      } else if (!wifiConfigGetBleEnabled()) {
+        s_pager_ble_after_wifi = false;
+      }
+    }
+#endif
   }
 #ifdef DISPLAY_CLASS
   { uint32_t _wfdt = millis() - _wf0; if (_wfdt >= 200) stallLog("wifi-sm", _wfdt); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -901,6 +901,9 @@ void loop() {
   static const uint32_t WIFI_RETRY_INTERVAL_MS = 10000;
   static bool wifi_radio_prev = true;
   static bool wifi_radio_inited = false;
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+  static bool pager_wifi_was_connected = false;
+#endif
   /* Run the saved Wi-Fi state machine whenever its radio preference is on.
    * Pager setup separately guarantees that Wi-Fi claims its coexistence
    * resources before a cold BLE start. */
@@ -915,8 +918,12 @@ void loop() {
       delay(50);
       WiFi.mode(WIFI_OFF);
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-      if (s_pager_ble_after_wifi) {
-        s_pager_ble_after_wifi = false;
+      pager_wifi_was_connected = false;
+      const bool ble_waiting = s_pager_ble_after_wifi ||
+                               (wifiConfigGetBleEnabled() &&
+                                !serial_interface.isBleStackBegun());
+      s_pager_ble_after_wifi = false;
+      if (ble_waiting) {
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
           serial_interface.enableBle();
           if (serial_interface.isBleEnabled()) {
@@ -1019,7 +1026,12 @@ void loop() {
     static uint32_t sntp_kick_ms = 0;
     if (WiFi.status() == WL_CONNECTED) {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-      if (s_pager_ble_after_wifi) {
+      const bool became_connected = !pager_wifi_was_connected;
+      pager_wifi_was_connected = true;
+      const bool ble_waiting = s_pager_ble_after_wifi ||
+                               (wifiConfigGetBleEnabled() &&
+                                !serial_interface.isBleStackBegun());
+      if (became_connected && ble_waiting) {
         s_pager_ble_after_wifi = false;
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
           // Wi-Fi is now stable, so a cold BLE allocation cannot enter WPA in
@@ -1068,6 +1080,9 @@ void loop() {
         }
       }
     } else {
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+      pager_wifi_was_connected = false;
+#endif
       // Link dropped: allow re-sync on next reconnect.
       if (sntp_kicked && !sntp_pushed) sntp_kicked = false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -945,14 +945,14 @@ void loop() {
    * from the UI (the transition above already covered the on case). */
   if (wifiConfigConsumeApplyRequest()) {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-    // With NimBLE resident, every explicit credential/reconnect request must
-    // return through setup. Wi-Fi-only applies stay live: opening the Wi-Fi
-    // page itself performs a scan/rejoin and must not reboot the device.
+    // Credential changes need the same Wi-Fi-before-BLE order as boot. Release
+    // the resident controller without changing the saved BLE intent, apply the
+    // credentials live, then recreate BLE after the new link reaches GOT_IP.
     if (wifi_radio_en && wifiConfigHasRuntime() &&
         serial_interface.isBleStackBegun()) {
-      Serial.println("[wifi] restarting for ordered T-Pager association");
-      ui_task.rebootDevice();
-      return;
+      s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
+      serial_interface.suspendBleForWifiReconnect();
+      Serial.println("[wifi] BLE released for ordered T-Pager association");
     }
     if (wifi_radio_en && !serial_interface.isBleStackBegun()) {
       WiFi.setAutoReconnect(true);
@@ -999,11 +999,13 @@ void loop() {
         last_wifi_retry_ms = now;
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
         if (serial_interface.isBleStackBegun()) {
-          // Auto-reconnect is disabled once NimBLE exists. Re-authenticate at
-          // boot before recreating BLE rather than entering WPA under coex.
-          Serial.println("[wifi] link lost with BLE resident; restarting for ordered association");
-          ui_task.rebootDevice();
-          return;
+          // Auto-reconnect is disabled once NimBLE exists. Release the BLE
+          // controller first, then use the ordinary retry below; GOT_IP recreates
+          // BLE once Wi-Fi owns the coexistence path again. This bounds an AP
+          // outage to transport reconnects instead of a device reboot loop.
+          s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
+          serial_interface.suspendBleForWifiReconnect();
+          Serial.println("[wifi] BLE released after link loss; re-associating");
         }
 #endif
         char ssid[WIFI_CONFIG_SSID_MAX];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,16 +105,21 @@ static uint32_t _atoi(const char* sp) {
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA),
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
     }
-    // Claim Wi-Fi's coexistence resources first. A real WPA association owns a
-    // bounded ordering window; idle/scannable Wi-Fi and a failed association
-    // both allow BLE to run.
+    // Claim Wi-Fi's coexistence resources first. A cold STA allocation or real
+    // WPA association owns a bounded ordering window; idle/scannable Wi-Fi and
+    // a failed association both allow BLE to run.
     static bool s_pager_ble_after_wifi = false;
     static uint32_t s_pager_wifi_ble_deadline_ms = 0;
     static const uint32_t PAGER_WIFI_BLE_HANDOFF_MS = 6000;
 
     static void pagerWifiEnterBleFallback(const char* reason) {
       WiFi.setAutoReconnect(false);
-      WiFi.mode(WIFI_OFF);
+      // Stop WPA without deinitializing esp_wifi. Keeping the STA allocation
+      // resident lets BLE come back immediately and avoids repeating the
+      // order-sensitive cold allocation for a later scan or explicit retry.
+      if ((WiFi.getMode() & WIFI_MODE_STA) != 0) {
+        WiFi.disconnect(false, false);
+      }
       wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::BleFallback);
       s_pager_wifi_ble_deadline_ms = 0;
       Serial.printf("[wifi] BLE fallback: %s\n", reason ? reason : "association stopped");
@@ -724,8 +729,11 @@ void setup() {
    * contiguous DMA block, so let it claim memory before BLE. (Association
    * happens later in loop(); this just inits the stack.) */
   if (want_wifi) {
-    WiFi.mode(WIFI_STA);
+    const bool wifi_mode_ready = WiFi.mode(WIFI_STA);
 #if defined(TLORA_PAGER)
+    if (!wifi_mode_ready) {
+      pagerWifiEnterBleFallback("boot STA initialization failed");
+    }
     // Pager reconnects are owned by the loop below. Background WPA retries are
     // invisible to PagerWifiBlePhase and could overlap a cold NimBLE start.
     WiFi.setAutoReconnect(false);
@@ -744,7 +752,7 @@ void setup() {
      * first and wait on the state transition (not a fixed delay), while
      * internal heap is still plentiful; BLE starts below only after the link
      * is established. T-Deck does not reproduce this ordering constraint. */
-    if (pager_has_wifi_credentials) {
+    if (wifi_mode_ready && pager_has_wifi_credentials) {
       char ssid[WIFI_CONFIG_SSID_MAX];
       char pwd[WIFI_CONFIG_PWD_MAX];
       wifiConfigGetSsid(ssid, sizeof(ssid));
@@ -772,7 +780,7 @@ void setup() {
                       (unsigned long)(millis() - assoc_start_ms));
         pagerLogInternalHeap("after Wi-Fi association");
       }
-    } else {
+    } else if (wifi_mode_ready) {
       // Keep STA available for the setup wizard's scan, but with no credentials
       // there is no association to order ahead of BLE.
       WiFi.setAutoReconnect(false);
@@ -939,9 +947,6 @@ void loop() {
   static const uint32_t WIFI_RETRY_INTERVAL_MS = 10000;
   static bool wifi_radio_prev = true;
   static bool wifi_radio_inited = false;
-#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-  static bool pager_wifi_was_connected = false;
-#endif
   /* Run the saved Wi-Fi state machine whenever its radio preference is on.
    * Pager setup separately guarantees that Wi-Fi claims its coexistence
    * resources before a cold BLE start. */
@@ -949,8 +954,10 @@ void loop() {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
   // BLE fallback pauses automatic association so a missing AP cannot make the
   // advertised GATT service disappear every retry interval. Turning Bluetooth
-  // off releases that preference: Wi-Fi may resume its ordinary retry loop.
-  if (wifiConfigPagerBleFallbackActive() && !wifiConfigGetBleEnabled()) {
+  // off resumes retries only when the STA allocation itself is healthy; an
+  // allocation failure stays latched until an explicit Apply/toggle.
+  if (wifiConfigPagerBleFallbackActive() && !wifiConfigGetBleEnabled() &&
+      (WiFi.getMode() & WIFI_MODE_STA) != 0) {
     wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
   }
   // An association may have started while Bluetooth was disabled. If the user
@@ -973,7 +980,6 @@ void loop() {
       delay(50);
       WiFi.mode(WIFI_OFF);
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-      pager_wifi_was_connected = false;
       s_pager_wifi_ble_deadline_ms = 0;
       wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
       const bool ble_waiting = s_pager_ble_after_wifi ||
@@ -986,9 +992,8 @@ void loop() {
           if (serial_interface.isBleEnabled()) {
             Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi was disabled");
           } else {
-            Serial.println("[boot] restarting to allocate deferred BLE before the UI");
-            ui_task.rebootDevice();
-            return;
+            Serial.println("[wifi] deferred BLE unavailable after Wi-Fi was disabled");
+            ui_task.showAlert(TR("Bluetooth unavailable; retry from Settings"), 2600);
           }
         }
       }
@@ -1000,21 +1005,34 @@ void loop() {
    * by forcing wifi_started=false; on next iter the block below will WiFi.begin
    * with the freshly-saved credentials. Also handles toggling radio_en off
    * from the UI (the transition above already covered the on case). */
-  if (wifiConfigConsumeApplyRequest()) {
+  bool wifi_apply_ready = true;
+#if defined(ESP32)
+  // Keep a queued credential/radio re-apply pending until the worker releases
+  // its scan. Consuming it here would disconnect or reconfigure the driver
+  // underneath esp_wifi_scan_start on the other core.
+  wifi_apply_ready = !wifiScanIsActive();
+#endif
+  if (wifi_apply_ready && wifiConfigConsumeApplyRequest()) {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-    // Credential changes need the same Wi-Fi-before-BLE order as boot. Release
-    // the resident controller without changing the saved BLE intent, apply the
-    // credentials live, then recreate BLE after the new link reaches GOT_IP.
-    if (wifi_radio_en && wifiConfigHasRuntime()) {
-      s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
-      s_pager_wifi_ble_deadline_ms = s_pager_ble_after_wifi
-          ? millis() + PAGER_WIFI_BLE_HANDOFF_MS : 0;
-      wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Associating);
-      if (serial_interface.isBleStackBegun()) {
+    // Cold Wi-Fi allocation and credential changes use the same live handoff:
+    // preserve BLE intent, release NimBLE, let the main task own esp_wifi_init
+    // and WPA, then recreate NimBLE once Wi-Fi is stable (or has timed out).
+    if (wifi_radio_en) {
+      const bool cold_sta = (WiFi.getMode() & WIFI_MODE_STA) == 0;
+      const bool ordered_handoff = cold_sta || wifiConfigHasRuntime();
+      s_pager_ble_after_wifi = wifiConfigGetBleEnabled() &&
+          (ordered_handoff || !serial_interface.isBleStackBegun());
+      s_pager_wifi_ble_deadline_ms =
+          (wifiConfigHasRuntime() && s_pager_ble_after_wifi)
+              ? millis() + PAGER_WIFI_BLE_HANDOFF_MS : 0;
+      wifiConfigSetPagerWifiBlePhase(ordered_handoff
+          ? PagerWifiBlePhase::Associating : PagerWifiBlePhase::Idle);
+      if (ordered_handoff && serial_interface.isBleStackBegun()) {
         serial_interface.suspendBleForWifiReconnect();
-        Serial.println("[wifi] BLE released for ordered T-Pager association");
+        Serial.println("[wifi] BLE released for ordered T-Pager Wi-Fi start");
       }
     } else {
+      s_pager_ble_after_wifi = false;
       s_pager_wifi_ble_deadline_ms = 0;
       wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
     }
@@ -1046,9 +1064,33 @@ void loop() {
 #endif
   if (wifi_state_machine_active) {
     if (!wifi_started) {
-      wifi_started = true;
-      WiFi.mode(WIFI_STA);
-      if (wifiConfigHasRuntime()) {
+      const bool wifi_mode_ready = WiFi.mode(WIFI_STA);
+      if (!wifi_mode_ready) {
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+        const bool ble_waiting = s_pager_ble_after_wifi ||
+                                 (wifiConfigGetBleEnabled() &&
+                                  !serial_interface.isBleStackBegun());
+        s_pager_ble_after_wifi = false;
+        last_wifi_retry_ms = millis();
+        pagerWifiEnterBleFallback("STA initialization failed; Bluetooth restored");
+        if (ble_waiting && wifiConfigGetBleEnabled() &&
+            !serial_interface.isBleEnabled()) {
+          serial_interface.enableBle();
+        }
+        if (wifiConfigGetBleEnabled() && serial_interface.isBleEnabled()) {
+          ui_task.showAlert(TR("Wi-Fi unavailable; Bluetooth restored"), 2200);
+        } else if (wifiConfigGetBleEnabled()) {
+          ui_task.showAlert(TR("Wi-Fi and Bluetooth unavailable; retry from Settings"), 2800);
+        } else {
+          ui_task.showAlert(TR("Wi-Fi unavailable; retry from Settings"), 2200);
+        }
+#else
+        last_wifi_retry_ms = millis();
+#endif
+      } else {
+        wifi_started = true;
+      }
+      if (wifi_mode_ready && wifiConfigHasRuntime() && !wifiScanIsActive()) {
         char ssid[WIFI_CONFIG_SSID_MAX];
         char pwd[WIFI_CONFIG_PWD_MAX];
         wifiConfigGetSsid(ssid, sizeof(ssid));
@@ -1061,8 +1103,23 @@ void loop() {
         }
         last_wifi_retry_ms = millis();
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-      } else {
+      } else if (wifi_mode_ready) {
         wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
+        s_pager_wifi_ble_deadline_ms = 0;
+        const bool ble_waiting = s_pager_ble_after_wifi ||
+                                 (wifiConfigGetBleEnabled() &&
+                                  !serial_interface.isBleStackBegun());
+        s_pager_ble_after_wifi = false;
+        if (ble_waiting && wifiConfigGetBleEnabled() &&
+            !serial_interface.isBleEnabled()) {
+          serial_interface.enableBle();
+          if (serial_interface.isBleEnabled()) {
+            Serial.println("[wifi] BLE restored after idle STA initialization");
+          } else {
+            Serial.println("[wifi] BLE unavailable after idle STA initialization");
+            ui_task.showAlert(TR("Bluetooth unavailable; retry from Settings"), 2600);
+          }
+        }
 #endif
       }
     }
@@ -1109,12 +1166,11 @@ void loop() {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
       wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Connected);
       s_pager_wifi_ble_deadline_ms = 0;
-      const bool became_connected = !pager_wifi_was_connected;
-      pager_wifi_was_connected = true;
-      const bool ble_waiting = s_pager_ble_after_wifi ||
-                               (wifiConfigGetBleEnabled() &&
-                                !serial_interface.isBleStackBegun());
-      if (became_connected && ble_waiting) {
+      // Consume only the explicit handoff token. If the cold NimBLE recreate
+      // is refused, do not hammer the allocator and alert on every loop while
+      // Wi-Fi remains connected; Settings is the deliberate retry surface.
+      const bool ble_waiting = s_pager_ble_after_wifi;
+      if (ble_waiting) {
         s_pager_ble_after_wifi = false;
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
           // Wi-Fi is now stable, so a cold BLE allocation cannot enter WPA in
@@ -1164,7 +1220,6 @@ void loop() {
       }
     } else {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-      pager_wifi_was_connected = false;
       if (wifiConfigGetPagerWifiBlePhase() == PagerWifiBlePhase::Connected)
         wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
 #endif
@@ -1178,7 +1233,6 @@ void loop() {
       if (s_pager_ble_after_wifi && wifiConfigGetBleEnabled() &&
           WiFi.status() != WL_CONNECTED) {
         s_pager_ble_after_wifi = false;
-        pager_wifi_was_connected = false;
         wifi_started = false;
         pagerWifiEnterBleFallback("association timed out; Bluetooth restored");
         serial_interface.enableBle();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,9 +104,9 @@ static uint32_t _atoi(const char* sp) {
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA),
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
     }
-    // On a fresh profile there may be no saved credentials yet.
-    // Claim Wi-Fi's coexistence resources first, then start the prepared BLE
-    // stack as soon as that first association succeeds.
+    // Claim Wi-Fi's coexistence resources first. If association cannot finish
+    // during setup, keep NimBLE uninitialised and either retry Wi-Fi alone or
+    // reboot once before enabling the prepared BLE stack.
     static bool s_pager_ble_after_wifi = false;
     #endif
   #elif defined(WIFI_SSID)
@@ -711,9 +711,8 @@ void setup() {
    * happens later in loop(); this just inits the stack.) */
   if (want_wifi) {
     WiFi.mode(WIFI_STA);
-    WiFi.setAutoReconnect(true);   // let esp_wifi rejoin on its own after a beacon loss / AP reboot
-                                   // (was false — the 10 s poll below was the ONLY recovery, and a
-                                   // bare begin() on a wedged supplicant is a no-op -> never reconnected)
+    WiFi.setAutoReconnect(true);   // safe while NimBLE is not resident; disabled below once BLE
+                                   // exists so a later WPA re-auth cannot bypass Wi-Fi-first ordering
     WiFi.persistent(false);
     // NOTE: do NOT enable modem-sleep here. On a fresh, *unassociated* STA (the
     // setup wizard, no creds yet) DTIM modem-sleep naps the radio through the
@@ -763,28 +762,27 @@ void setup() {
   {
     const bool want_ble = wifiConfigGetBleEnabled();
     /* Serialise the Pager's first association before BLE init. Once associated,
-     * the two radios coexist normally. When Wi-Fi is enabled, pre-create the
-     * stack even if the saved BLE state is off: late allocation after LVGL has
-     * built the home UI can no longer find a large enough internal block, while
-     * a pre-created disabled stack can start advertising allocation-free. */
-    if (!want_wifi || pager_wifi_ready_for_ble || !wifiConfigHasRuntime()) {
+     * the two radios coexist normally. Pre-create the stack even if the saved
+     * BLE state is off, but only after Wi-Fi is actually associated; otherwise
+     * the setup wizard or an automatic retry could re-enter WPA with NimBLE
+     * resident and reproduce the coexistence watchdog. */
+    if (!want_wifi || pager_wifi_ready_for_ble) {
       if (want_ble || want_wifi) {
         serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
                                   the_mesh.getBLEPin(), want_ble);
+        if (want_wifi) WiFi.setAutoReconnect(false);
         Serial.printf("[boot] BLE stack ready (enabled=%d wifi=%d)\n",
                       (int)want_ble, (int)want_wifi);
         pagerLogInternalHeap("after BLE init");
       }
     } else {
-      // Wi-Fi owns its required heap now, but a saved association did not
-      // complete. Still allocate the NimBLE/GATT objects before LVGL consumes
-      // and fragments the remaining internal RAM; leave advertising disabled
-      // until Wi-Fi connects (or the user explicitly enables BLE live).
-      serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
-                                the_mesh.getBLEPin(), false);
+      // No credentials yet, or the saved association timed out. Leave NimBLE
+      // completely absent so all credential/apply and retry paths remain safe.
+      // If BLE is requested, a late Wi-Fi success reboots once through setup's
+      // Wi-Fi -> BLE -> UI order before advertising begins.
       s_pager_ble_after_wifi = want_ble;
-      Serial.printf("[boot] BLE stack ready disabled; deferred enable=%d\n", (int)want_ble);
-      pagerLogInternalHeap("after deferred BLE init");
+      Serial.printf("[boot] BLE init deferred until ordered Wi-Fi association (enable=%d)\n",
+                    (int)want_ble);
     }
   }
 #else
@@ -921,7 +919,13 @@ void loop() {
         s_pager_ble_after_wifi = false;
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
           serial_interface.enableBle();
-          Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi was disabled");
+          if (serial_interface.isBleEnabled()) {
+            Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi was disabled");
+          } else {
+            Serial.println("[boot] restarting to allocate deferred BLE before the UI");
+            ui_task.rebootDevice();
+            return;
+          }
         }
       }
 #endif
@@ -933,11 +937,21 @@ void loop() {
    * with the freshly-saved credentials. Also handles toggling radio_en off
    * from the UI (the transition above already covered the on case). */
   if (wifiConfigConsumeApplyRequest()) {
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+    // Every explicit credential/reconnect request must return through setup.
+    // This covers the setup wizard, saved-network/slot activation, scan
+    // reconnect, transport settings, and companion/CLI-backed preference
+    // updates instead of relying on each caller to remember the Pager's order.
+    if (wifi_radio_en && wifiConfigHasRuntime()) {
+      Serial.println("[wifi] restarting for ordered T-Pager association");
+      ui_task.rebootDevice();
+      return;
+    }
+#endif
     /* Only touch WiFi state if it was actually started this session. When
      * BLE is the active transport (no creds saved), WiFi was never inited
      * and calling WiFi.disconnect()/mode(WIFI_OFF) would trigger esp_wifi_init
-     * under low heap → crash. Setting wifi_started=false here is harmless;
-     * setup() will re-pick BLE-vs-WiFi on the auto-reboot from saveWifiCb. */
+     * under low heap → crash. Setting wifi_started=false here is harmless. */
     if (wifi_started) {
       if (!wifi_radio_en) {
         WiFi.disconnect(true);
@@ -973,6 +987,15 @@ void loop() {
       uint32_t now = millis();
       if ((uint32_t)(now - last_wifi_retry_ms) >= WIFI_RETRY_INTERVAL_MS) {
         last_wifi_retry_ms = now;
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+        if (serial_interface.isBleStackBegun()) {
+          // Auto-reconnect is disabled once NimBLE exists. Re-authenticate at
+          // boot before recreating BLE rather than entering WPA under coex.
+          Serial.println("[wifi] link lost with BLE resident; restarting for ordered association");
+          ui_task.rebootDevice();
+          return;
+        }
+#endif
         char ssid[WIFI_CONFIG_SSID_MAX];
         char pwd[WIFI_CONFIG_PWD_MAX];
         wifiConfigGetSsid(ssid, sizeof(ssid));
@@ -996,8 +1019,11 @@ void loop() {
       if (s_pager_ble_after_wifi) {
         s_pager_ble_after_wifi = false;
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
-          serial_interface.enableBle();
-          Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi association");
+          // Wi-Fi associated after setup, when the UI already owns its working
+          // set. Reboot once so BLE allocates before LVGL and after Wi-Fi.
+          Serial.println("[boot] Wi-Fi ready; restarting to allocate deferred BLE in order");
+          ui_task.rebootDevice();
+          return;
         }
       }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -776,6 +776,12 @@ void setup() {
           Serial.printf("[boot] BLE stack ready (enabled=1 wifi=%d)\n", (int)want_wifi);
           pagerLogInternalHeap("after BLE init");
         } else {
+          // Leave the same pending state the association-timeout branch below
+          // leaves, so the GOT_IP retry picks this up too. Note it cannot fire
+          // in the !want_wifi case: Wi-Fi never associates, so a BLE-only boot
+          // that loses the heap guard stays deferred until the user toggles
+          // Bluetooth (which reboots into a clean allocation order).
+          s_pager_ble_after_wifi = true;
           Serial.println("[boot] BLE cold start deferred: insufficient contiguous heap");
         }
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1015,22 +1015,33 @@ void loop() {
   if (wifi_apply_ready && wifiConfigConsumeApplyRequest()) {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
     // Cold Wi-Fi allocation and credential changes use the same live handoff:
-    // preserve BLE intent, release NimBLE, let the main task own esp_wifi_init
-    // and WPA, then recreate NimBLE once Wi-Fi is stable (or has timed out).
+    // preserve BLE intent and bond state, quiesce BLE traffic, let the main task
+    // own esp_wifi_init and WPA, then resume BLE once Wi-Fi is stable (or has
+    // timed out).
     if (wifi_radio_en) {
       const bool cold_sta = (WiFi.getMode() & WIFI_MODE_STA) == 0;
       const bool ordered_handoff = cold_sta || wifiConfigHasRuntime();
       s_pager_ble_after_wifi = wifiConfigGetBleEnabled() &&
           (ordered_handoff || !serial_interface.isBleStackBegun());
-      s_pager_wifi_ble_deadline_ms =
-          (wifiConfigHasRuntime() && s_pager_ble_after_wifi)
-              ? millis() + PAGER_WIFI_BLE_HANDOFF_MS : 0;
+      s_pager_wifi_ble_deadline_ms = 0;
       wifiConfigSetPagerWifiBlePhase(ordered_handoff
           ? PagerWifiBlePhase::Associating : PagerWifiBlePhase::Idle);
       if (ordered_handoff && serial_interface.isBleStackBegun()) {
-        serial_interface.suspendBleForWifiReconnect();
-        Serial.println("[wifi] BLE released for ordered T-Pager Wi-Fi start");
+        if (!serial_interface.suspendBleForWifiReconnect()) {
+          s_pager_ble_after_wifi = false;
+          s_pager_wifi_ble_deadline_ms = 0;
+          pagerWifiEnterBleFallback("BLE disconnect timed out; Wi-Fi start cancelled");
+          if (wifiConfigGetBleEnabled()) serial_interface.enableBle();
+          ui_task.showAlert(TR("Wi-Fi paused; Bluetooth disconnect timed out"), 2600);
+          return;
+        }
+        Serial.println("[wifi] BLE paused for ordered T-Pager Wi-Fi start");
       }
+      // Give WPA its full window; the bounded asynchronous BLE disconnect above
+      // is part of quiescing the old transport, not part of association time.
+      s_pager_wifi_ble_deadline_ms =
+          (wifiConfigHasRuntime() && s_pager_ble_after_wifi)
+              ? millis() + PAGER_WIFI_BLE_HANDOFF_MS : 0;
     } else {
       s_pager_ble_after_wifi = false;
       s_pager_wifi_ble_deadline_ms = 0;
@@ -1132,17 +1143,25 @@ void loop() {
         last_wifi_retry_ms = now;
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
         s_pager_ble_after_wifi = wifiConfigGetBleEnabled();
-        s_pager_wifi_ble_deadline_ms = s_pager_ble_after_wifi
-            ? now + PAGER_WIFI_BLE_HANDOFF_MS : 0;
+        s_pager_wifi_ble_deadline_ms = 0;
         wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Associating);
         if (serial_interface.isBleStackBegun()) {
-          // Auto-reconnect is disabled once NimBLE exists. Release the BLE
-          // controller first, then use the ordinary retry below; GOT_IP recreates
-          // BLE once Wi-Fi owns the coexistence path again. This bounds an AP
-          // outage to transport reconnects instead of a device reboot loop.
-          serial_interface.suspendBleForWifiReconnect();
-          Serial.println("[wifi] BLE released after link loss; re-associating");
+          // Auto-reconnect is disabled once NimBLE exists. Pause advertising and
+          // disconnect its peer first, then use the ordinary retry below; GOT_IP
+          // resumes BLE once Wi-Fi owns the coexistence path again. This preserves
+          // the bond and bounds an AP outage to transport reconnects.
+          if (!serial_interface.suspendBleForWifiReconnect()) {
+            s_pager_ble_after_wifi = false;
+            s_pager_wifi_ble_deadline_ms = 0;
+            pagerWifiEnterBleFallback("BLE disconnect timed out; Wi-Fi retry cancelled");
+            if (wifiConfigGetBleEnabled()) serial_interface.enableBle();
+            ui_task.showAlert(TR("Wi-Fi paused; Bluetooth disconnect timed out"), 2600);
+            return;
+          }
+          Serial.println("[wifi] BLE paused after link loss; re-associating");
         }
+        s_pager_wifi_ble_deadline_ms = s_pager_ble_after_wifi
+            ? millis() + PAGER_WIFI_BLE_HANDOFF_MS : 0;
 #endif
         char ssid[WIFI_CONFIG_SSID_MAX];
         char pwd[WIFI_CONFIG_PWD_MAX];
@@ -1166,16 +1185,16 @@ void loop() {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
       wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Connected);
       s_pager_wifi_ble_deadline_ms = 0;
-      // Consume only the explicit handoff token. If the cold NimBLE recreate
-      // is refused, do not hammer the allocator and alert on every loop while
-      // Wi-Fi remains connected; Settings is the deliberate retry surface.
+      // Consume only the explicit handoff token. If a cold NimBLE start is
+      // refused, do not hammer the allocator and alert on every loop while
+      // Wi-Fi remains connected; a resident stack simply resumes advertising.
       const bool ble_waiting = s_pager_ble_after_wifi;
       if (ble_waiting) {
         s_pager_ble_after_wifi = false;
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
           // Wi-Fi is now stable, so a cold BLE allocation cannot enter WPA in
-          // the unsafe order. The transport still refuses low-fragmentation
-          // headroom rather than risking an OOM after the UI has started.
+          // the unsafe order. A resident stack resumes allocation-free; the
+          // transport guards heap only if it genuinely needs a cold start.
           serial_interface.enableBle();
           if (serial_interface.isBleEnabled()) {
             WiFi.setAutoReconnect(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "helpers/esp32/TouchPrefsStore.h"   // QUOTED: get wadamesh's copy (touchPrefsReload), not the lib's stale one
 #include "helpers/esp32/SdNvsPrefs.h"        // route prefs to file storage (SD/SPIFFS), off NVS
                                              // (quoted: use wadamesh's src/ copy, not the lib's stale one)
+#include "ui-touch/i18n.h"                    // translated Pager transport-state alerts
 #include "wadamesh_mark_rgb.h"               // anti-aliased mesh-mark (RGB565) for the pre-LVGL boot screen
 #include "ui-touch/TouchSleep.h"             // idle light-sleep controller (loopEnd called at end of loop())
 #endif
@@ -105,8 +106,8 @@ static uint32_t _atoi(const char* sp) {
                     (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
     }
     // Claim Wi-Fi's coexistence resources first. If association cannot finish
-    // during setup, keep NimBLE uninitialised and either retry Wi-Fi alone or
-    // reboot once before enabling the prepared BLE stack.
+    // during setup, keep NimBLE uninitialised; a later successful association
+    // may cold-start BLE only after Wi-Fi is already stable.
     static bool s_pager_ble_after_wifi = false;
     #endif
   #elif defined(WIFI_SSID)
@@ -733,7 +734,7 @@ void setup() {
         const uint32_t assoc_start_ms = millis();
         WiFi.begin(ssid, pwd[0] ? pwd : nullptr);
         while (WiFi.status() != WL_CONNECTED &&
-               (uint32_t)(millis() - assoc_start_ms) < 12000UL) {
+               (uint32_t)(millis() - assoc_start_ms) < 6000UL) {
           delay(20);
         }
         pager_wifi_ready_for_ble = WiFi.status() == WL_CONNECTED;
@@ -762,12 +763,11 @@ void setup() {
   {
     const bool want_ble = wifiConfigGetBleEnabled();
     /* Serialise the Pager's first association before BLE init. Once associated,
-     * the two radios coexist normally. Pre-create the stack even if the saved
-     * BLE state is off, but only after Wi-Fi is actually associated; otherwise
-     * the setup wizard or an automatic retry could re-enter WPA with NimBLE
-     * resident and reproduce the coexistence watchdog. */
+     * the two radios coexist normally. Do not create a disabled NimBLE stack
+     * for Wi-Fi-only users: keeping Wi-Fi's normal auto-reconnect path avoids a
+     * needless device reboot when no Bluetooth controller is resident. */
     if (!want_wifi || pager_wifi_ready_for_ble) {
-      if (want_ble || want_wifi) {
+      if (want_ble) {
         serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
                                   the_mesh.getBLEPin(), want_ble);
         if (want_wifi) WiFi.setAutoReconnect(false);
@@ -778,8 +778,8 @@ void setup() {
     } else {
       // No credentials yet, or the saved association timed out. Leave NimBLE
       // completely absent so all credential/apply and retry paths remain safe.
-      // If BLE is requested, a late Wi-Fi success reboots once through setup's
-      // Wi-Fi -> BLE -> UI order before advertising begins.
+      // If BLE is requested, a late Wi-Fi success may allocate it only after
+      // association, subject to the same internal-heap guard as a UI cold start.
       s_pager_ble_after_wifi = want_ble;
       Serial.printf("[boot] BLE init deferred until ordered Wi-Fi association (enable=%d)\n",
                     (int)want_ble);
@@ -1019,11 +1019,17 @@ void loop() {
       if (s_pager_ble_after_wifi) {
         s_pager_ble_after_wifi = false;
         if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
-          // Wi-Fi associated after setup, when the UI already owns its working
-          // set. Reboot once so BLE allocates before LVGL and after Wi-Fi.
-          Serial.println("[boot] Wi-Fi ready; restarting to allocate deferred BLE in order");
-          ui_task.rebootDevice();
-          return;
+          // Wi-Fi is now stable, so a cold BLE allocation cannot enter WPA in
+          // the unsafe order. The transport still refuses low-fragmentation
+          // headroom rather than risking an OOM after the UI has started.
+          serial_interface.enableBle();
+          if (serial_interface.isBleEnabled()) {
+            WiFi.setAutoReconnect(false);
+            Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi association");
+          } else {
+            Serial.println("[boot] deferred BLE unavailable; retry from Bluetooth settings");
+            ui_task.showAlert(TR("Bluetooth deferred; retry from Settings"), 2600);
+          }
         }
       }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -769,7 +769,7 @@ void setup() {
     if (!want_wifi || pager_wifi_ready_for_ble) {
       if (want_ble) {
         serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
-                                  the_mesh.getBLEPin(), want_ble);
+                                  the_mesh.getBLEPin());
         if (want_wifi) WiFi.setAutoReconnect(false);
         Serial.printf("[boot] BLE stack ready (enabled=%d wifi=%d)\n",
                       (int)want_ble, (int)want_wifi);
@@ -938,14 +938,17 @@ void loop() {
    * from the UI (the transition above already covered the on case). */
   if (wifiConfigConsumeApplyRequest()) {
 #if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
-    // Every explicit credential/reconnect request must return through setup.
-    // This covers the setup wizard, saved-network/slot activation, scan
-    // reconnect, transport settings, and companion/CLI-backed preference
-    // updates instead of relying on each caller to remember the Pager's order.
-    if (wifi_radio_en && wifiConfigHasRuntime()) {
+    // With NimBLE resident, every explicit credential/reconnect request must
+    // return through setup. Wi-Fi-only applies stay live: opening the Wi-Fi
+    // page itself performs a scan/rejoin and must not reboot the device.
+    if (wifi_radio_en && wifiConfigHasRuntime() &&
+        serial_interface.isBleStackBegun()) {
       Serial.println("[wifi] restarting for ordered T-Pager association");
       ui_task.rebootDevice();
       return;
+    }
+    if (wifi_radio_en && !serial_interface.isBleStackBegun()) {
+      WiFi.setAutoReconnect(true);
     }
 #endif
     /* Only touch WiFi state if it was actually started this session. When

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -725,8 +725,14 @@ void setup() {
    * happens later in loop(); this just inits the stack.) */
   if (want_wifi) {
     WiFi.mode(WIFI_STA);
+#if defined(TLORA_PAGER)
+    // Pager reconnects are owned by the loop below. Background WPA retries are
+    // invisible to PagerWifiBlePhase and could overlap a cold NimBLE start.
+    WiFi.setAutoReconnect(false);
+#else
     WiFi.setAutoReconnect(true);   // safe while NimBLE is not resident; disabled below once BLE
                                    // exists so a later WPA re-auth cannot bypass Wi-Fi-first ordering
+#endif
     WiFi.persistent(false);
     // NOTE: do NOT enable modem-sleep here. On a fresh, *unassociated* STA (the
     // setup wizard, no creds yet) DTIM modem-sleep naps the radio through the
@@ -947,6 +953,15 @@ void loop() {
   if (wifiConfigPagerBleFallbackActive() && !wifiConfigGetBleEnabled()) {
     wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
   }
+  // An association may have started while Bluetooth was disabled. If the user
+  // requests BLE during that attempt, join the already-running ordered handoff
+  // immediately instead of waiting for the next 10-second Wi-Fi retry to arm it.
+  if (wifiConfigGetPagerWifiBlePhase() == PagerWifiBlePhase::Associating &&
+      wifiConfigGetBleEnabled() && !s_pager_ble_after_wifi) {
+    s_pager_ble_after_wifi = true;
+    s_pager_wifi_ble_deadline_ms = millis() + PAGER_WIFI_BLE_HANDOFF_MS;
+    Serial.println("[wifi] Bluetooth requested during association; handoff armed");
+  }
 #endif
   if (!wifi_radio_inited) {
     wifi_radio_inited = true;
@@ -1003,9 +1018,10 @@ void loop() {
       s_pager_wifi_ble_deadline_ms = 0;
       wifiConfigSetPagerWifiBlePhase(PagerWifiBlePhase::Idle);
     }
-    if (wifi_radio_en && !serial_interface.isBleStackBegun()) {
-      WiFi.setAutoReconnect(true);
-    }
+    // Keep Pager WPA retries explicit even when BLE is currently absent. The
+    // loop below records Associating before each begin(), so a simultaneous
+    // Bluetooth request can never cold-start NimBLE over a hidden retry.
+    if (wifi_radio_en) WiFi.setAutoReconnect(false);
 #endif
     /* Only touch WiFi state if it was actually started this session. When
      * BLE is the active transport (no creds saved), WiFi was never inited

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,11 @@ static uint32_t _atoi(const char* sp) {
 
 #ifdef ESP32
   #ifdef MULTI_TRANSPORT_COMPANION
-    #include <helpers/esp32/MultiTransportCompanionInterface.h>
+    // This class is extended locally (web mirror/P4 routing/BLE state). Include
+    // the matching project header explicitly: the MeshCore dependency ships an
+    // older class layout, and mixing that header with our local .cpp makes the
+    // placement allocation undersized and shifts every member after _ws_started.
+    #include "helpers/esp32/MultiTransportCompanionInterface.h"
     #include "helpers/esp32/MqttBridge.h"
     #include <esp_heap_caps.h>
     #include <new>
@@ -87,6 +91,23 @@ static uint32_t _atoi(const char* sp) {
     #endif
     #ifndef WS_PORT
       #define WS_PORT 8765
+    #endif
+
+    #if defined(TLORA_PAGER)
+    static void pagerLogInternalHeap(const char* phase) {
+      const uint32_t caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+      Serial.printf("[heap] %s: internal free=%u largest=%u low=%u dma=%u psram=%u\n",
+                    phase,
+                    (unsigned)heap_caps_get_free_size(caps),
+                    (unsigned)heap_caps_get_largest_free_block(caps),
+                    (unsigned)heap_caps_get_minimum_free_size(caps),
+                    (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA),
+                    (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+    }
+    // On a fresh profile there may be no saved credentials yet.
+    // Claim Wi-Fi's coexistence resources first, then start the prepared BLE
+    // stack as soon as that first association succeeds.
+    static bool s_pager_ble_after_wifi = false;
     #endif
   #elif defined(WIFI_SSID)
     #include <helpers/esp32/SerialWifiInterface.h>
@@ -677,16 +698,13 @@ void setup() {
   serial_interface.begin(Serial, TCP_PORT, WS_PORT);
   Serial.println("[BOOT] serial_interface ok");
   serial_interface.setBroadcastResponses(true);  // RX log, channel messages, etc. go to all clients (USB + TCP + WS [+ BLE]), not only last sender
-  /* Pick BLE vs WiFi at boot. The ESP32-S3 doesn't have enough internal heap
-   * (esp_wifi_init needs ~50KB for DMA buffers) to run Bluedroid BLE +
-   * LVGL/TFT + WiFi all at once — esp_wifi_init silently returns ESP_ERR_NO_MEM,
-   * leaving WiFi.getMode() at WIFI_MODE_NULL. So we mutex them: if the user
-   * has saved WiFi credentials AND the radio is enabled, skip BLE init and
-   * use WiFi exclusively. Otherwise init BLE. Toggle by saving/clearing creds
-   * + reboot (saveWifiCb auto-restarts). On the touch build the user can also
-   * pick Wi-Fi with no creds yet (to scan/configure on-device) — wantsWifi()
-   * returns true for that case so the radio comes up scannable. */
+  /* Wi-Fi and NimBLE coexist, but their first allocations are order-sensitive
+   * on the Pager. Claim Wi-Fi's DMA/coexistence resources before starting BLE;
+   * T-Deck does not reproduce this sequencing constraint. */
   bool want_wifi = wifiConfigWantsWifi();
+#if defined(TLORA_PAGER)
+  bool pager_wifi_ready_for_ble = false;
+#endif
   /* Wi-Fi + BLE now COEXIST (NimBLE host is light enough — the old Bluedroid
    * heap clash is gone). Bring Wi-Fi up FIRST: esp_wifi_init grabs a big
    * contiguous DMA block, so let it claim memory before BLE. (Association
@@ -701,6 +719,32 @@ void setup() {
     // setup wizard, no creds yet) DTIM modem-sleep naps the radio through the
     // scan dwell, so WiFi.scanNetworks() comes back empty ("no networks found").
     // It's enabled once we actually associate — see the GOT_IP handler below.
+#if defined(TLORA_PAGER)
+    /* Arduino-ESP32 2.0.17 can watchdog in WPA3 SAE on the Pager when NimBLE
+     * already owns the coexistence path. Start the saved Wi-Fi association
+     * first and wait on the state transition (not a fixed delay), while
+     * internal heap is still plentiful; BLE starts below only after the link
+     * is established. T-Deck does not reproduce this ordering constraint. */
+    if (wifiConfigHasRuntime()) {
+      char ssid[WIFI_CONFIG_SSID_MAX];
+      char pwd[WIFI_CONFIG_PWD_MAX];
+      wifiConfigGetSsid(ssid, sizeof(ssid));
+      wifiConfigGetPwd(pwd, sizeof(pwd));
+      if (ssid[0]) {
+        const uint32_t assoc_start_ms = millis();
+        WiFi.begin(ssid, pwd[0] ? pwd : nullptr);
+        while (WiFi.status() != WL_CONNECTED &&
+               (uint32_t)(millis() - assoc_start_ms) < 12000UL) {
+          delay(20);
+        }
+        pager_wifi_ready_for_ble = WiFi.status() == WL_CONNECTED;
+        Serial.printf("[boot] Pager Wi-Fi pre-BLE association: %s (%lums)\n",
+                      pager_wifi_ready_for_ble ? "ready" : "deferred",
+                      (unsigned long)(millis() - assoc_start_ms));
+        pagerLogInternalHeap("after Wi-Fi association");
+      }
+    }
+#endif
   }
 #if defined(BLE_PIN_CODE)
   /* Always stash the BLE params so the toggle can bring BLE up live later, even
@@ -715,6 +759,35 @@ void setup() {
   { NodePrefs* _np = the_mesh.getNodePrefs();
     _np->node_name[sizeof(_np->node_name) - 1] = '\0'; }
   serial_interface.prepareBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name, the_mesh.getBLEPin());
+#if defined(TLORA_PAGER)
+  {
+    const bool want_ble = wifiConfigGetBleEnabled();
+    /* Serialise the Pager's first association before BLE init. Once associated,
+     * the two radios coexist normally. When Wi-Fi is enabled, pre-create the
+     * stack even if the saved BLE state is off: late allocation after LVGL has
+     * built the home UI can no longer find a large enough internal block, while
+     * a pre-created disabled stack can start advertising allocation-free. */
+    if (!want_wifi || pager_wifi_ready_for_ble || !wifiConfigHasRuntime()) {
+      if (want_ble || want_wifi) {
+        serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
+                                  the_mesh.getBLEPin(), want_ble);
+        Serial.printf("[boot] BLE stack ready (enabled=%d wifi=%d)\n",
+                      (int)want_ble, (int)want_wifi);
+        pagerLogInternalHeap("after BLE init");
+      }
+    } else {
+      // Wi-Fi owns its required heap now, but a saved association did not
+      // complete. Still allocate the NimBLE/GATT objects before LVGL consumes
+      // and fragments the remaining internal RAM; leave advertising disabled
+      // until Wi-Fi connects (or the user explicitly enables BLE live).
+      serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
+                                the_mesh.getBLEPin(), false);
+      s_pager_ble_after_wifi = want_ble;
+      Serial.printf("[boot] BLE stack ready disabled; deferred enable=%d\n", (int)want_ble);
+      pagerLogInternalHeap("after deferred BLE init");
+    }
+  }
+#else
   if (wifiConfigGetBleEnabled()) {
     const size_t BLE_COEXIST_MIN_FREE  = 50 * 1024;   // free heap after Wi-Fi to also start BLE
     const size_t BLE_COEXIST_MIN_BLOCK = 20 * 1024;   // largest contiguous block (NimBLE controller/host)
@@ -727,6 +800,7 @@ void setup() {
       Serial.printf("[boot] BLE deferred: low heap (free=%u maxblk=%u) — Wi-Fi only\n", (unsigned)freeh, (unsigned)maxblk);
     }
   }
+#endif
 #endif
 #elif defined(WIFI_SSID)
   board.setInhibitSleep(true);   // prevent sleep when WiFi is active
@@ -798,6 +872,9 @@ void setup() {
 #ifdef DISPLAY_CLASS
   ui_task.begin(disp, &sensors, the_mesh.getNodePrefs());  // still want to pass this in as dependency, as prefs might be moved
   Serial.println("[BOOT] ui ready");
+#if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
+  pagerLogInternalHeap("after UI init");
+#endif
 #endif
 
   board.onBootComplete();
@@ -826,12 +903,9 @@ void loop() {
   static const uint32_t WIFI_RETRY_INTERVAL_MS = 10000;
   static bool wifi_radio_prev = true;
   static bool wifi_radio_inited = false;
-  /* BLE-vs-WiFi mutex (chosen at setup based on saved creds + radio_en pref):
-   * if BLE was initialized, do NOT attempt to bring WiFi up here — esp_wifi_init
-   * would fail with ESP_ERR_NO_MEM after Bluedroid grabbed the internal heap,
-   * and the resulting OOM cascade freezes LVGL. Only run the WiFi state
-   * machine if creds are saved AND the radio pref is on, mirroring `want_wifi`
-   * in setup(). (Touch may also want Wi-Fi up with no creds, to scan.) */
+  /* Run the saved Wi-Fi state machine whenever its radio preference is on.
+   * Pager setup separately guarantees that Wi-Fi claims its coexistence
+   * resources before a cold BLE start. */
   bool wifi_radio_en = wifiConfigWantsWifi();
   if (!wifi_radio_inited) {
     wifi_radio_inited = true;
@@ -842,6 +916,15 @@ void loop() {
       WiFi.disconnect(true);
       delay(50);
       WiFi.mode(WIFI_OFF);
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+      if (s_pager_ble_after_wifi) {
+        s_pager_ble_after_wifi = false;
+        if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
+          serial_interface.enableBle();
+          Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi was disabled");
+        }
+      }
+#endif
     }
     wifi_started = false;
   }
@@ -877,10 +960,10 @@ void loop() {
         char pwd[WIFI_CONFIG_PWD_MAX];
         wifiConfigGetSsid(ssid, sizeof(ssid));
         wifiConfigGetPwd(pwd, sizeof(pwd));
-        if (strlen(ssid) > 0) {
+        if (strlen(ssid) > 0 && WiFi.status() != WL_CONNECTED) {
           WiFi.begin(ssid, pwd[0] ? pwd : nullptr);
-          last_wifi_retry_ms = millis();
         }
+        last_wifi_retry_ms = millis();
       }
     }
     // Automatic WiFi recovery for TCP mode: retry connection periodically if link drops.
@@ -909,6 +992,15 @@ void loop() {
     static bool sntp_pushed = false;
     static uint32_t sntp_kick_ms = 0;
     if (WiFi.status() == WL_CONNECTED) {
+#if defined(TLORA_PAGER) && defined(BLE_PIN_CODE)
+      if (s_pager_ble_after_wifi) {
+        s_pager_ble_after_wifi = false;
+        if (wifiConfigGetBleEnabled() && !serial_interface.isBleEnabled()) {
+          serial_interface.enableBle();
+          Serial.println("[boot] deferred BLE enabled after T-Pager Wi-Fi association");
+        }
+      }
+#endif
       // Now that we're associated, enable DTIM modem-sleep (saves power + gives
       // BLE coexistence airtime). Deferred to here on purpose: enabling it on the
       // unassociated STA naps the radio through a scan dwell and breaks the setup

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -768,12 +768,16 @@ void setup() {
      * needless device reboot when no Bluetooth controller is resident. */
     if (!want_wifi || pager_wifi_ready_for_ble) {
       if (want_ble) {
-        serial_interface.beginBle(BLE_NAME_PREFIX, the_mesh.getNodePrefs()->node_name,
-                                  the_mesh.getBLEPin());
-        if (want_wifi) WiFi.setAutoReconnect(false);
-        Serial.printf("[boot] BLE stack ready (enabled=%d wifi=%d)\n",
-                      (int)want_ble, (int)want_wifi);
-        pagerLogInternalHeap("after BLE init");
+        // Use the same contiguous-heap guard as every other cold NimBLE start.
+        // Boot normally has the most headroom, but a future driver allocation
+        // must degrade to BLE-pending instead of OOM-panicking setup().
+        serial_interface.enableBle();
+        if (serial_interface.isBleEnabled()) {
+          Serial.printf("[boot] BLE stack ready (enabled=1 wifi=%d)\n", (int)want_wifi);
+          pagerLogInternalHeap("after BLE init");
+        } else {
+          Serial.println("[boot] BLE cold start deferred: insufficient contiguous heap");
+        }
       }
     } else {
       // No credentials yet, or the saved association timed out. Leave NimBLE

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -13453,6 +13453,7 @@ static bool wifiPrepareEnable(lv_obj_t* switch_to_revert = nullptr) {
     lv_refr_now(NULL);
     g_lv.task->rebootDevice();
   } else {
+    touchPrefsFlush();
     ESP.restart();
   }
   return false;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -7906,9 +7906,18 @@ static const char* bleEnableFailureText() {
   return TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first.");
 }
 
+static bool bleRequestedOrEnabled() {
+  bool requested = g_lv.task && g_lv.task->isBleEnabled();
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  requested = requested || wifiConfigGetBleEnabled();
+#endif
+  return requested;
+}
+
 static void toggleBleCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED || !g_lv.task || !g_lv.task->hasBleCapability()) return;
-  if (g_lv.task->isBleEnabled()) {
+  const bool requested = bleRequestedOrEnabled();
+  if (requested) {
     g_lv.task->disableBle();
   } else if (!g_lv.task->enableBle()) {
     g_lv.task->showAlert(bleEnableFailureText(), 2600);
@@ -13014,10 +13023,16 @@ static void bleEnableSwitchCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED || !g_lv.task) return;
   if (!g_lv.task->hasBleCapability()) { g_lv.task->showAlert(TR("No Bluetooth on this device"), 1400); return; }
   const bool want = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
-  if (want == g_lv.task->isBleEnabled()) return;
+  const bool requested = bleRequestedOrEnabled();
+  if (want == requested) return;
   if (want) {
     if (!g_lv.task->enableBle()) {
-      lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);   // revert the switch
+      // A Pager request queued behind Wi-Fi is still ON as user intent. Keep it
+      // checked so a second tap can cancel; only a true refusal reverts to OFF.
+      if (wifiConfigGetBleEnabled())
+        lv_obj_add_state(lv_event_get_target(e), LV_STATE_CHECKED);
+      else
+        lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);
       g_lv.task->showAlert(bleEnableFailureText(), 2600);
       return;
     }
@@ -13131,7 +13146,8 @@ static void buildBluetoothSettings() {
   lv_obj_set_pos(sw_lbl, 2, y + 6);
   g_set_modal.wifi_sw = lv_switch_create(body);  // reuse the same slot — only one switch lives in a modal at a time
   lv_obj_align(g_set_modal.wifi_sw, LV_ALIGN_TOP_RIGHT, 0, y);   // flush right
-  if (ble_active) lv_obj_add_state(g_set_modal.wifi_sw, LV_STATE_CHECKED);
+  if (ble_active || wifiConfigGetBleEnabled())
+    lv_obj_add_state(g_set_modal.wifi_sw, LV_STATE_CHECKED);
   lv_obj_add_event_cb(g_set_modal.wifi_sw, bleEnableSwitchCb, LV_EVENT_VALUE_CHANGED, nullptr);  // instant toggle (BLE is live)
   y += SC(38);
   // No Save button — the enable switch toggles BLE live, and the pairing code auto-saves on blur.
@@ -13163,8 +13179,8 @@ static void doApplyWifi() {
   wifiConfigSetRadioEnabled(s_pending_wifi_radio_on);
   wifiConfigRequestApply();
 
-  // Non-Pager boards apply live. Pager credential/reconnect requests return
-  // through setup so Wi-Fi associates before a resident NimBLE stack exists.
+  // Credential changes apply live. Pager first releases resident NimBLE in the
+  // main loop, re-associates Wi-Fi, then recreates BLE after GOT_IP.
   if (g_lv.task)
     g_lv.task->showAlert(
         s_pending_wifi_radio_on ? TR("Saved — applying\xE2\x80\xA6")
@@ -13294,8 +13310,8 @@ static void saveWifiCb(lv_event_t* e) {
     lv_obj_add_state(g_set_modal.wifi_sw, LV_STATE_CHECKED);
   }
   s_pending_wifi_was_wifi = wifiConfigWantsWifi();   // kept for status display; no longer gates a reboot
-  // Save immediately. Other boards reconnect live; Pager's main loop reboots
-  // through the ordered Wi-Fi -> BLE setup path.
+  // Save immediately. Pager's main loop preserves Wi-Fi -> BLE ordering with a
+  // live controller handoff rather than a reboot.
   doApplyWifi();
 }
 #endif
@@ -36138,7 +36154,7 @@ static void refreshSettingsSectionSubtitles() {
 // Status-bar control center (tap the top bar)
 // A small drop-down panel with date/time + battery/Wi-Fi info and quick
 // Wi-Fi / Bluetooth toggles, iPhone-control-center style. Resident stacks
-// toggle live; a cold or reconnecting Pager may take an ordered restart.
+// toggle live; a genuinely cold Pager allocation may take an ordered restart.
 // ============================================================
 
 static void closeControlCenter() {
@@ -36180,8 +36196,8 @@ static void openControlCenter();   // fwd — toggle cbs rebuild the panel
 static void toggleControlCenter() { if (s_cc_root) closeControlCenter(); else openControlCenter(); }
 
 // Wi-Fi and Bluetooth coexist once allocated. Resident stacks toggle live;
-// Pager cold starts/re-authentication use the ordered reboot path. Each radio's
-// requested state is persisted independently (radio_en / ble_en).
+// Pager cold starts may use the ordered reboot path; re-authentication releases
+// and recreates BLE live. Each requested state persists independently.
 static void ccWifiCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(ESP32)
@@ -36200,15 +36216,15 @@ static void ccBleCb(lv_event_t* e) {
     return;
 #if defined(ESP32)
   // Live: enableBle() lazily brings NimBLE up if it wasn't started at boot.
-  const bool on = g_lv.task->isBleEnabled();
-  if (on) {
+  const bool requested = bleRequestedOrEnabled();
+  if (requested) {
     g_lv.task->disableBle();
   } else if (!g_lv.task->enableBle()) {
     g_lv.task->showAlert(bleEnableFailureText(), 2600);
     openControlCenter();
     return;
   }
-  g_lv.task->showAlert(on ? TR("Bluetooth off") : TR("Bluetooth on"), 800);
+  g_lv.task->showAlert(requested ? TR("Bluetooth off") : TR("Bluetooth on"), 800);
   openControlCenter();
 #endif
 }
@@ -36969,7 +36985,7 @@ static void openControlCenter() {
 #if defined(ESP32)
   wifi_on = wifiConfigGetRadioEnabled();
 #endif
-  if (g_lv.task) ble_on = g_lv.task->isBleEnabled();
+  if (g_lv.task) ble_on = bleRequestedOrEnabled();
   lv_obj_t* row = lv_obj_create(card);
   lv_obj_remove_style_all(row);
 #if defined(HAS_TANMATSU)
@@ -40940,7 +40956,7 @@ static void setupFinishCb(lv_event_t* e) {
 #endif
   // Region was applied live when the user advanced past the region step
   // (setRadioParams -> applyRadioFromPrefs). Close the wizard; the Wi-Fi apply
-  // request reconnects live elsewhere and takes Pager's ordered restart path.
+  // request reconnects live; Pager temporarily releases BLE to preserve order.
   setupWizardClose();
   if (g_lv.task) g_lv.task->showAlert(TR("Setup complete"), 1400);
 }

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -7902,7 +7902,7 @@ static bool bleEnableWaitingForWifi() {
 
 static const char* bleEnableFailureText() {
   if (bleEnableWaitingForWifi())
-    return TR("Bluetooth will start after Wi-Fi connects, or turn Wi-Fi off first.");
+    return TR("Bluetooth will start after Wi-Fi connects or times out.");
   return TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first.");
 }
 

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -7892,12 +7892,26 @@ static void toggleTcpCb(lv_event_t* e) {
   refreshStatusLabels();
 }
 
+static bool bleEnableWaitingForWifi() {
+#if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
+  return wifiConfigWantsWifi() && WiFi.status() != WL_CONNECTED;
+#else
+  return false;
+#endif
+}
+
+static const char* bleEnableFailureText() {
+  if (bleEnableWaitingForWifi())
+    return TR("Bluetooth will start after Wi-Fi connects, or turn Wi-Fi off first.");
+  return TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first.");
+}
+
 static void toggleBleCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED || !g_lv.task || !g_lv.task->hasBleCapability()) return;
   if (g_lv.task->isBleEnabled()) {
     g_lv.task->disableBle();
   } else if (!g_lv.task->enableBle()) {
-    g_lv.task->showAlert(TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first."), 2200);
+    g_lv.task->showAlert(bleEnableFailureText(), 2600);
     refreshStatusLabels();
     return;
   }
@@ -12857,11 +12871,7 @@ static void saveTransportWifiCb(lv_event_t* e) {
       return;
     }
     wifiConfigRequestApply();
-#if defined(TLORA_PAGER)
-    g_lv.task->showAlert(TR("Wi-Fi saved, restarting"), 1400);
-#else
-    g_lv.task->showAlert(TR("Wi-Fi saved, reconnecting"), 1400);
-#endif
+    g_lv.task->showAlert(TR("Wi-Fi saved, applying"), 1400);
   } else {
     wifiConfigRequestApply();
     g_lv.task->showAlert(TR("Wi-Fi saved (radio off)"), 1400);
@@ -13008,7 +13018,7 @@ static void bleEnableSwitchCb(lv_event_t* e) {
   if (want) {
     if (!g_lv.task->enableBle()) {
       lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);   // revert the switch
-      g_lv.task->showAlert(TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first."), 2200);
+      g_lv.task->showAlert(bleEnableFailureText(), 2600);
       return;
     }
   } else {
@@ -13157,11 +13167,7 @@ static void doApplyWifi() {
   // through setup so Wi-Fi associates before a resident NimBLE stack exists.
   if (g_lv.task)
     g_lv.task->showAlert(
-#if defined(TLORA_PAGER)
-        s_pending_wifi_radio_on ? TR("Saved — restarting\xE2\x80\xA6")
-#else
-        s_pending_wifi_radio_on ? TR("Saved — reconnecting\xE2\x80\xA6")
-#endif
+        s_pending_wifi_radio_on ? TR("Saved — applying\xE2\x80\xA6")
                                 : TR("Wi-Fi saved (radio off)"), 1600);
   refreshStatusLabels();
 }
@@ -13449,7 +13455,15 @@ static bool wifiPrepareEnable(lv_obj_t* switch_to_revert = nullptr) {
   // the normal flush path so setup can claim Wi-Fi before NimBLE and LVGL.
   wifiConfigSetRadioEnabled(true);
   if (g_lv.task) {
-    g_lv.task->showAlert(TR("Restarting to enable Wi-Fi"), 800);
+    g_lv.task->showAlert(
+#if defined(TLORA_PAGER)
+        wifiConfigGetBleEnabled()
+          ? TR("Restarting for Wi-Fi; Bluetooth resumes after it connects")
+          : TR("Restarting to enable Wi-Fi"),
+#else
+        TR("Restarting to enable Wi-Fi"),
+#endif
+        1400);
     lv_refr_now(NULL);
     g_lv.task->rebootDevice();
   } else {
@@ -13478,14 +13492,18 @@ static void wifiScanStartCb(lv_event_t* e) {
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
 static void wifiRebuildNetworkList();   // fwd: reworked Wi-Fi page list (defined before buildWifiSettings)
 #endif
-// Kick a Wi-Fi scan from the UI (LVGL ctx — only sets flags, never calls WiFi). On
-// the S3, scanning while associated is unreliable, so if we're connected we ask the
-// MAIN task to drop the link first (wifiScanMainService); otherwise scan straight away.
+// Kick a Wi-Fi scan from the UI (LVGL ctx — only sets flags, never calls WiFi).
+// Most S3 targets get more reliable results by dropping an association first.
+// Pager keeps an established link intact because re-authenticating while NimBLE
+// is resident crosses its known-unsafe coexistence boundary; its scan is
+// best-effort while associated and never turns a page-open into a reboot.
 static void wifiKickScan() {
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
   ensureTileFetchTaskRunning();
 #if defined(HAS_TANMATSU)
   s_wifiscan_request = true;                         // esp-hosted C6 sweeps fine while associated
+#elif defined(TLORA_PAGER)
+  s_wifiscan_request = true;                         // never force WPA re-auth under resident NimBLE
 #else
   if (WiFi.status() == WL_CONNECTED) s_wifiscan_drop_req = true;
   else                               s_wifiscan_request = true;
@@ -36186,7 +36204,7 @@ static void ccBleCb(lv_event_t* e) {
   if (on) {
     g_lv.task->disableBle();
   } else if (!g_lv.task->enableBle()) {
-    g_lv.task->showAlert(TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first."), 2200);
+    g_lv.task->showAlert(bleEnableFailureText(), 2600);
     openControlCenter();
     return;
   }
@@ -47602,6 +47620,13 @@ bool UITask::enableBle() {
   // NimBLE. A resident disabled stack can always be re-enabled allocation-free.
   if (_serial->isBleEnabled()) return true;
 #if defined(TLORA_PAGER)
+  if (bleEnableWaitingForWifi()) {
+    // Remember the request; main.cpp cold-starts NimBLE after a stable Wi-Fi
+    // association. Rebooting here cannot improve the ordering and would return
+    // to the same deferred state, so surface the wait instead.
+    wifiConfigSetBleEnabled(true);
+    return false;
+  }
   // Same cold-start contract as Wi-Fi above. This is not an OOM failure the
   // user can repair by toggling the other radio: remember the requested state
   // and allocate NimBLE during the next ordered boot, before LVGL fragments

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -7894,7 +7894,7 @@ static void toggleTcpCb(lv_event_t* e) {
 
 static bool bleEnableWaitingForWifi() {
 #if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
-  return wifiConfigWantsWifi() && WiFi.status() != WL_CONNECTED;
+  return wifiConfigPagerWifiBlocksBle();
 #else
   return false;
 #endif
@@ -47651,18 +47651,20 @@ static bool uiHistWaitWorkerIdle() {
 
 bool UITask::enableBle() {
   if (!_serial) return false;
+#if defined(TLORA_PAGER)
+  if (bleEnableWaitingForWifi()) {
+    // Remember the request; main.cpp enables BLE when this bounded association
+    // either succeeds or falls back. Wi-Fi intent without an active attempt
+    // never enters this branch.
+    wifiConfigSetBleEnabled(true);
+    return false;
+  }
+#endif
   _serial->enableBle();
   // The concrete transport applies the heap guard only when it must cold-start
   // NimBLE. A resident disabled stack can always be re-enabled allocation-free.
   if (_serial->isBleEnabled()) return true;
 #if defined(TLORA_PAGER)
-  if (bleEnableWaitingForWifi()) {
-    // Remember the request; main.cpp cold-starts NimBLE after a stable Wi-Fi
-    // association. Rebooting here cannot improve the ordering and would return
-    // to the same deferred state, so surface the wait instead.
-    wifiConfigSetBleEnabled(true);
-    return false;
-  }
   // Same cold-start contract as Wi-Fi above. This is not an OOM failure the
   // user can repair by toggling the other radio: remember the requested state
   // and allocate NimBLE during the next ordered boot, before LVGL fragments

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -7906,9 +7906,17 @@ static const char* bleEnableFailureText() {
   return TR("Not enough free memory for Bluetooth. Turn Wi-Fi off first.");
 }
 
+// "The user wants BLE on", covering the Pager's queued-behind-Wi-Fi request as
+// well as a live stack. Scoped to the Pager on purpose: only UITask::enableBle()
+// records a pending request (wifiConfigSetBleEnabled(true) on the deferral
+// path), and only main.cpp retries one after association. Everywhere else
+// wifiConfigGetBleEnabled() is a plain persisted preference that DEFAULTS TO ON
+// and can sit true with no stack begun (the boot co-init heap guard, an OTA
+// release) — folding that in there would make the toggles read ON while BLE is
+// dead, and turn the first tap into "clear my preference" instead of "start it".
 static bool bleRequestedOrEnabled() {
   bool requested = g_lv.task && g_lv.task->isBleEnabled();
-#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+#if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
   requested = requested || wifiConfigGetBleEnabled();
 #endif
   return requested;
@@ -13029,7 +13037,12 @@ static void bleEnableSwitchCb(lv_event_t* e) {
     if (!g_lv.task->enableBle()) {
       // A Pager request queued behind Wi-Fi is still ON as user intent. Keep it
       // checked so a second tap can cancel; only a true refusal reverts to OFF.
-      if (wifiConfigGetBleEnabled())
+      // Other boards have no pending-request state, so a refusal always reverts.
+      bool still_requested = false;
+#if defined(TLORA_PAGER)
+      still_requested = wifiConfigGetBleEnabled();
+#endif
+      if (still_requested)
         lv_obj_add_state(lv_event_get_target(e), LV_STATE_CHECKED);
       else
         lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);
@@ -13146,7 +13159,9 @@ static void buildBluetoothSettings() {
   lv_obj_set_pos(sw_lbl, 2, y + 6);
   g_set_modal.wifi_sw = lv_switch_create(body);  // reuse the same slot — only one switch lives in a modal at a time
   lv_obj_align(g_set_modal.wifi_sw, LV_ALIGN_TOP_RIGHT, 0, y);   // flush right
-  if (ble_active || wifiConfigGetBleEnabled())
+  // Must be the SAME predicate bleEnableSwitchCb compares against, or its
+  // `want == requested` early-out swallows the first tap.
+  if (ble_active || bleRequestedOrEnabled())
     lv_obj_add_state(g_set_modal.wifi_sw, LV_STATE_CHECKED);
   lv_obj_add_event_cb(g_set_modal.wifi_sw, bleEnableSwitchCb, LV_EVENT_VALUE_CHANGED, nullptr);  // instant toggle (BLE is live)
   y += SC(38);

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -13098,7 +13098,10 @@ static void buildBluetoothSettings() {
   const bool ble_cap_m = g_lv.task && g_lv.task->hasBleCapability();
   if (ble_active)
     lv_label_set_text(mode, wifi_on_m ? "Mode: BLE on (+ Wi-Fi)" : "Mode: BLE on");
-  else if (ble_cap_m && wifiConfigGetBleEnabled())
+  // "starting" only where something will actually act on the request later
+  // (the Pager's post-association retry). Elsewhere a saved-but-not-resident
+  // preference just means off, and one tap brings the stack up.
+  else if (ble_cap_m && bleRequestedOrEnabled())
     lv_label_set_text(mode, TR("Mode: BLE starting / low memory"));
   else
     lv_label_set_text(mode, wifi_on_m ? "Mode: BLE off (Wi-Fi on)" : "Mode: BLE off");
@@ -36051,7 +36054,7 @@ static void refreshSettingsSectionSubtitles() {
     } else {
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
       lv_label_set_text(g_set_sec_sub[SEC_BLUETOOTH],
-                        (g_lv.task->hasBleCapability() && wifiConfigGetBleEnabled())
+                        (g_lv.task->hasBleCapability() && bleRequestedOrEnabled())
                           ? "Starting…" : "Off");
 #else
       lv_label_set_text(g_set_sec_sub[SEC_BLUETOOTH], TR("Inactive"));

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -13459,7 +13459,9 @@ static WifiEnableGate wifiEnableGate() {
 #if defined(TLORA_PAGER)
   // Pager coexistence is reliable only when setup claims Wi-Fi before NimBLE
   // and before LVGL. Always route a genuinely cold Wi-Fi start through that
-  // ordering, even if the current heap happens to look large enough.
+  // ordering, even if the current heap happens to look large enough. No heap
+  // check here on purpose: the restart is unconditional, so there is no
+  // LowMemory outcome to fall through to on this board.
   return WifiEnableGate::RestartRequired;
 #else
   const uint32_t internal_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
@@ -13468,8 +13470,8 @@ static WifiEnableGate wifiEnableGate() {
   if (freeh >= 50u * 1024u && maxblk >= 20u * 1024u) return WifiEnableGate::Ready;
   Serial.printf("[wifi] cold start refused: free=%u maxblk=%u\n",
                 (unsigned)freeh, (unsigned)maxblk);
-#endif
   return WifiEnableGate::LowMemory;
+#endif
 #else
   return WifiEnableGate::Ready;
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -1993,11 +1993,11 @@ static bool discoveredSweepHops() {
 static bool g_cap_touch_hw_started = false;
 
 // ---- LVGL draw buffer ----
-// 240x24 RGB565 = 11,520 bytes. Allocated in PSRAM at UITask::begin() so the
-// internal DRAM stays free for WiFi DMA buffers (esp_wifi_init needs ~50 KB
-// of DRAM; with the buffer + LVGL widgets in DRAM the device was OOM'ing as
-// soon as WiFi came up). PSRAM is slower than DRAM but the Adafruit ST7789
-// SPI driver reads the buffer linearly which the cache handles well.
+// 240x24 RGB565 = 11,520 bytes. The T-Pager keeps this in PSRAM so Wi-Fi +
+// NimBLE connection/security allocations retain enough contiguous internal
+// DRAM. Its ST7796 flush is synchronous TFT_eSPI::pushColors (no DMA), so the
+// external-RAM source is valid. Other boards retain the faster internal-DMA
+// allocation below unless it fails.
 //
 // 1.5x the original 240x16 size — modest bump to reduce setAddrWindow
 // round-trips without giving LVGL more headroom to over-invalidate.
@@ -12987,15 +12987,15 @@ static void showConfirm(const char* msg, const char* ok_label, SimpleCb on_confi
 }
 
 // ----- Bluetooth settings page -----
-// Wi-Fi + BLE coexist now (NimBLE's host is light enough to share the ESP32-S3
-// internal heap with esp_wifi + LVGL), so this is a plain LIVE toggle of the BLE
-// radio — no reboot, and Wi-Fi is left untouched. State is persisted (ble_en).
+// Wi-Fi + BLE coexist once both stacks are allocated. Re-enabling a resident
+// stack is live; a cold Pager allocation restarts through setup's Wi-Fi-first
+// ordering. State is persisted (ble_en), and Wi-Fi is left enabled.
 // The pairing code is editable here (persisted to _prefs.ble_pin; applied at the
 // next boot, since the passkey is baked into serial_interface.begin()).
 static lv_obj_t* s_ble_pin_ta = nullptr;   // editable 6-digit pairing-code field on the BLE page
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
-// Bluetooth enable switch: instant toggle (BLE on/off is live — enableBle() lazily brings
-// NimBLE up; no Save button, no reboot).
+// Bluetooth enable switch: resident BLE toggles live; enableBle() handles the
+// Pager's ordered-restart fallback for a cold stack. No Save button is needed.
 static void bleEnableSwitchCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED || !g_lv.task) return;
   if (!g_lv.task->hasBleCapability()) { g_lv.task->showAlert(TR("No Bluetooth on this device"), 1400); return; }
@@ -13400,28 +13400,66 @@ static void wifiScanOpenAndKick() {
 
 // Mirror of the BLE-enable guard: bringing esp_wifi up needs ~50 KB free internal
 // heap, and with BLE already holding its share on a tight board the init fails
-// DEEP in the Wi-Fi state machine (main.cpp) where nothing reports it — the UI
-// toasted "Wi-Fi on" while the radio never came up. Refuse at the toggle instead,
-// symmetrically with UITask::enableBle(). Thresholds match the boot co-init guard.
-static bool wifiEnableGuardOk() {
+// DEEP in the Wi-Fi state machine (main.cpp) where nothing reports it. Keep the
+// decision pure so every caller can distinguish a Pager's ordered restart from
+// a real low-memory refusal.
+enum class WifiEnableGate : uint8_t { Ready, RestartRequired, LowMemory };
+
+static WifiEnableGate wifiEnableGate() {
 #if defined(ESP32)
-  return ESP.getFreeHeap() >= 50u * 1024u && ESP.getMaxAllocHeap() >= 20u * 1024u;
+  // Once esp_wifi is initialized, a live off/on toggle does not need its large
+  // one-time DMA allocation. Apply the reserve only to a cold start.
+  if (WiFi.getMode() != WIFI_MODE_NULL) return WifiEnableGate::Ready;
+#if defined(TLORA_PAGER)
+  // Pager coexistence is reliable only when setup claims Wi-Fi before NimBLE
+  // and before LVGL. Always route a genuinely cold Wi-Fi start through that
+  // ordering, even if the current heap happens to look large enough.
+  return WifiEnableGate::RestartRequired;
 #else
-  return true;
+  const uint32_t internal_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+  const size_t freeh = heap_caps_get_free_size(internal_caps);
+  const size_t maxblk = heap_caps_get_largest_free_block(internal_caps);
+  if (freeh >= 50u * 1024u && maxblk >= 20u * 1024u) return WifiEnableGate::Ready;
+  Serial.printf("[wifi] cold start refused: free=%u maxblk=%u\n",
+                (unsigned)freeh, (unsigned)maxblk);
+#endif
+  return WifiEnableGate::LowMemory;
+#else
+  return WifiEnableGate::Ready;
 #endif
 }
 
+static bool wifiPrepareEnable(lv_obj_t* switch_to_revert = nullptr) {
+  const WifiEnableGate gate = wifiEnableGate();
+  if (gate == WifiEnableGate::Ready) return true;
+  if (gate == WifiEnableGate::LowMemory) {
+    if (switch_to_revert) lv_obj_clear_state(switch_to_revert, LV_STATE_CHECKED);
+    if (g_lv.task)
+      g_lv.task->showAlert(TR("Not enough free memory for Wi-Fi. Turn Bluetooth off first."), 2200);
+    return false;
+  }
+
+  // Persist the requested state, paint an honest status, then reboot through
+  // the normal flush path so setup can claim Wi-Fi before NimBLE and LVGL.
+  wifiConfigSetRadioEnabled(true);
+  if (g_lv.task) {
+    g_lv.task->showAlert(TR("Restarting to enable Wi-Fi"), 800);
+    lv_refr_now(NULL);
+    g_lv.task->rebootDevice();
+  } else {
+    ESP.restart();
+  }
+  return false;
+}
+
 // "Scan" button -> open the popup + queue a scan on the core-0 worker. If Wi-Fi
-// is off (BLE active), bring the radio up LIVE first — it coexists with NimBLE,
-// no reboot — then scan; the worker brings STA up and lists networks.
+// is off, prepare the radio first (a cold Pager needs the ordered restart above;
+// other live stacks can continue immediately), then let the worker list networks.
 static void wifiScanStartCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(MULTI_TRANSPORT_COMPANION)
   if (!wifiConfigWantsWifi()) {
-    if (!wifiEnableGuardOk()) {
-      if (g_lv.task) g_lv.task->showAlert(TR("Not enough free memory for Wi-Fi. Turn Bluetooth off first."), 2200);
-      return;
-    }
+    if (!wifiPrepareEnable()) return;
     wifiConfigSetRadioEnabled(true);   // wantsWifi() now true -> the scan worker can bring STA up
     wifiConfigRequestApply();          // main loop brings esp_wifi up live (no reboot)
     if (g_lv.task) g_lv.task->showAlert(TR("Wi-Fi on, scanning\xE2\x80\xA6"), 1200);
@@ -13518,18 +13556,14 @@ static void wifiScanService() {
 #endif
 }
 
-// Live Wi-Fi radio toggle on the Wi-Fi settings page (mirrors the control-center
-// toggle). wifiConfigSetRadioEnabled persists the pref + flags an apply, so the
-// main loop brings esp_wifi up / down on the spot — no Save needed, no reboot.
+// Wi-Fi radio toggle on the Wi-Fi settings page (mirrors the control-center
+// toggle). Existing stacks apply live; a cold Pager routes through the ordered
+// restart above. No separate Save action is needed.
 static void wifiRadioToggleCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
   const bool on = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
-  if (on && !wifiEnableGuardOk()) {
-    lv_obj_clear_state(lv_event_get_target(e), LV_STATE_CHECKED);   // revert the switch
-    if (g_lv.task) g_lv.task->showAlert(TR("Not enough free memory for Wi-Fi. Turn Bluetooth off first."), 2200);
-    return;
-  }
+  if (on && !wifiPrepareEnable(lv_event_get_target(e))) return;
   wifiConfigSetRadioEnabled(on);
   if (g_lv.task) g_lv.task->showAlert(on ? TR("Wi-Fi on") : TR("Wi-Fi off"), 800);
   refreshStatusLabels();
@@ -36122,14 +36156,10 @@ static void toggleControlCenter() { if (s_cc_root) closeControlCenter(); else op
 static void ccWifiCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(ESP32)
-  // Live: the main loop brings esp_wifi up (WiFi.mode/begin) or down (WIFI_OFF)
-  // in response to this pref — no reboot.
+  // Existing stacks apply live in the main loop; a cold Pager takes the ordered
+  // restart path so Wi-Fi claims its allocations before NimBLE and LVGL.
   const bool on = wifiConfigGetRadioEnabled();
-  if (!on && !wifiEnableGuardOk()) {
-    if (g_lv.task) g_lv.task->showAlert(TR("Not enough free memory for Wi-Fi. Turn Bluetooth off first."), 2200);
-    openControlCenter();
-    return;
-  }
+  if (!on && !wifiPrepareEnable()) return;
   wifiConfigSetRadioEnabled(!on);
   if (g_lv.task) g_lv.task->showAlert(on ? TR("Wi-Fi off") : TR("Wi-Fi on"), 800);
   openControlCenter();
@@ -46148,17 +46178,25 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
       const int draw_band_w = 240;
 #endif
       const size_t buf_bytes = sizeof(lv_color_t) * draw_band_w * LV_DRAW_BUF_LINES;
-      // Internal DMA-capable DRAM — this is the hot loop's read source
-      // during SPI flush. PSRAM (~80 MHz QSPI) is ~3× slower than
-      // internal SRAM. INTERNAL|DMA also makes it eligible for SPI DMA
-      // transfers if the display driver ever grows them. Fall back to
-      // PSRAM if internal DRAM is too fragmented at boot.
+      // Internal DMA-capable DRAM — this is the hot loop's read source during
+      // SPI flush. The T-Pager is deliberately the exception: ST7796LCDDisplay
+      // uses synchronous pushColors (not DMA), while BLE needs this contiguous
+      // internal block later when a client connects and negotiates security.
+#if defined(TLORA_PAGER)
+      g_draw_buffer = (lv_color_t*)heap_caps_malloc(
+          buf_bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (!g_draw_buffer) {
+        g_draw_buffer = (lv_color_t*)heap_caps_malloc(
+            buf_bytes, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
+      }
+#else
       g_draw_buffer = (lv_color_t*)heap_caps_malloc(
           buf_bytes, MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
       if (!g_draw_buffer) {
         g_draw_buffer = (lv_color_t*)heap_caps_malloc(
             buf_bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
       }
+#endif
       if (!g_draw_buffer) g_draw_buffer = (lv_color_t*)malloc(buf_bytes);
       // Last-ditch under severe DRAM pressure — e.g. a unit whose PSRAM didn't
       // init (some T-Deck clones are QSPI, not the expected OPI), so even SPIRAM
@@ -47549,15 +47587,20 @@ static bool uiHistWaitWorkerIdle() {
 
 bool UITask::enableBle() {
   if (!_serial) return false;
-#if defined(ESP32)
-  // Same thresholds as the boot-time co-init guard (main.cpp) — keep in sync.
-  const size_t BLE_COEXIST_MIN_FREE  = 50u * 1024u;
-  const size_t BLE_COEXIST_MIN_BLOCK = 20u * 1024u;
-  if (ESP.getFreeHeap() < BLE_COEXIST_MIN_FREE || ESP.getMaxAllocHeap() < BLE_COEXIST_MIN_BLOCK)
-    return false;
-#endif
   _serial->enableBle();
-  return true;
+  // The concrete transport applies the heap guard only when it must cold-start
+  // NimBLE. A resident disabled stack can always be re-enabled allocation-free.
+  if (_serial->isBleEnabled()) return true;
+#if defined(TLORA_PAGER)
+  // Same cold-start contract as Wi-Fi above. This is not an OOM failure the
+  // user can repair by toggling the other radio: remember the requested state
+  // and allocate NimBLE during the next ordered boot, before LVGL fragments
+  // internal DRAM. rebootDevice() flushes pending history before ESP.restart().
+  wifiConfigSetBleEnabled(true);
+  showAlert("Restarting to enable Bluetooth", 800);
+  rebootDevice();
+#endif
+  return false;
 }
 
 void UITask::persistHistoryNow() {

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -12857,7 +12857,11 @@ static void saveTransportWifiCb(lv_event_t* e) {
       return;
     }
     wifiConfigRequestApply();
+#if defined(TLORA_PAGER)
+    g_lv.task->showAlert(TR("Wi-Fi saved, restarting"), 1400);
+#else
     g_lv.task->showAlert(TR("Wi-Fi saved, reconnecting"), 1400);
+#endif
   } else {
     wifiConfigRequestApply();
     g_lv.task->showAlert(TR("Wi-Fi saved (radio off)"), 1400);
@@ -13149,13 +13153,16 @@ static void doApplyWifi() {
   wifiConfigSetRadioEnabled(s_pending_wifi_radio_on);
   wifiConfigRequestApply();
 
-  // Wi-Fi and BLE coexist now (NimBLE shares the heap with esp_wifi), so the main
-  // loop brings esp_wifi up / down live in response to these prefs — exactly like
-  // the control-center Wi-Fi toggle. No reboot to switch transports any more,
-  // whatever the previous transport was.
+  // Non-Pager boards apply live. Pager credential/reconnect requests return
+  // through setup so Wi-Fi associates before a resident NimBLE stack exists.
   if (g_lv.task)
-    g_lv.task->showAlert(s_pending_wifi_radio_on ? TR("Saved — reconnecting\xE2\x80\xA6")
-                                                 : TR("Wi-Fi saved (radio off)"), 1600);
+    g_lv.task->showAlert(
+#if defined(TLORA_PAGER)
+        s_pending_wifi_radio_on ? TR("Saved — restarting\xE2\x80\xA6")
+#else
+        s_pending_wifi_radio_on ? TR("Saved — reconnecting\xE2\x80\xA6")
+#endif
+                                : TR("Wi-Fi saved (radio off)"), 1600);
   refreshStatusLabels();
 }
 
@@ -13281,9 +13288,8 @@ static void saveWifiCb(lv_event_t* e) {
     lv_obj_add_state(g_set_modal.wifi_sw, LV_STATE_CHECKED);
   }
   s_pending_wifi_was_wifi = wifiConfigWantsWifi();   // kept for status display; no longer gates a reboot
-  // Wi-Fi + BLE coexist (NimBLE), so applying creds is always a live operation —
-  // the main loop brings the radio up/down with the new settings. No reboot and
-  // no confirm prompt; just save and (re)connect.
+  // Save immediately. Other boards reconnect live; Pager's main loop reboots
+  // through the ordered Wi-Fi -> BLE setup path.
   doApplyWifi();
 }
 #endif
@@ -13461,7 +13467,7 @@ static void wifiScanStartCb(lv_event_t* e) {
   if (!wifiConfigWantsWifi()) {
     if (!wifiPrepareEnable()) return;
     wifiConfigSetRadioEnabled(true);   // wantsWifi() now true -> the scan worker can bring STA up
-    wifiConfigRequestApply();          // main loop brings esp_wifi up live (no reboot)
+    wifiConfigRequestApply();          // main loop applies live or takes Pager's ordered restart
     if (g_lv.task) g_lv.task->showAlert(TR("Wi-Fi on, scanning\xE2\x80\xA6"), 1200);
   }
   wifiScanOpenAndKick();
@@ -36108,8 +36114,8 @@ static void refreshSettingsSectionSubtitles() {
 // ============================================================
 // Status-bar control center (tap the top bar)
 // A small drop-down panel with date/time + battery/Wi-Fi info and quick
-// Wi-Fi / Bluetooth toggles, iPhone-control-center style. Both toggle live now
-// (NimBLE coexists with esp_wifi) — no reboot to switch.
+// Wi-Fi / Bluetooth toggles, iPhone-control-center style. Resident stacks
+// toggle live; a cold or reconnecting Pager may take an ordered restart.
 // ============================================================
 
 static void closeControlCenter() {
@@ -36150,9 +36156,9 @@ static void openControlCenter();   // fwd — toggle cbs rebuild the panel
 // (no touch), so a long-press of the green ○ Home key triggers this (see navPump).
 static void toggleControlCenter() { if (s_cc_root) closeControlCenter(); else openControlCenter(); }
 
-// Wi-Fi and Bluetooth COEXIST now (NimBLE host shares the heap with esp_wifi),
-// so both are plain LIVE toggles — no reboot to switch. Each radio is
-// independent and its state is persisted (radio_en / ble_en).
+// Wi-Fi and Bluetooth coexist once allocated. Resident stacks toggle live;
+// Pager cold starts/re-authentication use the ordered reboot path. Each radio's
+// requested state is persisted independently (radio_en / ble_en).
 static void ccWifiCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(ESP32)
@@ -40910,9 +40916,8 @@ static void setupFinishCb(lv_event_t* e) {
   }
 #endif
   // Region was applied live when the user advanced past the region step
-  // (setRadioParams -> applyRadioFromPrefs), and Wi-Fi re-associates live via the
-  // apply request above — so nothing here needs a reboot. Just close the wizard
-  // back to the main UI.
+  // (setRadioParams -> applyRadioFromPrefs). Close the wizard; the Wi-Fi apply
+  // request reconnects live elsewhere and takes Pager's ordered restart path.
   setupWizardClose();
   if (g_lv.task) g_lv.task->showAlert(TR("Setup complete"), 1400);
 }

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -36165,7 +36165,7 @@ static void ccWifiCb(lv_event_t* e) {
   // Existing stacks apply live in the main loop; a cold Pager takes the ordered
   // restart path so Wi-Fi claims its allocations before NimBLE and LVGL.
   const bool on = wifiConfigGetRadioEnabled();
-  if (!on && !wifiPrepareEnable()) return;
+  if (!on && !wifiPrepareEnable()) { openControlCenter(); return; }
   wifiConfigSetRadioEnabled(!on);
   if (g_lv.task) g_lv.task->showAlert(on ? TR("Wi-Fi off") : TR("Wi-Fi on"), 800);
   openControlCenter();
@@ -47602,7 +47602,8 @@ bool UITask::enableBle() {
   // and allocate NimBLE during the next ordered boot, before LVGL fragments
   // internal DRAM. rebootDevice() flushes pending history before ESP.restart().
   wifiConfigSetBleEnabled(true);
-  showAlert("Restarting to enable Bluetooth", 800);
+  showAlert(TR("Restarting to enable Bluetooth"), 800);
+  lv_refr_now(NULL);
   rebootDevice();
 #endif
   return false;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -13534,7 +13534,9 @@ static void wifiScanMainService() {
     s_wifiscan_reconnect_after = false;
     s_wifiscan_drop_ms = 0;
     wifiScanSetActive(false);             // un-gate main.cpp's reconnect retry
+#if !defined(TLORA_PAGER)
     WiFi.setAutoReconnect(true);
+#endif
     wifiConfigRequestApply();             // re-begin with the stored cred (main task)
   }
 }
@@ -13555,7 +13557,9 @@ static void wifiScanService() {
     s_wifiscan_reconnect_after = false;
     s_wifiscan_guard_ms = 0;              // normal completion — disarm the stuck-gate deadline
     wifiScanSetActive(false);
+#if !defined(TLORA_PAGER)
     WiFi.setAutoReconnect(true);
+#endif
     wifiConfigRequestApply();             // main.cpp re-begins with the stored cred (main task)
   }
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -4964,12 +4964,17 @@ static char          s_wifiscan_ssids[kWifiScanMax][WIFI_CONFIG_SSID_MAX];
 static volatile int  s_wifiscan_count   = 0;
 static volatile bool s_wifiscan_request = false;   // UI -> worker: scan now
 static volatile bool s_wifiscan_done    = false;   // worker -> UI: results ready
+#if defined(TLORA_PAGER)
+static bool          s_wifiscan_wait_for_radio = false; // main task must cold-start STA first
+static uint32_t      s_wifiscan_pager_guard_ms = 0;     // recover if worker never services request
+#endif
 // Scan-while-connected handshake (S3): the radio can't sweep reliably while
 // associated, so the MAIN task briefly drops the link before the worker scans and
 // rejoins after. All WiFi state changes happen on the main task (never the worker).
 static volatile bool s_wifiscan_drop_req       = false;  // UI -> main: drop link, then scan
 static bool          s_wifiscan_reconnect_after = false;  // main: rejoin once results land
 static uint32_t      s_wifiscan_drop_ms        = 0;      // main: disassoc-settle timer
+static uint32_t      s_wifiscan_guard_ms       = 0;      // main: cancel only an unclaimed scan
 // DEBUG: last wifiScanWatchdogSafe outcome (so the main-task list rebuild can log it).
 static volatile int16_t  s_swd_kick   = -9;
 static volatile int16_t  s_swd_st     = -9;
@@ -13429,6 +13434,38 @@ static void openWifiScanPopup() {
 // results instantly (if any) while the rescan lands. Shared by the Settings
 // Wi-Fi page, the setup wizard's Scan button, and the wizard's auto-scan on
 // arrival. Caller must have already confirmed wifiConfigWantsWifi() (radio up).
+static void wifiQueueScanWhenReady() {
+  if (wifiScanIsActive() ||
+      __atomic_load_n(&s_wifiscan_request, __ATOMIC_ACQUIRE) ||
+      s_wifiscan_drop_req || s_wifiscan_drop_ms != 0
+#if defined(TLORA_PAGER)
+      || s_wifiscan_wait_for_radio
+#endif
+     ) return;
+  ensureTileFetchTaskRunning();   // the worker idles out after 5 s — respawn it
+#if defined(TLORA_PAGER)
+  wifiScanSetActive(true);   // suppress main-loop reconnects for the whole sweep
+  s_wifiscan_pager_guard_ms = millis();
+  s_wifiscan_reconnect_after = false;
+  if ((WiFi.getMode() & WIFI_MODE_STA) == 0 || wifiConfigPagerWifiBlocksBle()) {
+    // The worker must never call esp_wifi_init. Ask the main-loop handoff to
+    // initialize STA, and release the scan only after the ordering phase ends.
+    s_wifiscan_wait_for_radio = true;
+    if ((WiFi.getMode() & WIFI_MODE_STA) == 0) {
+      s_wifiscan_reconnect_after = wifiConfigHasRuntime();
+      wifiConfigRequestApply();
+    }
+    return;
+  }
+#elif defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && !defined(HAS_TANMATSU)
+  wifiScanSetActive(true);
+  s_wifiscan_guard_ms = millis();
+  s_wifiscan_reconnect_after =
+      wifiConfigHasRuntime() && WiFi.status() != WL_CONNECTED;
+#endif
+  __atomic_store_n(&s_wifiscan_request, true, __ATOMIC_RELEASE);
+}
+
 static void wifiScanOpenAndKick() {
   hideKb();   // unbind the keyboard mirror so it can't later revert the picked SSID
   openWifiScanPopup();
@@ -13440,16 +13477,14 @@ static void wifiScanOpenAndKick() {
     lv_obj_set_style_text_color(l, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
     lv_obj_set_style_text_font(l, &g_font_14, LV_PART_MAIN);
   }
-  ensureTileFetchTaskRunning();   // the worker idles out after 5 s — respawn it
-  s_wifiscan_request = true;
+  wifiQueueScanWhenReady();
 }
 
 // Mirror of the BLE-enable guard: bringing esp_wifi up needs ~50 KB free internal
 // heap, and with BLE already holding its share on a tight board the init fails
-// DEEP in the Wi-Fi state machine (main.cpp) where nothing reports it. Keep the
-// decision pure so every caller can distinguish a Pager's ordered restart from
-// a real low-memory refusal.
-enum class WifiEnableGate : uint8_t { Ready, RestartRequired, LowMemory };
+// DEEP in the Wi-Fi state machine (main.cpp) where nothing reports it. Pager
+// uses the live main-loop BLE handoff; the preflight remains for other boards.
+enum class WifiEnableGate : uint8_t { Ready, LowMemory };
 
 static WifiEnableGate wifiEnableGate() {
 #if defined(ESP32)
@@ -13457,12 +13492,9 @@ static WifiEnableGate wifiEnableGate() {
   // one-time DMA allocation. Apply the reserve only to a cold start.
   if (WiFi.getMode() != WIFI_MODE_NULL) return WifiEnableGate::Ready;
 #if defined(TLORA_PAGER)
-  // Pager coexistence is reliable only when setup claims Wi-Fi before NimBLE
-  // and before LVGL. Always route a genuinely cold Wi-Fi start through that
-  // ordering, even if the current heap happens to look large enough. No heap
-  // check here on purpose: the restart is unconditional, so there is no
-  // LowMemory outcome to fall through to on this board.
-  return WifiEnableGate::RestartRequired;
+  // The main loop releases NimBLE, allocates Wi-Fi, then recreates NimBLE live.
+  // Let that path make the authoritative allocation attempt and report failure.
+  return WifiEnableGate::Ready;
 #else
   const uint32_t internal_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
   const size_t freeh = heap_caps_get_free_size(internal_caps);
@@ -13486,39 +13518,19 @@ static bool wifiPrepareEnable(lv_obj_t* switch_to_revert = nullptr) {
       g_lv.task->showAlert(TR("Not enough free memory for Wi-Fi. Turn Bluetooth off first."), 2200);
     return false;
   }
-
-  // Persist the requested state, paint an honest status, then reboot through
-  // the normal flush path so setup can claim Wi-Fi before NimBLE and LVGL.
-  wifiConfigSetRadioEnabled(true);
-  if (g_lv.task) {
-    g_lv.task->showAlert(
-#if defined(TLORA_PAGER)
-        wifiConfigGetBleEnabled()
-          ? TR("Restarting for Wi-Fi; Bluetooth resumes after it connects")
-          : TR("Restarting to enable Wi-Fi"),
-#else
-        TR("Restarting to enable Wi-Fi"),
-#endif
-        1400);
-    lv_refr_now(NULL);
-    g_lv.task->rebootDevice();
-  } else {
-    touchPrefsFlush();
-    ESP.restart();
-  }
-  return false;
+  return true;
 }
 
 // "Scan" button -> open the popup + queue a scan on the core-0 worker. If Wi-Fi
-// is off, prepare the radio first (a cold Pager needs the ordered restart above;
-// other live stacks can continue immediately), then let the worker list networks.
+// is off, prepare the radio first, then let the main loop initialize it before
+// the worker lists networks.
 static void wifiScanStartCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(MULTI_TRANSPORT_COMPANION)
   if (!wifiConfigWantsWifi()) {
     if (!wifiPrepareEnable()) return;
     wifiConfigSetRadioEnabled(true);   // wantsWifi() now true -> the scan worker can bring STA up
-    wifiConfigRequestApply();          // main loop applies live or takes Pager's ordered restart
+    wifiConfigRequestApply();          // main loop applies the live Pager handoff
     if (g_lv.task) g_lv.task->showAlert(TR("Wi-Fi on, scanning\xE2\x80\xA6"), 1200);
   }
   wifiScanOpenAndKick();
@@ -13535,14 +13547,17 @@ static void wifiRebuildNetworkList();   // fwd: reworked Wi-Fi page list (define
 // best-effort while associated and never turns a page-open into a reboot.
 static void wifiKickScan() {
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+  if (wifiScanIsActive() ||
+      __atomic_load_n(&s_wifiscan_request, __ATOMIC_ACQUIRE) ||
+      s_wifiscan_drop_req || s_wifiscan_drop_ms != 0) return;
   ensureTileFetchTaskRunning();
 #if defined(HAS_TANMATSU)
-  s_wifiscan_request = true;                         // esp-hosted C6 sweeps fine while associated
+  __atomic_store_n(&s_wifiscan_request, true, __ATOMIC_RELEASE); // esp-hosted C6 sweeps fine while associated
 #elif defined(TLORA_PAGER)
-  s_wifiscan_request = true;                         // never force WPA re-auth under resident NimBLE
+  wifiQueueScanWhenReady();                          // main task owns any cold STA allocation
 #else
   if (WiFi.status() == WL_CONNECTED) s_wifiscan_drop_req = true;
-  else                               s_wifiscan_request = true;
+  else                               wifiQueueScanWhenReady();
 #endif
 #endif
 }
@@ -13552,9 +13567,6 @@ static void wifiKickScan() {
 // here (sequential with main.cpp's wifi loop on the same task — no worker race, and
 // never eraseap, which wedges this radio). Drop the link, let the disassoc settle,
 // then kick the worker; wifiScanService rejoins once results land.
-// Wall-clock deadline for the scan gate below (0 = not armed). See the recovery
-// branch in wifiScanMainService for why this exists.
-static uint32_t s_wifiscan_guard_ms = 0;
 static void wifiScanMainService() {
   if (s_wifiscan_drop_req) {
     s_wifiscan_drop_req = false;
@@ -13566,11 +13578,11 @@ static void wifiScanMainService() {
       s_wifiscan_guard_ms = millis();     // arm the stuck-gate deadline (recovery below)
       s_wifiscan_reconnect_after = true;
     } else {
-      s_wifiscan_request = true;          // already disconnected — scan now
+      wifiQueueScanWhenReady();            // already disconnected — establish scan ownership now
     }
   } else if (s_wifiscan_drop_ms && (uint32_t)(millis() - s_wifiscan_drop_ms) >= 400) {
     s_wifiscan_drop_ms = 0;
-    s_wifiscan_request = true;            // disassoc settled -> run the sweep
+    __atomic_store_n(&s_wifiscan_request, true, __ATOMIC_RELEASE); // disassoc settled -> run the sweep
   }
   // RECOVERY: opening the Wi-Fi page drops the link and raises the scan gate, which is
   // normally lowered in wifiScanService() once the worker reports s_wifiscan_done. But
@@ -13579,20 +13591,29 @@ static void wifiScanMainService() {
   // long tile/LOS/OTA job. If it never reports, the gate LATCHES: autoreconnect is off
   // and main.cpp's 10 s reconnect retry stays suppressed (main.cpp gates it on
   // !wifiScanIsActive()), so Wi-Fi never comes back until a reboot — a plausible source
-  // of "connects on a fresh flash, never reconnects after a reboot" (issue #171). The
-  // deadline is deliberately far longer than any legitimate sweep (the worker's own scan
-  // path allows several seconds plus retries) so this can only fire when the normal
-  // completion path is genuinely lost, never mid-scan.
+  // of "connects on a fresh flash, never reconnects after a reboot" (issue #171).
+  // Only cancel a request the worker has not claimed. Once the worker atomically
+  // consumes the request, its bounded scan owns the gate until normal completion;
+  // clearing it on a wall-clock guess would race esp_wifi_scan_start.
   if (s_wifiscan_guard_ms && wifiScanIsActive() &&
-      (uint32_t)(millis() - s_wifiscan_guard_ms) >= 30000UL) {
+      (uint32_t)(millis() - s_wifiscan_guard_ms) >= 60000UL) {
     s_wifiscan_guard_ms = 0;
-    s_wifiscan_reconnect_after = false;
-    s_wifiscan_drop_ms = 0;
-    wifiScanSetActive(false);             // un-gate main.cpp's reconnect retry
+    bool cancelled = false;
+    if (s_wifiscan_drop_ms != 0) {
+      s_wifiscan_drop_ms = 0;
+      cancelled = true;
+    }
+    if (__atomic_exchange_n(&s_wifiscan_request, false, __ATOMIC_ACQ_REL))
+      cancelled = true;
+    if (cancelled) {
+      const bool reconnect = s_wifiscan_reconnect_after;
+      s_wifiscan_reconnect_after = false;
+      wifiScanSetActive(false);           // un-gate main.cpp's reconnect retry
 #if !defined(TLORA_PAGER)
-    WiFi.setAutoReconnect(true);
+      WiFi.setAutoReconnect(true);
 #endif
-    wifiConfigRequestApply();             // re-begin with the stored cred (main task)
+      if (reconnect) wifiConfigRequestApply();
+    }
   }
 }
 #endif
@@ -13602,28 +13623,68 @@ static void wifiScanService() {
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && !defined(HAS_TANMATSU)
   wifiScanMainService();   // drive the drop-link-then-scan handshake (main task)
 #endif
+#if defined(TLORA_PAGER) && defined(MULTI_TRANSPORT_COMPANION)
+  if (s_wifiscan_wait_for_radio) {
+    const bool sta_ready = (WiFi.getMode() & WIFI_MODE_STA) != 0;
+    if (!wifiConfigWantsWifi()) {
+      s_wifiscan_wait_for_radio = false;
+      s_wifiscan_reconnect_after = false;
+      s_wifiscan_done = true;
+    } else if (sta_ready && !wifiConfigPagerWifiBlocksBle()) {
+      s_wifiscan_wait_for_radio = false;
+      __atomic_store_n(&s_wifiscan_request, true, __ATOMIC_RELEASE);
+    } else if (!sta_ready && wifiConfigPagerBleFallbackActive()) {
+      // main.cpp already reported the failed allocation and restored BLE.
+      s_wifiscan_wait_for_radio = false;
+      s_wifiscan_reconnect_after = false;
+      s_wifiscan_done = true;
+    }
+  }
+  // Cancel only a wait or queue entry the worker has not claimed. If the worker
+  // already atomically consumed the request, normal completion alone releases
+  // the scan gate; a timeout must never race its esp_wifi_scan_start call.
+  if (s_wifiscan_pager_guard_ms && wifiScanIsActive() &&
+      (uint32_t)(millis() - s_wifiscan_pager_guard_ms) >= 60000UL) {
+    s_wifiscan_pager_guard_ms = 0;
+    bool cancelled = s_wifiscan_wait_for_radio;
+    s_wifiscan_wait_for_radio = false;
+    if (__atomic_exchange_n(&s_wifiscan_request, false, __ATOMIC_ACQ_REL))
+      cancelled = true;
+    if (cancelled) s_wifiscan_done = true;
+  }
+#endif
   if (!s_wifiscan_done) return;
   s_wifiscan_done = false;
   wifiScanFillList();   // legacy scan popup — no-op if closed
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
   wifiRebuildNetworkList();   // refresh the reworked Wi-Fi page (guarded: no-op unless it's open)
 #if !defined(HAS_TANMATSU)
-  if (s_wifiscan_reconnect_after) {       // we dropped the link for this sweep — rejoin now
+#if defined(TLORA_PAGER)
+  const bool reconnect_after_scan = s_wifiscan_reconnect_after;
+  s_wifiscan_reconnect_after = false;
+  s_wifiscan_pager_guard_ms = 0;
+  wifiScanSetActive(false);
+  if (reconnect_after_scan) wifiConfigRequestApply();
+#else
+  if (wifiScanIsActive()) {
+    const bool reconnect_after_scan = s_wifiscan_reconnect_after;
     s_wifiscan_reconnect_after = false;
     s_wifiscan_guard_ms = 0;              // normal completion — disarm the stuck-gate deadline
     wifiScanSetActive(false);
 #if !defined(TLORA_PAGER)
     WiFi.setAutoReconnect(true);
 #endif
-    wifiConfigRequestApply();             // main.cpp re-begins with the stored cred (main task)
+    if (reconnect_after_scan)
+      wifiConfigRequestApply();           // main.cpp re-begins with the stored cred (main task)
   }
+#endif
 #endif
 #endif
 }
 
 // Wi-Fi radio toggle on the Wi-Fi settings page (mirrors the control-center
-// toggle). Existing stacks apply live; a cold Pager routes through the ordered
-// restart above. No separate Save action is needed.
+// toggle). Existing stacks apply live; a cold Pager uses the main-loop BLE
+// handoff above. No separate Save action is needed.
 static void wifiRadioToggleCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
@@ -13889,7 +13950,12 @@ static void wifiHiddenRowCb(lv_event_t* e) {
 static void wifiRefreshRowCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   if (!wifiConfigWantsWifi()) { if (g_lv.task) g_lv.task->showAlert(TR("Turn Wi-Fi on first"), 1200); return; }
-  if (s_wifiscan_request || s_wifiscan_drop_req || s_wifiscan_drop_ms) return;   // a scan is already queued/running
+  if (wifiScanIsActive() || s_wifiscan_request ||
+      s_wifiscan_drop_req || s_wifiscan_drop_ms
+#if defined(TLORA_PAGER)
+      || s_wifiscan_wait_for_radio
+#endif
+     ) return;   // a scan is already queued/running
   wifiKickScan();                                 // connected -> main task drops link first
   wifiRebuildNetworkList();                        // re-render so the row shows "Scanning…"
 }
@@ -13945,7 +14011,12 @@ static void wifiRebuildNetworkList() {
   const bool connected = (WiFi.status() == WL_CONNECTED);
   if (connected) strlcpy(cur, WiFi.SSID().c_str(), sizeof cur);
   // "Scanning…" spans the whole cycle: the main-task drop window AND the worker sweep.
-  const bool scanning_now = (s_wifiscan_request || s_wifiscan_drop_req || s_wifiscan_drop_ms != 0);
+  const bool scanning_now = (wifiScanIsActive() || s_wifiscan_request ||
+                             s_wifiscan_drop_req || s_wifiscan_drop_ms != 0
+#if defined(TLORA_PAGER)
+                             || s_wifiscan_wait_for_radio
+#endif
+                            );
 
   // Saved networks, most-recent first.
   TouchWifiNet nets[TOUCH_WIFI_NET_COUNT];
@@ -25108,16 +25179,26 @@ static void tileFetchTaskFn(void* arg) {
 #endif
     // Wi-Fi scan (user-initiated from the Network tab / setup wizard). Blocking
     // here on the Wi-Fi core, not the UI thread. Mirrors the CLI `wifi scan`.
-    if (s_wifiscan_request) {
-      s_wifiscan_request = false;
+    if (__atomic_exchange_n(&s_wifiscan_request, false, __ATOMIC_ACQ_REL)) {
       s_wifiscan_count = 0;
       // Never bring the Wi-Fi driver up from here when BLE owns the radio (fresh device
       // on BLE => Bluedroid holds the internal heap). WiFi.mode(STA)/esp_wifi_init would
       // then OOM-panic (BLE-vs-Wi-Fi mutex, see main.cpp). wantsWifi() mirrors the boot
       // transport choice: true only when Wi-Fi is the active transport.
       if (!wifiConfigWantsWifi()) { s_wifiscan_done = true; continue; }
+#if defined(TLORA_PAGER)
+      // Cold STA allocation is order-sensitive with NimBLE on the Pager and is
+      // owned exclusively by main.cpp. If the driver disappeared after the UI
+      // released this request, fail the sweep instead of initializing it here.
+      if ((WiFi.getMode() & WIFI_MODE_STA) == 0 || wifiConfigPagerWifiBlocksBle()) {
+        s_wifiscan_done = true;
+        continue;
+      }
+      vTaskDelay(pdMS_TO_TICKS(40));
+#else
       if ((WiFi.getMode() & WIFI_MODE_STA) == 0) { WiFi.mode(WIFI_STA); vTaskDelay(pdMS_TO_TICKS(180)); }
       else                                        { vTaskDelay(pdMS_TO_TICKS(40)); }
+#endif
       // One bounded, yielding async pass — the stable beta_19 scan. NEVER touch WiFi
       // state (disconnect/begin/eraseap) from this worker: it races main.cpp's wifi
       // state machine and wedges the radio (a hard lesson). Scanning while associated
@@ -36215,14 +36296,13 @@ static void openControlCenter();   // fwd — toggle cbs rebuild the panel
 // (no touch), so a long-press of the green ○ Home key triggers this (see navPump).
 static void toggleControlCenter() { if (s_cc_root) closeControlCenter(); else openControlCenter(); }
 
-// Wi-Fi and Bluetooth coexist once allocated. Resident stacks toggle live;
-// Pager cold starts may use the ordered reboot path; re-authentication releases
-// and recreates BLE live. Each requested state persists independently.
+// Wi-Fi and Bluetooth coexist once allocated. Pager cold starts and
+// re-authentication release and recreate BLE live; no reboot is required.
 static void ccWifiCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
 #if defined(ESP32)
-  // Existing stacks apply live in the main loop; a cold Pager takes the ordered
-  // restart path so Wi-Fi claims its allocations before NimBLE and LVGL.
+  // Existing stacks apply live in the main loop; a cold Pager temporarily
+  // releases NimBLE so Wi-Fi can claim its allocation first.
   const bool on = wifiConfigGetRadioEnabled();
   if (!on && !wifiPrepareEnable()) { openControlCenter(); return; }
   wifiConfigSetRadioEnabled(!on);

--- a/src/ui-touch/UITask.h
+++ b/src/ui-touch/UITask.h
@@ -491,11 +491,9 @@ public:
   void disableTcp() { if (_serial) _serial->disableTcp(); }
   bool hasBleCapability() const { return _serial && _serial->hasBleCapability(); }
   bool isBleEnabled() const { return _serial && _serial->isBleEnabled(); }
-  // Live BLE enable, guarded like the boot co-init in main.cpp: NimBLE needs
-  // ~50 KB free internal heap + a 20 KB contiguous block, and starting it below
-  // that does not fail cleanly — it panics mid-init (the "reboots when I turn
-  // BLE on with Wi-Fi running" report). Returns false when refused; the caller
-  // shows the reason and reverts its switch. Defined in UITask.cpp.
+  // Live BLE enable. The concrete transport applies its heap guard only for a
+  // cold NimBLE allocation; re-enabling a pre-created stack is allocation-free.
+  // Returns false when a required cold start cannot be made safely.
   bool enableBle();
   void disableBle() { if (_serial) _serial->disableBle(); }
   int getWsConnectedCount() const { return _serial ? _serial->getWsConnectedCount() : 0; }

--- a/tanmatsu/main/main.cpp
+++ b/tanmatsu/main/main.cpp
@@ -17,7 +17,7 @@
 #include <SD_MMC.h>          // microSD (slot 0): reliable store for contacts/channels/chat (internal FFat loses them on this P4)
 #include "esp_partition.h"   // enumerate partitions (AppFS apps boot fresh — verify locfd is visible)
 #include <WiFi.h>
-#include <helpers/esp32/MultiTransportCompanionInterface.h>
+#include "helpers/esp32/MultiTransportCompanionInterface.h"
 #include <helpers/esp32/WifiRuntimeStore.h>
 #include <helpers/esp32/TouchPrefsStore.h>
 #include "esp32-hal-hosted.h"   // arduino's esp-hosted bring-up (shared by LoRa + WiFi on the C6)

--- a/tanmatsu/main/main.cpp
+++ b/tanmatsu/main/main.cpp
@@ -17,7 +17,7 @@
 #include <SD_MMC.h>          // microSD (slot 0): reliable store for contacts/channels/chat (internal FFat loses them on this P4)
 #include "esp_partition.h"   // enumerate partitions (AppFS apps boot fresh — verify locfd is visible)
 #include <WiFi.h>
-#include "helpers/esp32/MultiTransportCompanionInterface.h"
+#include "../../src/helpers/esp32/MultiTransportCompanionInterface.h"
 #include <helpers/esp32/WifiRuntimeStore.h>
 #include <helpers/esp32/TouchPrefsStore.h>
 #include "esp32-hal-hosted.h"   // arduino's esp-hosted bring-up (shared by LoRa + WiFi on the C6)

--- a/tdisplay_p4/main/main.cpp
+++ b/tdisplay_p4/main/main.cpp
@@ -23,7 +23,7 @@
 #include <SD_MMC.h>                // microSD on SDMMC slot 0 (primary store)
 #include "esp_partition.h"
 #include <WiFi.h>
-#include <helpers/esp32/MultiTransportCompanionInterface.h>
+#include "helpers/esp32/MultiTransportCompanionInterface.h"
 #include <helpers/esp32/WifiRuntimeStore.h>   // wifiConfig* (runtime Wi-Fi state the loop drives)
 #include <helpers/esp32/TouchPrefsStore.h>    // touchPrefsBuildLocalTz + WIFI_CONFIG_* sizes
 #include "esp_hosted.h"

--- a/tdisplay_p4/main/main.cpp
+++ b/tdisplay_p4/main/main.cpp
@@ -23,7 +23,7 @@
 #include <SD_MMC.h>                // microSD on SDMMC slot 0 (primary store)
 #include "esp_partition.h"
 #include <WiFi.h>
-#include "helpers/esp32/MultiTransportCompanionInterface.h"
+#include "../../src/helpers/esp32/MultiTransportCompanionInterface.h"
 #include <helpers/esp32/WifiRuntimeStore.h>   // wifiConfig* (runtime Wi-Fi state the loop drives)
 #include <helpers/esp32/TouchPrefsStore.h>    // touchPrefsBuildLocalTz + WIFI_CONFIG_* sizes
 #include "esp_hosted.h"


### PR DESCRIPTION
## Summary

This makes Wi-Fi and BLE coexist reliably on the LilyGo T-Pager without treating the ESP32-S3 radios as mutually exclusive and without rebooting to enable Wi-Fi.

- keep Pager LVGL allocations and the synchronous display buffer in PSRAM so controller allocations retain contiguous internal/DMA-capable memory
- initialize saved Wi-Fi before NimBLE at boot, while internal heap is least fragmented
- replace live NimBLE destruction with a bond-preserving handoff: stop advertising, disconnect the phone, associate Wi-Fi, then resume the existing GATT server
- wait for NimBLE's asynchronous disconnect to leave the connection table before WPA starts
- give WPA its full six-second association window after BLE is idle
- restore BLE without rebooting when Wi-Fi initialization, disconnect, or association fails
- disable hidden Wi-Fi auto-reconnect attempts while Pager BLE is resident
- harden the remaining intentional NimBLE teardown paths against the captured FreeRTOS timer race using the repository's pinned dependency-patch mechanism

## Failure mechanism

The T-Pager and T-Deck use the same ESP32-S3; the limitation was firmware lifecycle and timing, not different radio hardware.

The Pager could fail in several related ways:

1. UI/display allocations consumed or fragmented internal DRAM required by the Wi-Fi and NimBLE controllers.
2. Starting a cold radio stack after the full UI was running could fail despite ample PSRAM because controller allocations require contiguous internal memory.
3. WPA authentication could overlap an active BLE connection or a hidden Wi-Fi retry, causing BLE timeouts, watchdog resets, and misleading **Not enough memory** errors.
4. The first handoff implementation destroyed and recreated NimBLE. The six-digit PIN remained the same, but the long-term BLE bond state did not, leaving the phone and Pager with mismatched keys and forcing users to forget and re-pair.

The final boundary is narrower: BLE traffic is quiesced while WPA starts, but the bonded NimBLE host, GATT database, device address, and keys remain resident.

## Runtime behavior

- Wi-Fi and BLE remain enabled and allocated together.
- Enabling Wi-Fi while a phone is connected does not reboot the Pager.
- The active GATT connection closes briefly for WPA, but the bond and BLE preference are preserved.
- WPA starts only after `NimBLEServer::getConnectedCount()` reaches zero.
- A stuck disconnect cancels Wi-Fi after one second and restores BLE.
- Wi-Fi receives a fresh six-second association window after BLE is idle.
- BLE advertising resumes after Wi-Fi connects or the bounded attempt fails.
- A previously bonded phone reconnects without entering the PIN again.
- If the saved AP is unavailable, background WPA retries stop and the Pager remains reachable over BLE.
- T-Deck and other boards retain their existing coexistence behavior.

## Captured NimBLE teardown crash

A Pager coredump also identified a deterministic NimBLE-Arduino 1.4.3 race:

- exception: `InstrFetchProhibited`, `PC=0`, `EXCVADDR=0`
- crashing task: FreeRTOS `Tmr Svc`
- timer callback: NimBLE `os_callout_timer_cb`
- concurrent caller: `loopTask` during `NimBLEDevice::deinit(true)`

NimBLE queued `xTimerDelete()` and immediately invalidated callout state. An already-expired callback could run first and dereference the cleared callback. Routine Wi-Fi recovery no longer tears NimBLE down, but teardown remains valid when Bluetooth is explicitly disabled and during selected OTA cleanup paths.

The project already has a pinned PlatformIO dependency-patch mechanism. This PR uses it for the affected Pager environments and fails closed if the expected NimBLE 1.4.3 source does not match. It does not introduce a library fork or change NimBLE major versions.

## Hardware evidence

Tested on a physical SX1262 T-Pager using application-only flashes at `0x10000`; NVS, SPIFFS, partition data, SD contents, and backups were not modified.

Observed:

- boot reached `[BOOT] ui ready`
- saved Wi-Fi associated before the initial NimBLE allocation
- BLE connected using the phone's existing bond
- enabling Wi-Fi from a BLE-connected state completed without reboot or watchdog
- Wi-Fi associated while NimBLE remained allocated
- BLE resumed communication without forgetting or re-pairing the Pager
- an unavailable saved AP fell back to BLE after the bounded attempt
- the UI remained responsive throughout the handoff

The final disconnect-confirmation, WPA-deadline, and bond-preservation revisions were flashed and exercised on the Pager.

## Verification

- `git diff --check origin/main...HEAD`
- `uvx --from platformio platformio run -e tlora_pager_sx1262_companion_radio_touch`
  - success; RAM 101,232 / 327,680 bytes (30.9%), flash 3,433,345 / 4,063,232 bytes (84.5%)
- `uvx --from platformio platformio run -e tlora_pager_lr1121_companion_radio_touch`
  - success; RAM 101,168 / 327,680 bytes (30.9%), flash 3,432,313 / 4,063,232 bytes (84.5%)
- `uvx --from platformio platformio run -e LilyGo_TDeck_companion_radio_touch`
  - success; RAM 101,868 / 327,680 bytes (31.1%), flash 3,324,077 / 4,063,232 bytes (81.8%)
- Pager dependency patches are pinned and idempotent
- independent Codex review: clean after the disconnect wait, WPA deadline, allocation-failure fallback, and bond-preservation fixes
- fresh Claude review intentionally skipped at the user's request

## Scope

This PR does not change SD lifecycle, LoRa/SPI arbitration, radio calibration, profile migration, preferences schema, partitions, or UI layout.

Model: GPT-5.6 Sol | Harness: Codex in T3 Code
