### PR TITLE
fix(storage): commit rooted preference updates to the live file

### DIFF
--- a/src/DataStore.cpp
+++ b/src/DataStore.cpp
@@ -426,8 +426,17 @@ bool DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
       _fs->remove(_rp("/new_prefs.tmp"));   // short write (storage full?) — keep the old main file
       return false;
     }
-    _fs->remove(_rp("/new_prefs"));
-    return _fs->rename(_rp("/new_prefs.tmp"), _rp("/new_prefs"));
+    // _rp() returns a pointer to one shared scratch buffer when the store has
+    // a root prefix (for example SD:/meshcomod). Calling it twice in rename()
+    // therefore aliases both arguments to whichever path was formatted last,
+    // leaving new_prefs.tmp stranded even though the data itself was written.
+    // Keep the source and destination in independent buffers for the swap.
+    char tmp_path[48];
+    char live_path[48];
+    snprintf(tmp_path, sizeof(tmp_path), "%s/new_prefs.tmp", _root);
+    snprintf(live_path, sizeof(live_path), "%s/new_prefs", _root);
+    _fs->remove(live_path);
+    return _fs->rename(tmp_path, live_path);
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- give the temporary and live node-preference paths independent storage before the atomic rename
- preserve the existing rootless filesystem behavior while fixing stores rooted at paths such as `SD:/meshcomod`

## Why

`DataStore::_rp()` uses one shared scratch buffer whenever `_root` is set. `savePrefs()` passed two `_rp()` results directly to `rename()`:

```cpp
rename(_rp("/new_prefs.tmp"), _rp("/new_prefs"))
```

Both arguments therefore pointed at the same buffer after argument evaluation. The rename could become temp-to-temp or live-to-live instead of committing the fully written temporary file. On an SD-backed Pager/T-Deck profile this left `new_prefs.tmp` stranded and returned failure, producing the misleading **Couldn't save name to storage** alert even though the new bytes had been written.

The fix formats the two rooted paths into separate local buffers before removing the old live file and renaming the completed temporary file.

## Scope

This is independent of T-Pager SD bus arbitration. It fixes the generic rooted `DataStore` commit path and contains no mount, SPI, UI, radio, or migration changes.

## Verification

- `git diff --check origin/main...HEAD`
- reviewed both rooted (`/meshcomod`) and rootless path construction
- `uvx --from platformio platformio run -e tlora_pager_sx1262_companion_radio_touch`
  - success
  - RAM: 101,192 / 327,680 bytes (30.9%)
  - flash: 3,420,525 / 4,063,232 bytes (84.2%)
- the same final implementation was included in successful T-Deck and Heltec V4-R8 integration builds

Model: GPT-5.6 Sol | Harness: Codex in T3 Code
