### PR TITLE
fix(storage): make file-backed preferences concurrency-safe

### DIFF
--- a/src/helpers/esp32/SdNvsPrefs.cpp
+++ b/src/helpers/esp32/SdNvsPrefs.cpp
@@ -470,6 +470,14 @@ bool SdNvsPrefs::sdLoad() {
     ++cache.revision;
   }
   xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+  // Another task may have loaded this namespace while file I/O ran outside the
+  // mutex. Keep a single authoritative cache entry instead of inserting an
+  // invisible duplicate that the writer would still iterate.
+  if (FileCache* existing = findCacheLocked(_path)) {
+    const bool ok = existing->loaded;
+    xSemaphoreGive(s_cache_mutex);
+    return ok;
+  }
   s_caches.push_back(std::move(cache));
   xSemaphoreGive(s_cache_mutex);
   return true;
@@ -509,7 +517,7 @@ static bool scheduleOne(uint32_t now, bool force) {
     job->revision = cache.revision;
     job->slot = cache.active_slot == 'a' ? 'b'
               : cache.active_slot == 'b' ? 'a'
-              : 'b';   // first snapshot must not overwrite the legacy .kv path
+              : cache.legacy_present ? 'b' : 'a';
     cache.writing = true;
     strncpy(armed_path, cache.legacy_path, sizeof(armed_path) - 1);
     break;
@@ -608,7 +616,7 @@ bool SdNvsPrefs::writeFileBool(fs::FS* fs, const char* dir, const char* ns,
   std::vector<Kv> kv;
   uint32_t generation = 0;
   char active = 0;
-  loadExplicitNamespace(fs, legacy_path, kv, generation, active);
+  const bool existed = loadExplicitNamespace(fs, legacy_path, kv, generation, active);
   Kv* found = nullptr;
   for (auto& e : kv)
     if (strncmp(e.key, key, sizeof(e.key)) == 0) { found = &e; break; }
@@ -618,7 +626,7 @@ bool SdNvsPrefs::writeFileBool(fs::FS* fs, const char* dir, const char* ns,
     strncpy(found->key, key, sizeof(found->key) - 1);
   }
   found->val.assign(1, value ? 1 : 0);
-  const char slot = active == 'a' ? 'b' : active == 'b' ? 'a' : 'b';
+  const char slot = active == 'a' ? 'b' : active == 'b' ? 'a' : existed ? 'b' : 'a';
   if (!writeSnapshot(fs, legacy_path, slot, generation + 1, kv)) return false;
   return true;
 }

--- a/src/helpers/esp32/SdNvsPrefs.cpp
+++ b/src/helpers/esp32/SdNvsPrefs.cpp
@@ -542,7 +542,19 @@ void SdNvsPrefs::tick(uint32_t now_ms) {
 
 bool SdNvsPrefs::flush(uint32_t timeout_ms) {
   if (!fileMode()) return true;
-  if (!ensureWorker()) return false;
+  if (!ensureWorker()) {
+    // A writer-allocation failure is only a flush failure when RAM contains
+    // work that still needs landing. A clean store has nothing to wait for and
+    // must not permanently block unrelated migration/reboot workflows.
+    if (!s_cache_mutex) return true;
+    bool pending = false;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    for (const auto& cache : s_caches) {
+      if (cache.dirty || cache.writing) { pending = true; break; }
+    }
+    xSemaphoreGive(s_cache_mutex);
+    return !pending;
+  }
   const uint32_t start = millis();
   for (;;) {
     scheduleOne(millis(), true);

--- a/src/helpers/esp32/SdNvsPrefs.cpp
+++ b/src/helpers/esp32/SdNvsPrefs.cpp
@@ -219,18 +219,23 @@ static FileCache* findCacheLocked(const char* path) {
 }
 
 // File-mode caches are shared by every SdNvsPrefs instance and by both the UI
-// and worker cores. Copy a value while holding the cache mutex; returning a Kv*
-// would let a concurrent setter invalidate the vector element or its payload as
-// soon as the lock was released.
-static bool copyCachedValue(const char* path, const char* key, std::vector<uint8_t>& value) {
-  value.clear();
+// and worker cores. Copy into caller-owned storage while holding the cache
+// mutex; returning a Kv* would let a concurrent setter invalidate the vector
+// element or its payload as soon as the lock was released. Scalar and buffer
+// getters stay allocation-free, avoiding tiny heap churn on every preference
+// read. value_size reports the stored length even when the output is truncated.
+static bool copyCachedValue(const char* path, const char* key, void* out,
+                            size_t out_size, size_t& value_size) {
+  value_size = 0;
   if (!s_cache_mutex || !path || !key) return false;
   bool found = false;
   xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
   if (FileCache* cache = findCacheLocked(path)) {
     for (const auto& e : cache->kv) {
       if (strncmp(e.key, key, sizeof(e.key)) != 0) continue;
-      value = e.val;
+      value_size = e.val.size();
+      const size_t copy_size = value_size < out_size ? value_size : out_size;
+      if (out && copy_size) memcpy(out, e.val.data(), copy_size);
       found = true;
       break;
     }
@@ -644,22 +649,23 @@ bool SdNvsPrefs::writeFileBool(fs::FS* fs, const char* dir, const char* ns,
 }
 
 uint64_t SdNvsPrefs::sdGetInt(const char* key, uint64_t def, int width, bool* found) {
-  std::vector<uint8_t> cached;
-  const std::vector<uint8_t>* value = nullptr;
+  uint8_t cached[8] = {};
   if (fileMode()) {
-    const bool exists = copyCachedValue(_path, key, cached);
+    size_t value_size = 0;
+    const bool exists = copyCachedValue(_path, key, cached, sizeof cached, value_size);
     if (found) *found = exists;
-    if (!exists || cached.empty()) return def;
-    value = &cached;
-  } else {
-    Kv* e = sdFind(key);
-    if (found) *found = e != nullptr;
-    if (!e || e->val.empty()) return def;
-    value = &e->val;
+    if (!exists || value_size == 0) return def;
+    uint64_t v = 0;
+    int n = (int)value_size; if (n > width) n = width;
+    for (int i = 0; i < n; i++) v |= (uint64_t)cached[i] << (8 * i);
+    return v;
   }
+  Kv* e = sdFind(key);
+  if (found) *found = e != nullptr;
+  if (!e || e->val.empty()) return def;
   uint64_t v = 0;
-  int n = (int)value->size(); if (n > width) n = width;
-  for (int i = 0; i < n; i++) v |= (uint64_t)(*value)[i] << (8 * i);
+  int n = (int)e->val.size(); if (n > width) n = width;
+  for (int i = 0; i < n; i++) v |= (uint64_t)e->val[i] << (8 * i);
   return v;
 }
 
@@ -676,8 +682,9 @@ size_t SdNvsPrefs::sdPutInt(const char* key, uint64_t v, int width) {
 
 bool SdNvsPrefs::isKey(const char* key) {
   if (fileMode()) {
-    std::vector<uint8_t> value;
-    return copyCachedValue(_path, key, value) || (_nvs_open && _nvs.isKey(key));
+    size_t value_size = 0;
+    return copyCachedValue(_path, key, nullptr, 0, value_size) ||
+           (_nvs_open && _nvs.isKey(key));
   }
   return useNvs() ? (_nvs_open && _nvs.isKey(key)) : (sdFind(key) != nullptr);
 }
@@ -823,12 +830,23 @@ size_t SdNvsPrefs::putBool(const char* k, bool v) {
 
 String SdNvsPrefs::getString(const char* k, const String& def) {
   if (fileMode()) {
-    std::vector<uint8_t> value;
-    if (!copyCachedValue(_path, k, value))
+    if (!s_cache_mutex) return (_nvs_open && _nvs.isKey(k)) ? _nvs.getString(k, def) : def;
+    String value;
+    bool found = false;
+    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+    if (FileCache* cache = findCacheLocked(_path)) {
+      for (const auto& e : cache->kv) {
+        if (strncmp(e.key, k, sizeof(e.key)) != 0) continue;
+        value.reserve(e.val.size());
+        for (uint8_t c : e.val) value += (char)c;
+        found = true;
+        break;
+      }
+    }
+    xSemaphoreGive(s_cache_mutex);
+    if (!found)
       return (_nvs_open && _nvs.isKey(k)) ? _nvs.getString(k, def) : def;
-    String s; s.reserve(value.size());
-    for (uint8_t c : value) s += (char)c;
-    return s;
+    return value;
   }
   if (useNvs()) return _nvs.getString(k, def);
   Kv* e = sdFind(k);
@@ -840,15 +858,14 @@ String SdNvsPrefs::getString(const char* k, const String& def) {
 size_t SdNvsPrefs::getString(const char* k, char* buf, size_t maxLen) {
   if (!buf || !maxLen) return 0;
   if (fileMode()) {
-    std::vector<uint8_t> value;
-    if (!copyCachedValue(_path, k, value)) {
+    size_t value_size = 0;
+    if (!copyCachedValue(_path, k, buf, maxLen - 1, value_size)) {
       if (_nvs_open && _nvs.isKey(k)) return _nvs.getString(k, buf, maxLen);
       buf[0] = '\0';
       return 0;
     }
-    size_t n = value.size();
+    size_t n = value_size;
     if (n > maxLen - 1) n = maxLen - 1;
-    if (n) memcpy(buf, value.data(), n);
     buf[n] = '\0';
     return n;
   }
@@ -868,15 +885,10 @@ size_t SdNvsPrefs::putString(const char* k, const char* v) {
 
 size_t SdNvsPrefs::getBytes(const char* k, void* buf, size_t maxLen) {
   if (fileMode()) {
-    std::vector<uint8_t> value;
-    if (!copyCachedValue(_path, k, value))
+    size_t value_size = 0;
+    if (!copyCachedValue(_path, k, buf, maxLen, value_size))
       return (_nvs_open && _nvs.isKey(k)) ? _nvs.getBytes(k, buf, maxLen) : 0;
-    const size_t n = value.size();
-    if (buf && maxLen) {
-      const size_t copy_len = n > maxLen ? maxLen : n;
-      if (copy_len) memcpy(buf, value.data(), copy_len);
-    }
-    return n;
+    return value_size;
   }
   if (useNvs()) return _nvs.getBytes(k, buf, maxLen);
   Kv* e = sdFind(k);

--- a/src/helpers/esp32/SdNvsPrefs.cpp
+++ b/src/helpers/esp32/SdNvsPrefs.cpp
@@ -218,6 +218,27 @@ static FileCache* findCacheLocked(const char* path) {
   return nullptr;
 }
 
+// File-mode caches are shared by every SdNvsPrefs instance and by both the UI
+// and worker cores. Copy a value while holding the cache mutex; returning a Kv*
+// would let a concurrent setter invalidate the vector element or its payload as
+// soon as the lock was released.
+static bool copyCachedValue(const char* path, const char* key, std::vector<uint8_t>& value) {
+  value.clear();
+  if (!s_cache_mutex || !path || !key) return false;
+  bool found = false;
+  xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
+  if (FileCache* cache = findCacheLocked(path)) {
+    for (const auto& e : cache->kv) {
+      if (strncmp(e.key, key, sizeof(e.key)) != 0) continue;
+      value = e.val;
+      found = true;
+      break;
+    }
+  }
+  xSemaphoreGive(s_cache_mutex);
+  return found;
+}
+
 static void prefsWriterTask(void*) {
   for (;;) {
     WriteJob* job = nullptr;
@@ -331,18 +352,10 @@ void SdNvsPrefs::end() {
 
 // ----------------------------- file helpers -----------------------------
 SdNvsPrefs::Kv* SdNvsPrefs::sdFind(const char* key) {
-  if (fileMode()) {
-    if (!s_cache_mutex) return nullptr;
-    xSemaphoreTake(s_cache_mutex, portMAX_DELAY);
-    FileCache* cache = findCacheLocked(_path);
-    Kv* found = nullptr;
-    if (cache) {
-      for (auto& e : cache->kv)
-        if (strncmp(e.key, key, sizeof(e.key)) == 0) { found = &e; break; }
-    }
-    xSemaphoreGive(s_cache_mutex);
-    return found;
-  }
+  // Shared file-mode entries must never escape s_cache_mutex. File-mode
+  // callers use copyCachedValue() instead; this pointer helper is only for the
+  // legacy per-instance vector below.
+  if (fileMode()) return nullptr;
   for (auto& e : _sd) if (strncmp(e.key, key, sizeof(e.key)) == 0) return &e;
   return nullptr;
 }
@@ -496,7 +509,7 @@ static bool scheduleOne(uint32_t now, bool force) {
     job->revision = cache.revision;
     job->slot = cache.active_slot == 'a' ? 'b'
               : cache.active_slot == 'b' ? 'a'
-              : cache.legacy_present ? 'b' : 'a';
+              : 'b';   // first snapshot must not overwrite the legacy .kv path
     cache.writing = true;
     strncpy(armed_path, cache.legacy_path, sizeof(armed_path) - 1);
     break;
@@ -521,6 +534,7 @@ void SdNvsPrefs::tick(uint32_t now_ms) {
 
 bool SdNvsPrefs::flush(uint32_t timeout_ms) {
   if (!fileMode()) return true;
+  if (!ensureWorker()) return false;
   const uint32_t start = millis();
   for (;;) {
     scheduleOne(millis(), true);
@@ -594,7 +608,7 @@ bool SdNvsPrefs::writeFileBool(fs::FS* fs, const char* dir, const char* ns,
   std::vector<Kv> kv;
   uint32_t generation = 0;
   char active = 0;
-  const bool existed = loadExplicitNamespace(fs, legacy_path, kv, generation, active);
+  loadExplicitNamespace(fs, legacy_path, kv, generation, active);
   Kv* found = nullptr;
   for (auto& e : kv)
     if (strncmp(e.key, key, sizeof(e.key)) == 0) { found = &e; break; }
@@ -604,17 +618,28 @@ bool SdNvsPrefs::writeFileBool(fs::FS* fs, const char* dir, const char* ns,
     strncpy(found->key, key, sizeof(found->key) - 1);
   }
   found->val.assign(1, value ? 1 : 0);
-  const char slot = active == 'a' ? 'b' : active == 'b' ? 'a' : existed ? 'b' : 'a';
+  const char slot = active == 'a' ? 'b' : active == 'b' ? 'a' : 'b';
   if (!writeSnapshot(fs, legacy_path, slot, generation + 1, kv)) return false;
   return true;
 }
 
-uint64_t SdNvsPrefs::sdGetInt(const char* key, uint64_t def, int width) {
-  Kv* e = sdFind(key);
-  if (!e || e->val.empty()) return def;
+uint64_t SdNvsPrefs::sdGetInt(const char* key, uint64_t def, int width, bool* found) {
+  std::vector<uint8_t> cached;
+  const std::vector<uint8_t>* value = nullptr;
+  if (fileMode()) {
+    const bool exists = copyCachedValue(_path, key, cached);
+    if (found) *found = exists;
+    if (!exists || cached.empty()) return def;
+    value = &cached;
+  } else {
+    Kv* e = sdFind(key);
+    if (found) *found = e != nullptr;
+    if (!e || e->val.empty()) return def;
+    value = &e->val;
+  }
   uint64_t v = 0;
-  int n = (int)e->val.size(); if (n > width) n = width;
-  for (int i = 0; i < n; i++) v |= (uint64_t)e->val[i] << (8 * i);
+  int n = (int)value->size(); if (n > width) n = width;
+  for (int i = 0; i < n; i++) v |= (uint64_t)(*value)[i] << (8 * i);
   return v;
 }
 
@@ -630,7 +655,10 @@ size_t SdNvsPrefs::sdPutInt(const char* key, uint64_t v, int width) {
 // ever touch the file — nothing new is written to NVS.
 
 bool SdNvsPrefs::isKey(const char* key) {
-  if (fileMode()) return sdFind(key) != nullptr || (_nvs_open && _nvs.isKey(key));
+  if (fileMode()) {
+    std::vector<uint8_t> value;
+    return copyCachedValue(_path, key, value) || (_nvs_open && _nvs.isKey(key));
+  }
   return useNvs() ? (_nvs_open && _nvs.isKey(key)) : (sdFind(key) != nullptr);
 }
 
@@ -704,7 +732,9 @@ bool SdNvsPrefs::clear() {
 
 uint8_t SdNvsPrefs::getUChar(const char* k, uint8_t def) {
   if (fileMode()) {
-    if (sdFind(k)) return (uint8_t)sdGetInt(k, def, 1);
+    bool found = false;
+    const uint8_t value = (uint8_t)sdGetInt(k, def, 1, &found);
+    if (found) return value;
     if (_nvs_open && _nvs.isKey(k)) return _nvs.getUChar(k, def);
     return def;
   }
@@ -716,7 +746,9 @@ size_t SdNvsPrefs::putUChar(const char* k, uint8_t v) {
 }
 int8_t SdNvsPrefs::getChar(const char* k, int8_t def) {
   if (fileMode()) {
-    if (sdFind(k)) return (int8_t)sdGetInt(k, (uint8_t)def, 1);
+    bool found = false;
+    const int8_t value = (int8_t)sdGetInt(k, (uint8_t)def, 1, &found);
+    if (found) return value;
     if (_nvs_open && _nvs.isKey(k)) return _nvs.getChar(k, def);
     return def;
   }
@@ -728,7 +760,9 @@ size_t SdNvsPrefs::putChar(const char* k, int8_t v) {
 }
 uint16_t SdNvsPrefs::getUShort(const char* k, uint16_t def) {
   if (fileMode()) {
-    if (sdFind(k)) return (uint16_t)sdGetInt(k, def, 2);
+    bool found = false;
+    const uint16_t value = (uint16_t)sdGetInt(k, def, 2, &found);
+    if (found) return value;
     if (_nvs_open && _nvs.isKey(k)) return _nvs.getUShort(k, def);
     return def;
   }
@@ -740,7 +774,9 @@ size_t SdNvsPrefs::putUShort(const char* k, uint16_t v) {
 }
 uint32_t SdNvsPrefs::getUInt(const char* k, uint32_t def) {
   if (fileMode()) {
-    if (sdFind(k)) return (uint32_t)sdGetInt(k, def, 4);
+    bool found = false;
+    const uint32_t value = (uint32_t)sdGetInt(k, def, 4, &found);
+    if (found) return value;
     if (_nvs_open && _nvs.isKey(k)) return _nvs.getUInt(k, def);
     return def;
   }
@@ -752,7 +788,9 @@ size_t SdNvsPrefs::putUInt(const char* k, uint32_t v) {
 }
 bool SdNvsPrefs::getBool(const char* k, bool def) {
   if (fileMode()) {
-    if (sdFind(k)) return sdGetInt(k, def ? 1 : 0, 1) != 0;
+    bool found = false;
+    const bool value = sdGetInt(k, def ? 1 : 0, 1, &found) != 0;
+    if (found) return value;
     if (_nvs_open && _nvs.isKey(k)) return _nvs.getBool(k, def);
     return def;
   }
@@ -764,29 +802,38 @@ size_t SdNvsPrefs::putBool(const char* k, bool v) {
 }
 
 String SdNvsPrefs::getString(const char* k, const String& def) {
-  Kv* e = nullptr;
   if (fileMode()) {
-    e = sdFind(k);
-    if (!e) return (_nvs_open && _nvs.isKey(k)) ? _nvs.getString(k, def) : def;
-  } else {
-    if (useNvs()) return _nvs.getString(k, def);
-    e = sdFind(k);
-    if (!e) return def;
+    std::vector<uint8_t> value;
+    if (!copyCachedValue(_path, k, value))
+      return (_nvs_open && _nvs.isKey(k)) ? _nvs.getString(k, def) : def;
+    String s; s.reserve(value.size());
+    for (uint8_t c : value) s += (char)c;
+    return s;
   }
+  if (useNvs()) return _nvs.getString(k, def);
+  Kv* e = sdFind(k);
+  if (!e) return def;
   String s; s.reserve(e->val.size());
   for (uint8_t c : e->val) s += (char)c;
   return s;
 }
 size_t SdNvsPrefs::getString(const char* k, char* buf, size_t maxLen) {
   if (!buf || !maxLen) return 0;
-  Kv* e = nullptr;
   if (fileMode()) {
-    e = sdFind(k);
-    if (!e) { if (_nvs_open && _nvs.isKey(k)) return _nvs.getString(k, buf, maxLen); buf[0] = '\0'; return 0; }
-  } else {
-    if (useNvs()) return _nvs.getString(k, buf, maxLen);
-    e = sdFind(k);
+    std::vector<uint8_t> value;
+    if (!copyCachedValue(_path, k, value)) {
+      if (_nvs_open && _nvs.isKey(k)) return _nvs.getString(k, buf, maxLen);
+      buf[0] = '\0';
+      return 0;
+    }
+    size_t n = value.size();
+    if (n > maxLen - 1) n = maxLen - 1;
+    if (n) memcpy(buf, value.data(), n);
+    buf[n] = '\0';
+    return n;
   }
+  if (useNvs()) return _nvs.getString(k, buf, maxLen);
+  Kv* e = sdFind(k);
   size_t n = e ? e->val.size() : 0;
   if (n > maxLen - 1) n = maxLen - 1;
   if (e && n) memcpy(buf, e->val.data(), n);
@@ -800,15 +847,20 @@ size_t SdNvsPrefs::putString(const char* k, const char* v) {
 }
 
 size_t SdNvsPrefs::getBytes(const char* k, void* buf, size_t maxLen) {
-  Kv* e = nullptr;
   if (fileMode()) {
-    e = sdFind(k);
-    if (!e) return (_nvs_open && _nvs.isKey(k)) ? _nvs.getBytes(k, buf, maxLen) : 0;
-  } else {
-    if (useNvs()) return _nvs.getBytes(k, buf, maxLen);
-    e = sdFind(k);
-    if (!e) return 0;
+    std::vector<uint8_t> value;
+    if (!copyCachedValue(_path, k, value))
+      return (_nvs_open && _nvs.isKey(k)) ? _nvs.getBytes(k, buf, maxLen) : 0;
+    const size_t n = value.size();
+    if (buf && maxLen) {
+      const size_t copy_len = n > maxLen ? maxLen : n;
+      if (copy_len) memcpy(buf, value.data(), copy_len);
+    }
+    return n;
   }
+  if (useNvs()) return _nvs.getBytes(k, buf, maxLen);
+  Kv* e = sdFind(k);
+  if (!e) return 0;
   size_t n = e->val.size();
   if (buf && maxLen) { size_t c = n > maxLen ? maxLen : n; memcpy(buf, e->val.data(), c); }
   return n;

--- a/src/helpers/esp32/SdNvsPrefs.h
+++ b/src/helpers/esp32/SdNvsPrefs.h
@@ -86,7 +86,7 @@ private:
   bool   sdSet(const char* key, const uint8_t* data, size_t len);
   bool   sdLoad();
   bool   sdSave();              // queue current RAM mirror (no filesystem I/O)
-  uint64_t sdGetInt(const char* key, uint64_t def, int width);
+  uint64_t sdGetInt(const char* key, uint64_t def, int width, bool* found = nullptr);
   size_t sdPutInt(const char* key, uint64_t v, int width);
 };
 


### PR DESCRIPTION
## Summary

- copy file-backed preference values while holding the shared cache mutex
- keep scalar, key-existence, string-buffer, and byte-buffer cache reads allocation-free
- preserve the distinction between a stored default-valued key and a missing key that should fall back to NVS/defaults
- recheck the shared cache under the mutex after an SD load so concurrent `begin()` calls cannot insert duplicate hidden cache entries
- report a synchronous flush as successful when no write is pending even if the worker cannot be initialized; fail only while dirty/writing state remains
- write the first A/B snapshot to the alternate slot so a legacy `.kv` file remains recoverable until a new snapshot is committed

## Why

`SdNvsPrefs` caches are shared by every instance and accessed from the UI and writer cores. The old file-mode lookup returned a pointer into a shared `std::vector` after releasing its mutex. A concurrent setter could then reallocate the vector or replace the payload while a getter was still reading it, producing stale/corrupt values or a use-after-free.

There was a second power-loss edge on first conversion to A/B snapshots: the initial write could target the legacy `.kv` pathname. A reset or short write at that point could destroy the only known-good copy. When a legacy file exists, starting with the alternate slot keeps it intact until the new generation is durably committed; a genuinely fresh store retains the established slot-A start.

A concurrent first `begin()` also needed a second cache lookup after filesystem I/O. Without it, two tasks could both miss, load, and append separate cache objects for the same path; later callers could observe a stale hidden copy.

The change remains inside the file-backed preference implementation. It does not alter NVS-only behavior or SD mount policy.

## Verification

- `git diff --check origin/main...HEAD`
- isolated diff matches the reviewed integration implementation byte-for-byte
- `uvx --from platformio platformio run -e tlora_pager_sx1262_companion_radio_touch`
  - success
  - RAM: 101,192 / 327,680 bytes (30.9%)
  - flash: 3,421,269 / 4,063,232 bytes (84.2%)
- the same implementation was included in successful T-Deck and Heltec V4-R8 integration builds

## Known gap

No destructive power-cut or card-corruption test was performed. Recovery behavior was reviewed from the slot-selection and load paths, and all user storage was preserved.

Model: GPT-5.6 Sol | Harness: Codex in T3 Code
