### PR TITLE
fix(storage): preserve watchdog state during long filesystem operations

### DIFF
--- a/src/helpers/esp32/WdtHeavyGuard.h
+++ b/src/helpers/esp32/WdtHeavyGuard.h
@@ -53,12 +53,12 @@ struct LoopWdtGuard {
 #else
 // Tanmatsu and T-Display-P4 supply app_main() themselves. Their Arduino
 // component has no loopTaskHandle or loop-WDT helpers to preserve.
-struct LoopWdtGuard {};
+struct LoopWdtGuard { LoopWdtGuard() {} ~LoopWdtGuard() {} };
 #endif
 #else
 inline void wdtHeavyBegin() {}
 inline void wdtHeavyEnd()   {}
-struct LoopWdtGuard {};
+struct LoopWdtGuard { LoopWdtGuard() {} ~LoopWdtGuard() {} };
 #endif
 
 struct WdtHeavyGuard { WdtHeavyGuard() { wdtHeavyBegin(); } ~WdtHeavyGuard() { wdtHeavyEnd(); } };

--- a/src/helpers/esp32/WdtHeavyGuard.h
+++ b/src/helpers/esp32/WdtHeavyGuard.h
@@ -27,13 +27,28 @@
 // -----------------------------------------------------------------------------
 #if defined(ESP32)
 #include <Arduino.h>   // disableCore0WDT / enableCore0WDT
+#include <esp_task_wdt.h>
 
 inline int& _wdtHeavyDepth() { static int d = 0; return d; }
 inline void wdtHeavyBegin() { int& d = _wdtHeavyDepth(); if (d++ == 0)               disableCore0WDT(); }
 inline void wdtHeavyEnd()   { int& d = _wdtHeavyDepth(); if (d > 0 && --d == 0)      enableCore0WDT();  }
+
+// Arduino's enableLoopWDT() subscribes loopTask even when it was not watched
+// before. Preserve the caller's actual task-WDT state around slow filesystem
+// work instead of silently arming a new watchdog on the way out.
+struct LoopWdtGuard {
+  bool subscribed;
+  LoopWdtGuard() : subscribed(esp_task_wdt_status(nullptr) == ESP_OK) {
+    if (subscribed) disableLoopWDT();
+  }
+  ~LoopWdtGuard() {
+    if (subscribed) enableLoopWDT();
+  }
+};
 #else
 inline void wdtHeavyBegin() {}
 inline void wdtHeavyEnd()   {}
+struct LoopWdtGuard {};
 #endif
 
 struct WdtHeavyGuard { WdtHeavyGuard() { wdtHeavyBegin(); } ~WdtHeavyGuard() { wdtHeavyEnd(); } };

--- a/src/helpers/esp32/WdtHeavyGuard.h
+++ b/src/helpers/esp32/WdtHeavyGuard.h
@@ -38,6 +38,7 @@ inline void wdtHeavyEnd()   { int& d = _wdtHeavyDepth(); if (d > 0 && --d == 0) 
 // work instead of silently arming a new watchdog on the way out. The guard can
 // be constructed by a storage worker, so query Arduino's loopTask handle rather
 // than `nullptr` (which means the current worker task to ESP-IDF).
+#if defined(CONFIG_AUTOSTART_ARDUINO)
 extern TaskHandle_t loopTaskHandle;
 struct LoopWdtGuard {
   bool subscribed;
@@ -49,6 +50,11 @@ struct LoopWdtGuard {
     if (subscribed) enableLoopWDT();
   }
 };
+#else
+// Tanmatsu and T-Display-P4 supply app_main() themselves. Their Arduino
+// component has no loopTaskHandle or loop-WDT helpers to preserve.
+struct LoopWdtGuard {};
+#endif
 #else
 inline void wdtHeavyBegin() {}
 inline void wdtHeavyEnd()   {}

--- a/src/helpers/esp32/WdtHeavyGuard.h
+++ b/src/helpers/esp32/WdtHeavyGuard.h
@@ -35,10 +35,14 @@ inline void wdtHeavyEnd()   { int& d = _wdtHeavyDepth(); if (d > 0 && --d == 0) 
 
 // Arduino's enableLoopWDT() subscribes loopTask even when it was not watched
 // before. Preserve the caller's actual task-WDT state around slow filesystem
-// work instead of silently arming a new watchdog on the way out.
+// work instead of silently arming a new watchdog on the way out. The guard can
+// be constructed by a storage worker, so query Arduino's loopTask handle rather
+// than `nullptr` (which means the current worker task to ESP-IDF).
+extern TaskHandle_t loopTaskHandle;
 struct LoopWdtGuard {
   bool subscribed;
-  LoopWdtGuard() : subscribed(esp_task_wdt_status(nullptr) == ESP_OK) {
+  LoopWdtGuard() : subscribed(loopTaskHandle != nullptr &&
+                              esp_task_wdt_status(loopTaskHandle) == ESP_OK) {
     if (subscribed) disableLoopWDT();
   }
   ~LoopWdtGuard() {

--- a/src/helpers/esp32/WdtHeavyGuard.h
+++ b/src/helpers/esp32/WdtHeavyGuard.h
@@ -28,10 +28,34 @@
 #if defined(ESP32)
 #include <Arduino.h>   // disableCore0WDT / enableCore0WDT
 #include <esp_task_wdt.h>
+#include <atomic>
 
-inline int& _wdtHeavyDepth() { static int d = 0; return d; }
-inline void wdtHeavyBegin() { int& d = _wdtHeavyDepth(); if (d++ == 0)               disableCore0WDT(); }
-inline void wdtHeavyEnd()   { int& d = _wdtHeavyDepth(); if (d > 0 && --d == 0)      enableCore0WDT();  }
+// The depth is shared: the UI/loop task and the core-1 history worker both take
+// this guard around multi-second flash bursts, and they run at the same priority
+// on the same core, so plain tick round-robin can preempt between the load and
+// the store of a d++/--d. rebootDevice() makes that collision likely rather than
+// theoretical -- it takes the guard immediately before waiting up to 9 s on the
+// very worker that also takes it. A lost update either strands the depth above
+// zero (IDLE0 never re-subscribed to the task watchdog for the rest of the
+// session) or drops it to zero while a guard is still held (watchdog re-armed
+// during the burst the guard exists to cover, which panics and loses the
+// unflushed chat history rebootDevice() was written to save).
+inline std::atomic<int>& _wdtHeavyDepth() { static std::atomic<int> d{0}; return d; }
+inline void wdtHeavyBegin() {
+  if (_wdtHeavyDepth().fetch_add(1, std::memory_order_acq_rel) == 0) disableCore0WDT();
+}
+inline void wdtHeavyEnd() {
+  // Keep the original underflow guard rather than a bare fetch_sub:
+  // doFactoryReset() calls wdtHeavyBegin() with no matching end (it reboots),
+  // so the counter can legitimately stay elevated and an unbalanced end must
+  // never drive it negative.
+  std::atomic<int>& d = _wdtHeavyDepth();
+  int prev = d.load(std::memory_order_relaxed);
+  while (prev > 0 && !d.compare_exchange_weak(prev, prev - 1,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_relaxed)) {}
+  if (prev == 1) enableCore0WDT();
+}
 
 // Arduino's enableLoopWDT() subscribes loopTask even when it was not watched
 // before. Preserve the caller's actual task-WDT state around slow filesystem

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10826,9 +10826,11 @@ static void sdRestoreApply() {
   // Land everything in RAM first — this path used to reboot WITHOUT persisting,
   // silently dropping every message since the last lazy flush.
   g_lv.task->persistHistoryNow();
-  disableLoopWDT();
-  const bool ok = meshcomodMigrateSpiffsToSd(true);
-  enableLoopWDT();
+  bool ok = false;
+  {
+    LoopWdtGuard loop_wdt_guard;
+    ok = meshcomodMigrateSpiffsToSd(true);
+  }
   if (!ok) { g_lv.task->showAlert(TR("Copy failed (no internal identity)"), 2200); return; }
   meshcomodClearSdMigLatch();           // manual copy succeeded -> re-arm boot auto-adoption (GH #142/#148)
   touchPrefsSetUseSdStorage(true);      // make sure the reboot adopts the card
@@ -18731,30 +18733,31 @@ static bool fmSdTryMount() {
   const int kAttempts = (int)(sizeof(kMountLadder) / sizeof(kMountLadder[0]));
   bool mounted = false;
   uint32_t mounted_hz = 0;
-  disableLoopWDT();
-  for (int attempt = 0; attempt < kAttempts; ++attempt) {
-    SD.end();
-    delay(kMountLadder[attempt].settle_ms);
-    if (SD.begin(PIN_SD_CS, *spi, kMountLadder[attempt].hz, "/sd", 6) && SD.cardType() != CARD_NONE) {
-      mounted = true;
-      mounted_hz = kMountLadder[attempt].hz;
-      break;
-    }
-  }
-  // Renegotiate upward after a slow-rung success (GH #194): the succeeding rung's clock used
-  // to become the SESSION clock, so a card whose wake-up needed 400 kHz served contacts,
-  // history and tiles at ~25 KB/s forever after ("slower is fine" above predates the SD being
-  // the primary store). Init slow, then raise — fall back to the proven clock if 4 MHz fails.
-  if (mounted && mounted_hz < 4000000) {
-    SD.end();
-    delay(60);
-    if (!(SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6) && SD.cardType() != CARD_NONE)) {
+  {
+    LoopWdtGuard loop_wdt_guard;
+    for (int attempt = 0; attempt < kAttempts; ++attempt) {
       SD.end();
-      delay(120);
-      mounted = SD.begin(PIN_SD_CS, *spi, mounted_hz, "/sd", 6) && SD.cardType() != CARD_NONE;
+      delay(kMountLadder[attempt].settle_ms);
+      if (SD.begin(PIN_SD_CS, *spi, kMountLadder[attempt].hz, "/sd", 6) && SD.cardType() != CARD_NONE) {
+        mounted = true;
+        mounted_hz = kMountLadder[attempt].hz;
+        break;
+      }
+    }
+    // Renegotiate upward after a slow-rung success (GH #194): the succeeding rung's clock used
+    // to become the SESSION clock, so a card whose wake-up needed 400 kHz served contacts,
+    // history and tiles at ~25 KB/s forever after ("slower is fine" above predates the SD being
+    // the primary store). Init slow, then raise — fall back to the proven clock if 4 MHz fails.
+    if (mounted && mounted_hz < 4000000) {
+      SD.end();
+      delay(60);
+      if (!(SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6) && SD.cardType() != CARD_NONE)) {
+        SD.end();
+        delay(120);
+        mounted = SD.begin(PIN_SD_CS, *spi, mounted_hz, "/sd", 6) && SD.cardType() != CARD_NONE;
+      }
     }
   }
-  enableLoopWDT();
   if (mounted) {
     s_sd_mounted = true;
     s_sd_size = SD.cardSize();
@@ -35997,6 +36000,8 @@ static void powerOffCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   closePowerMenu();
 #if defined(ESP32)
+  WdtHeavyGuard idle_wdt_guard;
+  LoopWdtGuard loop_wdt_guard;
   if (g_lv.task) {
     g_lv.task->persistHistoryNow();        // flush chat before we go down
     discoveredFlushNow();                  // and the Discovered ring
@@ -36047,6 +36052,8 @@ static void powerDownloadCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   closePowerMenu();
 #if defined(ESP32)
+  WdtHeavyGuard idle_wdt_guard;
+  LoopWdtGuard loop_wdt_guard;
   if (g_lv.task) {
     g_lv.task->persistHistoryNow();   // flush chat before we go down
     discoveredFlushNow();             // and the Discovered ring
@@ -46060,6 +46067,8 @@ void UITask::persistHistoryNow() {
 }
 
 void UITask::rebootDevice() {
+  WdtHeavyGuard idle_wdt_guard;
+  LoopWdtGuard loop_wdt_guard;
   // Persist chat history synchronously before we reboot — the periodic
   // flush is rate-capped, so without this a reboot could drop the most
   // recent chat history.
@@ -47426,32 +47435,33 @@ void UITask::loop() {
   // watchdog around it (CPU0 idle keeps running, so no reset) to avoid a
   // mid-format reset that would corrupt the card.
   if (s_sd_format_pending && --s_sd_format_pending == 0) {
-    disableLoopWDT();
-    SPIClass* spi = tdeckSharedSPI();
     bool ok = false;
-    if (spi) {
-      // Explicit reformat (not SD.begin's format_if_empty, which only formats an
-      // already-unreadable card): init the card to register the FatFs diskio at
-      // pdrv (no mount), f_mkfs to FAT32, write the MESHCOMOD label by hand while
-      // unmounted, release, then remount the fresh FS via SD.begin. Works on any
-      // card (FAT32, exFAT, blank) since f_mkfs hardware-inits + overwrites it.
-      SD.end();                                          // drop any existing mount
-      uint8_t pdrv = sdcard_init(PIN_SD_CS, spi, 4000000);
-      if (pdrv != 0xFF) {
-        char drv[3] = { (char)('0' + pdrv), ':', 0 };
-        void* work = malloc(4096);                       // f_mkfs scratch (>= FF_MAX_SS)
-        if (work) {
-          if (f_mkfs(drv, MC_FM_FAT32, 0, work, 4096) == 0 /*FR_OK*/) {
-            sdWriteFatLabel(pdrv, "MESHCOMOD");
-            ok = true;
+    {
+      LoopWdtGuard loop_wdt_guard;
+      SPIClass* spi = tdeckSharedSPI();
+      if (spi) {
+        // Explicit reformat (not SD.begin's format_if_empty, which only formats an
+        // already-unreadable card): init the card to register the FatFs diskio at
+        // pdrv (no mount), f_mkfs to FAT32, write the MESHCOMOD label by hand while
+        // unmounted, release, then remount the fresh FS via SD.begin. Works on any
+        // card (FAT32, exFAT, blank) since f_mkfs hardware-inits + overwrites it.
+        SD.end();                                          // drop any existing mount
+        uint8_t pdrv = sdcard_init(PIN_SD_CS, spi, 4000000);
+        if (pdrv != 0xFF) {
+          char drv[3] = { (char)('0' + pdrv), ':', 0 };
+          void* work = malloc(4096);                       // f_mkfs scratch (>= FF_MAX_SS)
+          if (work) {
+            if (f_mkfs(drv, MC_FM_FAT32, 0, work, 4096) == 0 /*FR_OK*/) {
+              sdWriteFatLabel(pdrv, "MESHCOMOD");
+              ok = true;
+            }
+            free(work);
           }
-          free(work);
+          sdcard_uninit(pdrv);
         }
-        sdcard_uninit(pdrv);
+        if (ok) ok = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6);
       }
-      if (ok) ok = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6);
     }
-    enableLoopWDT();
     fmHideFormatOverlay();
     if (ok && SD.cardType() != CARD_NONE) {
       s_sd_mounted = true;
@@ -47476,9 +47486,11 @@ void UITask::loop() {
   }
   // Deferred copy/move (paste). WDT off — a big tree can take a while.
   if (s_fm_paste_pending && --s_fm_paste_pending == 0) {
-    disableLoopWDT();
-    bool ok = fmDoPaste();
-    enableLoopWDT();
+    bool ok = false;
+    {
+      LoopWdtGuard loop_wdt_guard;
+      ok = fmDoPaste();
+    }
     fmHideFormatOverlay();
     showAlert(ok ? TR("Pasted") : TR("Paste failed"), ok ? 1500 : 2400);
     if (s_fm_list) fmRefresh();


### PR DESCRIPTION
## Summary

- add an RAII guard that records whether `loopTask` is actually subscribed to the task watchdog
- disable the loop watchdog only when it was active, and restore only that prior state
- use the guard around long mount, migration, format, paste, shutdown, download-mode, and reboot persistence operations
- compile the real Arduino loop-task guard only when `CONFIG_AUTOSTART_ARDUINO` exists; standalone ESP-IDF `app_main` targets receive a no-op guard because they have no Arduino `loopTaskHandle`
- keep the no-op fallback nontrivial so scoped guard variables do not add unused-variable warnings to standalone IDF builds

## Why

The existing code paired Arduino's `disableLoopWDT()` and `enableLoopWDT()` around slow filesystem operations. That pair is not state-preserving: `enableLoopWDT()` subscribes `loopTask` even when the caller was not watched before the operation.

That can turn a successful storage action into a later, unrelated watchdog reset. It also made repeated SD recovery/reboot testing look like a bus or memory lockup because the watchdog state changed silently after the filesystem call returned.

`LoopWdtGuard` checks `esp_task_wdt_status(loopTaskHandle)` on entry. This must name Arduino's actual loop task because these guards may be constructed from a worker task; `nullptr` would query the caller instead. It only disables a real loop-task subscription and only re-enables one it actually removed. Arduino-ESP32 2.0.17's `disableLoopWDT()` returns `void`, so the prior state cannot be inferred from that call. Existing core-0 idle-WDT handling remains separate through `WdtHeavyGuard`.

## Data safety

This changes watchdog ownership only. No format, erase, migration, or destructive test was executed; the existing format implementation remains T-Deck-gated.

## Integration note

#206 now carries this same `LoopWdtGuard` helper and uses it at its two overlapping Pager SD recovery sites, so combining the branches cannot restore the unconditional `disableLoopWDT()` / `enableLoopWDT()` pair. This PR remains the broader rollout across the other long-running storage and reboot paths.

## Verification

- `git diff --check origin/main...HEAD`
- all raw `disableLoopWDT()` / `enableLoopWDT()` pairs in the affected storage UI paths were replaced by scoped guards
- `uvx --from platformio platformio run -e tlora_pager_sx1262_companion_radio_touch`
  - success
  - RAM: 101,192 / 327,680 bytes (30.9%)
  - flash: 3,421,029 / 4,063,232 bytes (84.2%)
- the same implementation was included in successful T-Deck and Heltec V4-R8 integration builds

The standalone T-Display-P4 wrapper could not be rebuilt in this checkout because its local ESP-IDF SDK/toolchain symlinks are absent. The compile-time guard was audited against that target's `app_main` configuration and removes all Arduino loop-task symbol references there.

Model: GPT-5.6 Sol | Harness: Codex in T3 Code
