### PR TITLE
Add PIN-selected kid profiles

### DIFF
--- a/src/DataStore.cpp
+++ b/src/DataStore.cpp
@@ -40,9 +40,47 @@ DataStore::DataStore(FILESYSTEM& fs, FILESYSTEM& fsExtra, mesh::RTCClock& clock)
 #endif
 
 const char* DataStore::_rp(const char* name) {
-  if (!_root[0]) return name;            // default: filesystem root, zero change
-  snprintf(_rpbuf, sizeof(_rpbuf), "%s%s", _root, name);
+  if (_active_profile == 0 && !_root[0]) return name; // legacy profile at filesystem root
+  snprintf(_rpbuf, sizeof(_rpbuf), "%s%s%s", _root,
+           _active_profile == 1 ? "/profile1" : "", name);
   return _rpbuf;
+}
+
+void DataStore::applyIdentityRoot() {
+#if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
+  const char* legacy = "";
+#else
+  const char* legacy = "/identity";
+#endif
+  if (_active_profile == 0) {
+    snprintf(_identity_root, sizeof(_identity_root), "%s%s", _root, legacy);
+  } else {
+    snprintf(_identity_root, sizeof(_identity_root), "%s/profile1/identity", _root);
+  }
+  identity_store.use(*_fs, _identity_root);
+}
+
+bool DataStore::selectProfile(uint8_t profile) {
+  if (profile > 1) return false;
+  _active_profile = profile;
+
+  if (profile == 1) {
+    char dir[48];
+    snprintf(dir, sizeof(dir), "%s/profile1", _root);
+    _fs->mkdir(dir);
+    char bl[56];
+    snprintf(bl, sizeof(bl), "%s/profile1/bl", _root);
+    _fs->mkdir(bl);
+    char id[56];
+    snprintf(id, sizeof(id), "%s/profile1/identity", _root);
+    _fs->mkdir(id);
+    if (_fsExtra) {
+      _fsExtra->mkdir("/profile1");
+      _fsExtra->mkdir("/profile1/bl");
+    }
+  }
+  applyIdentityRoot();
+  return true;
 }
 
 File DataStore::openWrite(FILESYSTEM* fs, const char* filename) {
@@ -64,6 +102,7 @@ File DataStore::openWrite(FILESYSTEM* fs, const char* filename) {
 #endif
 
 void DataStore::begin() {
+  applyIdentityRoot();
 #if defined(RP2040_PLATFORM)
   identity_store.begin();
 #endif
@@ -212,7 +251,7 @@ bool DataStore::removeFile(const char* filename) {
 }
 
 bool DataStore::removeFile(FILESYSTEM* fs, const char* filename) {
-  return fs->remove(filename);
+  return fs->remove(_rp(filename));
 }
 
 bool DataStore::formatFileSystem() {
@@ -426,8 +465,13 @@ bool DataStore::savePrefs(const NodePrefs& _prefs, double node_lat, double node_
       _fs->remove(_rp("/new_prefs.tmp"));   // short write (storage full?) — keep the old main file
       return false;
     }
-    _fs->remove(_rp("/new_prefs"));
-    return _fs->rename(_rp("/new_prefs.tmp"), _rp("/new_prefs"));
+    char tmp_path[96], final_path[96];
+    strncpy(tmp_path, _rp("/new_prefs.tmp"), sizeof(tmp_path) - 1);
+    tmp_path[sizeof(tmp_path) - 1] = '\0';
+    strncpy(final_path, _rp("/new_prefs"), sizeof(final_path) - 1);
+    final_path[sizeof(final_path) - 1] = '\0';
+    _fs->remove(final_path);
+    return _fs->rename(tmp_path, final_path);
   }
   return false;
 }
@@ -440,10 +484,10 @@ void DataStore::loadContacts(DataStoreHost* host) {
   {
     FILESYSTEM* cfs = _getContactsChannelsFS();
     char live[80], tmp[80];
-    if (_root[0]) { snprintf(live, sizeof live, "%s/contacts3", _root);
-                    snprintf(tmp,  sizeof tmp,  "%s/contacts3.tmp", _root); }
-    else          { strncpy(live, "/contacts3", sizeof live);
-                    strncpy(tmp,  "/contacts3.tmp", sizeof tmp); }
+    strncpy(live, _rp("/contacts3"), sizeof(live) - 1);
+    live[sizeof(live) - 1] = '\0';
+    strncpy(tmp, _rp("/contacts3.tmp"), sizeof(tmp) - 1);
+    tmp[sizeof(tmp) - 1] = '\0';
     if (cfs->exists(tmp)) {
       if (!cfs->exists(live)) cfs->rename(tmp, live);   // interrupted swap -> recover the temp
       else                    cfs->remove(tmp);          // stale temp -> the live file wins
@@ -588,10 +632,10 @@ void DataStore::saveContacts(DataStoreHost* host, bool (*filter)(const ContactIn
   {
     FILESYSTEM* cfs = _getContactsChannelsFS();
     char live[80], tmp[80];
-    if (_root[0]) { snprintf(live, sizeof live, "%s/contacts3", _root);
-                    snprintf(tmp,  sizeof tmp,  "%s/contacts3.tmp", _root); }
-    else          { strncpy(live, "/contacts3", sizeof live);
-                    strncpy(tmp,  "/contacts3.tmp", sizeof tmp); }
+    strncpy(live, _rp("/contacts3"), sizeof(live) - 1);
+    live[sizeof(live) - 1] = '\0';
+    strncpy(tmp, _rp("/contacts3.tmp"), sizeof(tmp) - 1);
+    tmp[sizeof(tmp) - 1] = '\0';
     if (wrote_ok) {
       cfs->remove(live);          // FAT/SPIFFS rename won't overwrite an existing target
       cfs->rename(tmp, live);     // if this rename fails, loadContacts recovers the temp at next boot
@@ -934,6 +978,7 @@ bool DataStore::useSdStorage() {
   _fs = &SD;
   _fsExtra = nullptr;
   identity_store.use(SD, "/meshcomod/identity");
+  applyIdentityRoot();
   return true;
 }
 #endif
@@ -964,6 +1009,7 @@ bool DataStore::useSdMmcStorage() {
   _fs = &SD_MMC;
   _fsExtra = nullptr;
   identity_store.use(SD_MMC, "/meshcomod/identity");
+  applyIdentityRoot();
   return true;
 }
 #endif

--- a/src/DataStore.h
+++ b/src/DataStore.h
@@ -23,8 +23,11 @@ class DataStore {
   // that, when SPIFFS is unavailable (e.g. installed under Launcher) or the user
   // opts in, all data lives in one tidy folder on the SD card. ESP32 only.
   char _root[24] = "";
-  char _rpbuf[80];
+  char _rpbuf[96];
+  char _identity_root[48] = "";
+  uint8_t _active_profile = 0;
   const char* _rp(const char* name);   // returns _root-prefixed path (name as-is when _root empty)
+  void applyIdentityRoot();
 
   void loadPrefsInt(const char *filename, NodePrefs& prefs, double& node_lat, double& node_lon);
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
@@ -35,6 +38,11 @@ public:
   DataStore(FILESYSTEM& fs, mesh::RTCClock& clock);
   DataStore(FILESYSTEM& fs, FILESYSTEM& fsExtra, mesh::RTCClock& clock);
   void begin();
+  // Select one of the two local user profiles. Profile 0 deliberately keeps
+  // the historical paths so existing installs require no migration. Profile 1
+  // lives below /profile1 (or /meshcomod/profile1 on a rooted SD store).
+  bool selectProfile(uint8_t profile);
+  uint8_t activeProfile() const { return _active_profile; }
   bool formatFileSystem();
   File openWrite(FILESYSTEM* fs, const char* filename);   // root-aware (was a free static fn)
 #if defined(ESP32)

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -1394,6 +1394,10 @@ static inline bool isMsgFloodType(uint8_t t) {
 void MyMesh::logRxRaw(float snr, float rssi, const uint8_t raw[], int len) {
   const int8_t   snr_q4 = (int8_t)(snr * 4.0f);
   const uint32_t now_ms = millis();
+  // Keep only encrypted direct/group text packets in the shared profile
+  // overflow. Packet hashes exclude route paths, so repeater echoes collapse
+  // to one unique record before they consume the 2,000-record queue.
+  captureEncryptedMessage(raw, len, snr_q4, (int8_t)rssi);
   // Parse route + path length (hop count). Header byte layout is
   //   [version:2][payload_type:4][route_type:2]
   // with 4 transport-code bytes following iff route is a TRANSPORT_* one; the
@@ -1677,6 +1681,7 @@ bool MyMesh::uiImportBackup(Stream& in, uint8_t sections,
         idx++;
       }
       saveChannels();
+      if (nch > 0) requestEncryptedBacklogRescan();
     }
   }
   int nco = 0;
@@ -1754,6 +1759,9 @@ bool MyMesh::shouldOverwriteWhenFull() const {
 }
 
 void MyMesh::onContactOverwrite(const uint8_t* pub_key) {
+  // The replacement is installed later in the same BaseChatMesh receive pass.
+  // Defer the scan to MyMesh::loop so it observes the new public key.
+  requestEncryptedBacklogRescan();
     _store->deleteBlobByKey(pub_key, PUB_KEY_SIZE); // delete from storage
   if (_serial->isConnected()) {
     out_frame[0] = PUSH_CODE_CONTACT_DELETED;
@@ -1770,6 +1778,12 @@ void MyMesh::onContactsFull() {
 }
 
 void MyMesh::onDiscoveredContact(ContactInfo &contact, bool is_new, uint8_t path_len, const uint8_t* path) {
+  // BaseChatMesh reports is_new=false for both an existing contact refresh and
+  // a freshly auto-added contact. Count growth identifies the latter without
+  // rescanning 2,000 packets after every routine advert.
+  const int contact_count = getNumContacts();
+  if (contact_count > _backlog_known_contact_count) requestEncryptedBacklogRescan();
+  else _backlog_known_contact_count = contact_count;
   if (_serial->isConnected()) {
     if (is_new) {
       writeContactRespFrame(PUSH_CODE_NEW_ADVERT, contact, true);
@@ -1948,7 +1962,8 @@ void MyMesh::queueMessage(const ContactInfo &from, uint8_t txt_type, mesh::Packe
     // per-message); RSSI is the radio's last-RSSI, which is current since
     // the packet handler runs inline with reception.
     const int8_t snr_q4 = (int8_t)(pkt->getSNR() * 4);
-    const int8_t rssi   = (int8_t)(_radio->getLastRSSI());
+    const int8_t rssi   = _replaying_backlog ? _replay_rssi
+                                              : (int8_t)(_radio->getLastRSSI());
     const bool   is_flood = pkt->isRouteFlood();
     uiStashRxMeta(pkt);   // capture route + scope for the per-message Info popup
     _last_sender_ts = sender_timestamp;   // embedded send-time -> UI bubble ts (room history replay)
@@ -2059,6 +2074,7 @@ void MyMesh::sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pk
 
 void MyMesh::onMessageRecv(const ContactInfo &from, mesh::Packet *pkt, uint32_t sender_timestamp,
                            const char *text) {
+  markEncryptedMessageSeen(pkt);
   markConnectionActive(from); // in case this is from a server, and we have a connection
   queueMessage(from, TXT_TYPE_PLAIN, pkt, sender_timestamp, NULL, 0, text);
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
@@ -2074,6 +2090,7 @@ void MyMesh::onCommandDataRecv(const ContactInfo &from, mesh::Packet *pkt, uint3
 
 void MyMesh::onSignedMessageRecv(const ContactInfo &from, mesh::Packet *pkt, uint32_t sender_timestamp,
                                  const uint8_t *sender_prefix, const char *text) {
+  markEncryptedMessageSeen(pkt);
   markConnectionActive(from);
   // from.sync_since change needs to be persisted
   dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
@@ -2085,6 +2102,7 @@ void MyMesh::onSignedMessageRecv(const ContactInfo &from, mesh::Packet *pkt, uin
 
 void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packet *pkt, uint32_t timestamp,
                                   const char *text) {
+  markEncryptedMessageSeen(pkt);
   // Clock bootstrap from a channel peer's send-time (same sane-window + unset-only guard
   // as queueMessage above) so a Wi-Fi/GPS-off node can still get time off public channels.
   if (timestamp > 1700000000UL && timestamp < 2000000000UL &&
@@ -2126,7 +2144,7 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
     _serial->writeFrameToAll(frame, 1);
   }
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
-  {
+  if (!_replaying_backlog) {
     const char* _ch_name = "";
     ChannelDetails _cd{};
     if (getChannel(channel_idx, _cd)) _ch_name = _cd.name;
@@ -2149,7 +2167,8 @@ void MyMesh::onChannelMessageRecv(const mesh::GroupChannel &channel, mesh::Packe
   if (_ui) _ui->notify(UIEventType::channelMessage);
   if (_ui) {
     const int8_t snr_q4 = (int8_t)(pkt->getSNR() * 4);
-    const int8_t rssi   = (int8_t)(_radio->getLastRSSI());
+    const int8_t rssi   = _replaying_backlog ? _replay_rssi
+                                              : (int8_t)(_radio->getLastRSSI());
     const bool   is_flood = pkt->isRouteFlood();
     uiStashRxMeta(pkt);   // capture route + scope for the per-message Info popup
     _ui->newMsgFromPubWithMeta(path_len, is_flood, nullptr, channel_name,
@@ -2617,6 +2636,390 @@ MyMesh::MyMesh(mesh::Radio &radio, mesh::RNG &rng, mesh::RTCClock &rtc, SimpleMe
 #endif
 }
 
+void MyMesh::captureEncryptedMessage(const uint8_t raw[], int len,
+                                     int8_t snr_q4, int8_t rssi) {
+  if (!_profile_mode_enabled || !_rx_backlog || !raw || len <= 0 || len > MAX_TRANS_UNIT) return;
+  mesh::Packet packet;
+  if (!tryParsePacket(&packet, raw, len)) return;
+  const uint8_t type = packet.getPayloadType();
+  if (type != PAYLOAD_TYPE_TXT_MSG && type != PAYLOAD_TYPE_GRP_TXT) return;
+
+  uint8_t fingerprint[MAX_HASH_SIZE];
+  packet.calculatePacketHash(fingerprint);
+  for (uint16_t i = 0; i < _rx_backlog_count; ++i) {
+    const uint16_t idx = (uint16_t)((_rx_backlog_head + i) % RX_BACKLOG_MAX);
+    if (memcmp(_rx_backlog[idx].fingerprint, fingerprint, sizeof(fingerprint)) == 0) {
+      ++_rx_backlog_dups;
+      return;
+    }
+  }
+
+  uint16_t idx;
+  if (_rx_backlog_count < RX_BACKLOG_MAX) {
+    idx = (uint16_t)((_rx_backlog_head + _rx_backlog_count) % RX_BACKLOG_MAX);
+    ++_rx_backlog_count;
+  } else {
+    idx = _rx_backlog_head;
+    _rx_backlog_head = (uint16_t)((_rx_backlog_head + 1) % RX_BACKLOG_MAX);
+  }
+  EncryptedRxRecord& rec = _rx_backlog[idx];
+  memset(&rec, 0, sizeof(rec));
+  rec.raw_len = (uint8_t)len;
+  rec.snr_q4 = snr_q4;
+  rec.rssi = rssi;
+  memcpy(rec.fingerprint, fingerprint, sizeof(rec.fingerprint));
+  memcpy(rec.raw, raw, (size_t)len);
+
+  // The dispatcher logs an echoed copy of our own flood before its seen-table
+  // drops it. Do not replay that echo back into the sending profile as a new
+  // incoming bubble; the other profile may still decrypt a shared-channel post.
+  const uint32_t sent_fp = fnv1a32(packet.payload, packet.payload_len);
+  for (int i = 0; i < UI_ECHO_SLOTS; ++i) {
+    if (_echo_fp[i] == sent_fp) {
+      rec.processed_mask |= (uint8_t)(1u << _active_profile);
+      break;
+    }
+  }
+}
+
+void MyMesh::markEncryptedMessageSeen(const mesh::Packet* packet) {
+  if (!_rx_backlog || !packet) return;
+  const uint8_t type = packet->getPayloadType();
+  if (type != PAYLOAD_TYPE_TXT_MSG && type != PAYLOAD_TYPE_GRP_TXT) return;
+  uint8_t fingerprint[MAX_HASH_SIZE];
+  packet->calculatePacketHash(fingerprint);
+  const uint8_t bit = (uint8_t)(1u << _active_profile);
+  for (uint16_t i = 0; i < _rx_backlog_count; ++i) {
+    const uint16_t idx = (uint16_t)((_rx_backlog_head + i) % RX_BACKLOG_MAX);
+    if (memcmp(_rx_backlog[idx].fingerprint, fingerprint, sizeof(fingerprint)) == 0) {
+      _rx_backlog[idx].processed_mask |= bit;
+      return;
+    }
+  }
+}
+
+bool MyMesh::findDecryptingContact(const mesh::Packet& packet, ContactInfo& contact,
+                                   uint8_t secret[PUB_KEY_SIZE],
+                                   uint8_t data[MAX_PACKET_PAYLOAD + 1], int& data_len) {
+  data_len = 0;
+  if (packet.getPayloadType() != PAYLOAD_TYPE_TXT_MSG ||
+      packet.payload_len <= 2 + CIPHER_MAC_SIZE) return false;
+  if (!self_id.isHashMatch(&packet.payload[0])) return false;
+  const uint8_t src_hash = packet.payload[1];
+  for (int i = 0; i < getNumContacts(); ++i) {
+    ContactInfo candidate{};
+    if (!getContactByIdx((uint32_t)i, candidate) ||
+        !candidate.id.isHashMatch(&src_hash)) continue;
+    // getContactByIdx returns a copy. Populate the live contact's cached ECDH
+    // secret on its first match so replaying a large backlog does not repeat an
+    // expensive key agreement for every packet from the same sender.
+    const uint8_t* shared = nullptr;
+    if (candidate.shared_secret_valid) {
+      shared = candidate.getSharedSecret(self_id);
+    } else {
+      ContactInfo* live = lookupContactByPubKey(candidate.id.pub_key, PUB_KEY_SIZE);
+      if (!live) continue;
+      shared = live->getSharedSecret(self_id);
+      candidate = *live;
+    }
+    memcpy(secret, shared, PUB_KEY_SIZE);
+    const int n = mesh::Utils::MACThenDecrypt(secret, data, &packet.payload[2],
+                                               packet.payload_len - 2);
+    if (n > 0 && n <= MAX_PACKET_PAYLOAD) {
+      data[n] = 0;
+      data_len = n;
+      contact = candidate;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MyMesh::decryptBacklogRecord(uint16_t idx, bool queue_ack) {
+  if (!_rx_backlog || idx >= RX_BACKLOG_MAX) return false;
+  EncryptedRxRecord& rec = _rx_backlog[idx];
+  const uint8_t bit = (uint8_t)(1u << _active_profile);
+  if (!rec.raw_len || (rec.processed_mask & bit)) return false;
+
+  mesh::Packet packet;
+  if (!tryParsePacket(&packet, rec.raw, rec.raw_len)) return false;
+  packet._snr = rec.snr_q4;
+  _replay_rssi = rec.rssi;
+  const uint8_t type = packet.getPayloadType();
+
+  if (type == PAYLOAD_TYPE_TXT_MSG) {
+    ContactInfo from{};
+    uint8_t secret[PUB_KEY_SIZE];
+    uint8_t data[MAX_PACKET_PAYLOAD + 1];
+    int data_len = 0;
+    if (!findDecryptingContact(packet, from, secret, data, data_len) || data_len <= 5) return false;
+
+    uint32_t timestamp = 0;
+    memcpy(&timestamp, data, sizeof(timestamp));
+    const uint8_t txt_type = data[4] >> 2;
+    if (txt_type == TXT_TYPE_PLAIN) {
+      const char* text = (const char*)&data[5];
+      const size_t text_len = strnlen(text, (size_t)data_len - 5);
+      if (text_len >= (size_t)data_len - 5) return false;
+      queueMessage(from, TXT_TYPE_PLAIN, &packet, timestamp, nullptr, 0, text);
+      if (queue_ack) {
+        mesh::Utils::sha256(rec.ack, 4, data, 5 + text_len, from.id.pub_key, PUB_KEY_SIZE);
+        rec.ack[4] = (5 + text_len + 1 <= (size_t)data_len) ? data[5 + text_len + 1] : 0;
+        getRNG()->random(&rec.ack[5], 1);
+        rec.ack_len = 6;
+        rec.ack_pending_mask |= bit;
+      }
+    } else if (txt_type == TXT_TYPE_SIGNED_PLAIN && data_len > 9) {
+      const char* text = (const char*)&data[9];
+      const size_t text_len = strnlen(text, (size_t)data_len - 9);
+      if (text_len >= (size_t)data_len - 9) return false;
+      queueMessage(from, TXT_TYPE_SIGNED_PLAIN, &packet, timestamp, &data[5], 4, text);
+      if (queue_ack) {
+        mesh::Utils::sha256(rec.ack, 4, data, 9 + text_len, self_id.pub_key, PUB_KEY_SIZE);
+        rec.ack_len = 4;
+        rec.ack_pending_mask |= bit;
+      }
+    } else {
+      return false;
+    }
+    rec.processed_mask |= bit;
+    return true;
+  }
+
+  if (type == PAYLOAD_TYPE_GRP_TXT && packet.payload_len > 1 + CIPHER_MAC_SIZE) {
+    for (int i = 0; i < MAX_GROUP_CHANNELS; ++i) {
+      ChannelDetails cd{};
+      if (!getChannel(i, cd) || cd.name[0] == '\0' ||
+          cd.channel.hash[0] != packet.payload[0]) continue;
+      uint8_t data[MAX_PACKET_PAYLOAD + 1];
+      const int n = mesh::Utils::MACThenDecrypt(cd.channel.secret, data, &packet.payload[1],
+                                                packet.payload_len - 1);
+      if (n <= 5 || n > MAX_PACKET_PAYLOAD) continue;
+      data[n] = 0;
+      if ((data[4] >> 2) != 0) continue;
+      const char* text = (const char*)&data[5];
+      if (strnlen(text, (size_t)n - 5) >= (size_t)n - 5) continue;
+      uint32_t timestamp = 0;
+      memcpy(&timestamp, data, sizeof(timestamp));
+      onChannelMessageRecv(cd.channel, &packet, timestamp, text);
+      rec.processed_mask |= bit;
+      return true;
+    }
+  }
+  return false;
+}
+
+int MyMesh::replayEncryptedBacklog() {
+  _profile_backlog_unlocked = true;
+  _backlog_rescan_pending = false;
+  if (!_rx_backlog) return 0;
+  int decoded = 0;
+  _replaying_backlog = true;
+  for (uint16_t i = 0; i < _rx_backlog_count; ++i) {
+    const uint16_t idx = (uint16_t)((_rx_backlog_head + i) % RX_BACKLOG_MAX);
+    if (decryptBacklogRecord(idx, true)) ++decoded;
+    if ((i & 31u) == 31u) delay(0);  // feed the ESP scheduler during a full 2,000-record unlock
+  }
+  _replaying_backlog = false;
+  if (_next_replay_ack_ms == 0) {
+    const uint8_t bit = (uint8_t)(1u << _active_profile);
+    for (uint16_t i = 0; i < _rx_backlog_count; ++i) {
+      const uint16_t idx = (uint16_t)((_rx_backlog_head + i) % RX_BACKLOG_MAX);
+      if (_rx_backlog[idx].ack_pending_mask & bit) {
+        _next_replay_ack_ms = millis();
+        break;
+      }
+    }
+  }
+  return decoded;
+}
+
+void MyMesh::requestEncryptedBacklogRescan() {
+  _backlog_known_contact_count = getNumContacts();
+  if (_profile_mode_enabled && _rx_backlog) _backlog_rescan_pending = true;
+}
+
+void MyMesh::serviceEncryptedBacklogRescan() {
+  if (!_backlog_rescan_pending || !_profile_backlog_unlocked ||
+      !_profile_mode_enabled || !_rx_backlog || _replaying_backlog) return;
+  replayEncryptedBacklog();
+}
+
+void MyMesh::serviceReplayAck() {
+  if (!_rx_backlog || _next_replay_ack_ms == 0 ||
+      (int32_t)(millis() - _next_replay_ack_ms) < 0) return;
+  const uint8_t bit = (uint8_t)(1u << _active_profile);
+  for (uint16_t i = 0; i < _rx_backlog_count; ++i) {
+    const uint16_t idx = (uint16_t)((_rx_backlog_head + i) % RX_BACKLOG_MAX);
+    EncryptedRxRecord& rec = _rx_backlog[idx];
+    if (!(rec.ack_pending_mask & bit) || (rec.ack_len != 4 && rec.ack_len != 6)) continue;
+    mesh::Packet packet;
+    if (!tryParsePacket(&packet, rec.raw, rec.raw_len)) {
+      rec.ack_pending_mask &= (uint8_t)~bit;
+      continue;
+    }
+    ContactInfo from{};
+    uint8_t secret[PUB_KEY_SIZE], data[MAX_PACKET_PAYLOAD + 1];
+    int data_len = 0;
+    if (!findDecryptingContact(packet, from, secret, data, data_len)) continue;
+
+    mesh::Packet* ack = nullptr;
+    if (packet.isRouteFlood()) {
+      ack = createPathReturn(from.id, secret, packet.path, packet.path_len,
+                             PAYLOAD_TYPE_ACK, rec.ack, rec.ack_len);
+      if (ack) sendFloodScoped(from, ack, 200);
+    } else {
+      ack = createAck(rec.ack, rec.ack_len);
+      if (ack) {
+        if (from.out_path_len == OUT_PATH_UNKNOWN) sendFloodScoped(from, ack, 200);
+        else sendDirect(ack, from.out_path, from.out_path_len, 200);
+      }
+    }
+    if (!ack) {
+      _next_replay_ack_ms = millis() + 1000;
+      return;
+    }
+    rec.ack_pending_mask &= (uint8_t)~bit;
+    _next_replay_ack_ms = millis() + 10000UL;
+    return;
+  }
+  _next_replay_ack_ms = 0;
+}
+
+void MyMesh::resetProfileRuntime() {
+  clearPendingReqs();
+  _ui_pending_status = 0;
+  _ui_pending_kind = UiReqKind::None;
+  _ui_pending_tag = 0;
+  cancelUIDeferredLogin();
+  memset(expected_ack_table, 0, sizeof(expected_ack_table));
+  next_ack_idx = 0;
+  offline_queue_len = 0;
+  history_count = 0;
+  history_head = 0;
+  history_next_seq = 0;
+  history_num_clients = 0;
+  _iter_started = false;
+  dirty_contacts_expiry = 0;
+  memset(_echo_fp, 0, sizeof(_echo_fp));
+  memset(_echo_rep, 0, sizeof(_echo_rep));
+  memset(_echo_hop, 0, sizeof(_echo_hop));
+  memset(_echo_hop_sz, 0, sizeof(_echo_hop_sz));
+  memset(_echo_hop_n, 0, sizeof(_echo_hop_n));
+  _echo_idx = 0;
+  _last_sent_fp = 0;
+  _last_rx_path_n = 0;
+  _last_rx_scope = 0;
+  _last_rx_has_scope = false;
+  _last_sender_ts = 0;
+  _echo_dirty = false;
+  _profile_backlog_unlocked = false;
+  _backlog_rescan_pending = false;
+  memset(advert_paths, 0, sizeof(advert_paths));
+  memset(_blob_seen, 0, sizeof(_blob_seen));
+  if (sign_data) { free(sign_data); sign_data = nullptr; sign_data_len = 0; }
+}
+
+bool MyMesh::selectLocalProfile(uint8_t profile) {
+  if (profile > 1) return false;
+  if (profile == _active_profile) return true;
+
+  const uint8_t old_profile = _active_profile;
+  const mesh::LocalIdentity old_identity = self_id;
+  NodePrefs inherited = _prefs;
+  const double inherited_lat = sensors.node_lat;
+  const double inherited_lon = sensors.node_lon;
+  auto rollback = [&]() {
+    _store->selectProfile(old_profile);
+    self_id = old_identity;
+    _prefs = inherited;
+    sensors.node_lat = inherited_lat;
+    sensors.node_lon = inherited_lon;
+  };
+  if (!savePrefs()) return false;
+  saveContacts();
+  saveChannels();
+
+  if (!_store->selectProfile(profile)) return false;
+  mesh::LocalIdentity identity;
+  const bool fresh = !_store->loadMainIdentity(identity);
+  if (fresh) {
+    identity = radio_new_identity();
+    int tries = 0;
+    while (tries++ < 10 && (identity.pub_key[0] == 0x00 || identity.pub_key[0] == 0xFF))
+      identity = radio_new_identity();
+    if (!_store->saveMainIdentity(identity)) {
+      rollback();
+      return false;
+    }
+
+    _prefs = inherited;
+    char key_hex[10];
+    mesh::Utils::toHex(key_hex, identity.pub_key, 4);
+    snprintf(_prefs.node_name, sizeof(_prefs.node_name), "Kid-%s", key_hex);
+    sensors.node_lat = inherited_lat;
+    sensors.node_lon = inherited_lon;
+    if (!_store->savePrefs(_prefs, sensors.node_lat, sensors.node_lon)) {
+      rollback();
+      return false;
+    }
+    // Seed the second profile with the current contacts/channels so it can
+    // decrypt immediately; later edits are isolated by the selected store.
+    saveContacts();
+    saveChannels();
+  }
+
+  for (int i = 0; i < getNumContacts(); ++i) {
+    ContactInfo c{};
+    if (getContactByIdx((uint32_t)i, c)) stopConnection(c.id.pub_key);
+  }
+
+  self_id = identity;
+  _prefs = inherited;
+  sensors.node_lat = inherited_lat;
+  sensors.node_lon = inherited_lon;
+  _store->loadPrefs(_prefs, sensors.node_lat, sensors.node_lon);
+
+  resetContacts();
+  for (int i = 0; i < MAX_GROUP_CHANNELS; ++i) {
+    ChannelDetails empty{};
+    setChannel(i, empty);
+  }
+  _store->loadContacts(this);
+  _store->loadChannels(this);
+  _backlog_known_contact_count = getNumContacts();
+  _active_profile = profile;
+  resetProfileRuntime();
+  applyRadioFromPrefs();
+#ifdef BLE_PIN_CODE
+  _active_ble_pin = _prefs.ble_pin ? _prefs.ble_pin : BLE_PIN_CODE;
+#endif
+  return true;
+}
+
+bool MyMesh::setProfileModeEnabled(bool enabled) {
+  if (enabled && !_rx_backlog) {
+    _rx_backlog = (EncryptedRxRecord*)msPsAlloc(sizeof(EncryptedRxRecord) * RX_BACKLOG_MAX);
+    if (!_rx_backlog) return false;
+    _backlog_known_contact_count = getNumContacts();
+    _backlog_rescan_pending = false;
+    _profile_backlog_unlocked = false;
+  }
+  if (!enabled && _rx_backlog) {
+    memset(_rx_backlog, 0, sizeof(EncryptedRxRecord) * RX_BACKLOG_MAX);
+    heap_caps_free(_rx_backlog);
+    _rx_backlog = nullptr;
+    _rx_backlog_head = 0;
+    _rx_backlog_count = 0;
+    _rx_backlog_dups = 0;
+    _next_replay_ack_ms = 0;
+    _backlog_rescan_pending = false;
+    _profile_backlog_unlocked = false;
+  }
+  _profile_mode_enabled = enabled;
+  return true;
+}
+
 void MyMesh::applyRadioFromPrefs() {
   // setParams is a multi-step SPI sequence; hold the radio against the buffered-
   // receive drain task so it can't re-arm RX between the steps (no-op when off).
@@ -2757,6 +3160,7 @@ void MyMesh::begin(bool has_display) {
 
   resetContacts();
   _store->loadContacts(this);
+  _backlog_known_contact_count = getNumContacts();
   bootstrapRTCfromContacts();
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
@@ -3233,6 +3637,7 @@ void MyMesh::handleCmdFrame(size_t len) {
       contact.lastmod = last_mod;
       contact.sync_since = 0;
       if (addContact(contact)) {
+        requestEncryptedBacklogRescan();
         dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
 #ifdef DISPLAY_CLASS
         // Tell the touch UI to refresh its thread list immediately so the new
@@ -3248,6 +3653,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     uint8_t *pub_key = &cmd_frame[1];
     ContactInfo *recipient = lookupContactByPubKey(pub_key, PUB_KEY_SIZE);
     if (recipient && removeContact(*recipient)) {
+      requestEncryptedBacklogRescan();  // keep contact-count detection in sync
       _store->deleteBlobByKey(pub_key, PUB_KEY_SIZE);
       dirty_contacts_expiry = futureMillis(LAZY_CONTACTS_WRITE_DELAY);
 #ifdef DISPLAY_CLASS
@@ -3622,7 +4028,10 @@ void MyMesh::handleCmdFrame(size_t len) {
       anon.out_path_len = 0;   // default to zero-hop direct
       anon.type = ADV_TYPE_NONE;  // unknown
 
-      if (addContact(anon)) recipient = &anon;
+      if (addContact(anon)) {
+        requestEncryptedBacklogRescan();
+        recipient = &anon;
+      }
     }
     uint8_t *data = &cmd_frame[1 + PUB_KEY_SIZE];
     if (recipient) {
@@ -3783,6 +4192,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     memset(channel.channel.secret, 0, sizeof(channel.channel.secret));
     memcpy(channel.channel.secret, &cmd_frame[2 + 32], 16); // NOTE: only 128-bit supported
     if (setChannel(channel_idx, channel)) {
+      requestEncryptedBacklogRescan();
       saveChannels();
 #ifdef DISPLAY_CLASS
       /* Tell the touch UI to refresh its thread list immediately so the new
@@ -4496,6 +4906,8 @@ void MyMesh::checkSerialInterface() {
 
 void MyMesh::loop() {
   BaseChatMesh::loop();
+  serviceEncryptedBacklogRescan();
+  serviceReplayAck();
 
   // Session keep-alives for logged-in servers (rooms). The core pinger sends the
   // 9-byte REQ_TYPE_KEEP_ALIVE (+ our sync_since) a room server expects; the ACK

--- a/src/MyMesh.h
+++ b/src/MyMesh.h
@@ -153,6 +153,7 @@ public:
     self_id = identity;
     resetContacts();
     _store->loadContacts(this);
+    requestEncryptedBacklogRescan();
     return true;
   }
   /** Add/merge a contact from a settings backup (name + pubkey + flags + GPS).
@@ -167,7 +168,9 @@ public:
     c.last_advert_timestamp = last_advert; c.lastmod = lastmod;
     c.out_path_len = OUT_PATH_UNKNOWN;
     strncpy(c.name, name ? name : "", sizeof(c.name) - 1);
-    return addContact(c);
+    if (!addContact(c)) return false;
+    requestEncryptedBacklogRescan();
+    return true;
   }
   // Channel count by iterating slots — `num_channels` is private in the base.
   // A channel slot is in-use when its name is non-empty (matches the lookup
@@ -791,6 +794,25 @@ private:
 public:
   bool savePrefs() { return _store->savePrefs(_prefs, sensors.node_lat, sensors.node_lon); }
 
+  // Switch the live mesh identity/contact/channel store without rebooting.
+  // Profile 0 uses all legacy paths; profile 1 is isolated below /profile1.
+  bool selectLocalProfile(uint8_t profile);
+  uint8_t activeLocalProfile() const { return _active_profile; }
+  bool setProfileModeEnabled(bool enabled);
+  bool profileModeEnabled() const { return _profile_mode_enabled; }
+
+  // Decrypt every shared encrypted backlog record not yet consumed by the
+  // active profile. This is called only after its PIN has unlocked that profile.
+  int replayEncryptedBacklog();
+  bool replayingEncryptedBacklog() const { return _replaying_backlog; }
+  int encryptedBacklogCount() const { return _rx_backlog_count; }
+  uint32_t encryptedBacklogDuplicates() const { return _rx_backlog_dups; }
+  // Key material can arrive after a packet (manual contact add, advert scan,
+  // channel import). Queue a safe pass from MyMesh::loop; it runs immediately
+  // only while the active profile has already passed its PIN gate.
+  void requestEncryptedBacklogRescan();
+  void lockEncryptedBacklog() { _profile_backlog_unlocked = false; }
+
   // Set the default flood scope (region) used to tag outgoing flood packets, so
   // repeaters on region-scoped networks ("flood only for their region") will
   // re-broadcast them. A public "#hashtag" region's scope key is SHA256("#name");
@@ -837,6 +859,7 @@ public:
     memset(channel.channel.secret, 0, sizeof(channel.channel.secret));
     memcpy(channel.channel.secret, secret16, 16);
     if (!setChannel(idx, channel)) return false;
+    requestEncryptedBacklogRescan();
     saveChannels();
     if (_ui) _ui->onThreadsChanged();
     return true;
@@ -884,6 +907,7 @@ public:
     ci.lastmod      = getRTCClock()->getCurrentTime();
     StrHelper::strncpy(ci.name, name, sizeof(ci.name));
     if (!addContact(ci)) return false;
+    requestEncryptedBacklogRescan();
     saveContacts();
     if (_ui) _ui->onThreadsChanged();
     return true;
@@ -905,6 +929,7 @@ public:
     ci.lastmod      = getRTCClock()->getCurrentTime();
     StrHelper::strncpy(ci.name, name, sizeof(ci.name));
     if (!addContact(ci)) return false;
+    requestEncryptedBacklogRescan();
     saveContacts();
     if (_ui) _ui->onThreadsChanged();
     return true;
@@ -927,6 +952,7 @@ public:
   bool uiRemoveContact(const ContactInfo& c) {
     ContactInfo* slot = lookupContactByPubKey(c.id.pub_key, PUB_KEY_SIZE);
     if (!slot || !removeContact(*slot)) return false;
+    requestEncryptedBacklogRescan();  // also keeps auto-add count tracking in sync
     _store->deleteBlobByKey(c.id.pub_key, PUB_KEY_SIZE);
     saveContacts();
     if (_ui) _ui->onThreadsChanged();
@@ -962,6 +988,7 @@ public:
     }
 #endif
     if (addChannel("Public", "izOH6cXN6mrJ5e26oRXNcg==") == nullptr) return false;
+    requestEncryptedBacklogRescan();
     saveChannels();
     if (_ui) _ui->onThreadsChanged();
     return true;
@@ -1035,6 +1062,15 @@ private:
   void checkCLIRescueCmd();
   void checkSerialInterface();
   bool isValidClientRepeatFreq(uint32_t f) const;
+  void captureEncryptedMessage(const uint8_t raw[], int len, int8_t snr_q4, int8_t rssi);
+  void markEncryptedMessageSeen(const mesh::Packet* packet);
+  bool decryptBacklogRecord(uint16_t idx, bool queue_ack);
+  bool findDecryptingContact(const mesh::Packet& packet, ContactInfo& contact,
+                             uint8_t secret[PUB_KEY_SIZE], uint8_t data[MAX_PACKET_PAYLOAD + 1],
+                             int& data_len);
+  void serviceReplayAck();
+  void serviceEncryptedBacklogRescan();
+  void resetProfileRuntime();
 
   // helpers, short-cuts
   void saveChannels() { _store->saveChannels(this); }
@@ -1099,6 +1135,36 @@ private:
   // putBlobByKey. Sized above a full contact list so the common case never thrashes.
   static const uint16_t kBlobSeenSlots = 512;   // power of two (mask), 2 KB total
   uint32_t _blob_seen[kBlobSeenSlots] = {0};
+
+  // The normal decrypted UI ring is 500 records; profile mode expands it to
+  // 2,000 and uses this shared queue to retain the encrypted TXT/GRP_TXT packet
+  // for either profile. Fingerprint dedupe guarantees that overflow records
+  // 501-2,000 are unique. Full packets live only in RAM and are not exposed as
+  // plaintext until a profile PIN unlocks the corresponding keys.
+  static const uint16_t RX_BACKLOG_MAX = 2000;
+  struct EncryptedRxRecord {
+    uint8_t  raw_len;
+    int8_t   snr_q4;
+    int8_t   rssi;
+    uint8_t  processed_mask;
+    uint8_t  ack_pending_mask;
+    uint8_t  ack_len;
+    uint8_t  ack[6];
+    uint8_t  fingerprint[MAX_HASH_SIZE];
+    uint8_t  raw[MAX_TRANS_UNIT];
+  };
+  EncryptedRxRecord* _rx_backlog = nullptr;
+  uint16_t _rx_backlog_head = 0;
+  uint16_t _rx_backlog_count = 0;
+  uint32_t _rx_backlog_dups = 0;
+  uint32_t _next_replay_ack_ms = 0;
+  uint8_t  _active_profile = 0;
+  bool     _profile_mode_enabled = false;
+  bool     _replaying_backlog = false;
+  int8_t   _replay_rssi = 0;
+  volatile bool _backlog_rescan_pending = false;
+  bool     _profile_backlog_unlocked = false;
+  int      _backlog_known_contact_count = 0;
 
   TransportKey send_scope;
   TransportKey _chan_scope_saved;             // push/popChannelScope stash

--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -8,6 +8,8 @@
 
 #include <Preferences.h>
 #include <SPIFFS.h>
+#include <SHA256.h>
+#include <esp_system.h>
 #include <stddef.h>   // offsetof
 #include <string.h>   // memcpy
 
@@ -36,7 +38,7 @@ static bool s_begun = false;
 // short read (→ treat as absent → defaults); `ver` lets later builds add fields.
 static const char* KEY_CFG = "cfg";
 static const uint16_t TOUCH_CFG_MAGIC = 0x5743;   // 'WC' (WadaCfg)
-static const uint8_t  TOUCH_CFG_VER   = 43;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab; v20 map_show_links; v21 map_style (0=OSM default, 1=OpenTopoMap); v22 tb_nav; v23 scope_direct (opt-in: scope direct/login floods to the region); v24 tb_nav default OFF (experimental); v25 fem_lna (Heltec V4.3 high-gain FEM LNA, opt-in); v26 msg_flash (flash keyboard backlight + wake screen on a new message, opt-in); v27 flood_adv_hrs + local_adv_min (periodic self-advert intervals, the standard MeshCore flood/local advert on a timer); v28 beta_updates (opt-in to test/beta firmware on the OTA update check + install); v29 ui_scale default -> Large/150% (Tanmatsu; bumps the old 100% default, leaves an explicit Large/Huge choice); v30 boot_advert (opt-in one-shot flood self-advert ~6s after boot, all boards, #76); v31 compact_chat (opt-in IRC-style dense chat rows instead of bubbles); v32 clock_floor (highest epoch handed out — monotonic send-timestamp floor across reboots, #89); v33 rx_queue (buffered LoRa receive: drain task + packet ring, experimental, default OFF); v34 web_mirror (web control panel: mirror the live UI to a phone browser + inject taps, opt-in, default OFF); v35 remote_mode (render the UI off-screen at a web resolution instead of the panel; boot mode, default OFF); v36 remote_landscape (remote mode orientation: landscape 800x480 vs portrait 480x800); v37 remote_landscape now defaults ON (remote mode = landscape/desktop by default; one-time flip of existing installs, portrait stays a toggle); v38 web_terminal (web mesh CLI terminal served on the device IP; runtime toggle, mutually exclusive with VNC, default OFF); v40 hist_sync_after (chat-history flush: consecutive off-thread write failures before the blocking loop-task fallback, 0 = never); v41 p4_antenna (T-Display P4 antenna select; now RESERVED/unused - the choice is session-only so every boot comes up on the on-board antenna); v42 hist_per_chat (max stored messages PER chat, default 250 - a busy public channel used to be able to fill the whole shared ring and drag the UI down); v43 Pager UI-size presets (reset the previously ignored large-screen default to Small once)
+static const uint8_t  TOUCH_CFG_VER   = 44;  // v44: two profiles and salted lock PIN verifiers
 
 // Defaults (kept identical to the historical per-key defaults).
 static const uint16_t DEFAULT_SCREEN_TIMEOUT_S = 20;
@@ -112,6 +114,9 @@ struct __attribute__((packed)) TouchCfg {
   uint8_t  hist_sync_after;   // chat-history flush: consecutive off-thread write failures before falling back to the blocking loop-task write; 0 = never — v40 (trailing)
   uint16_t hist_per_chat;     // max stored messages per chat/thread; 0 = no per-chat cap (ring only) - v42 (trailing)
   uint8_t  p4_antenna;        // RESERVED (was: T-Display P4 antenna select). The antenna choice is session-only by design and is never stored — see the note further down — v41 (trailing)
+  uint8_t  kid_mode;          // two PIN-selected local profiles enabled
+  uint8_t  profile_pin_salt[2][8];
+  uint8_t  profile_pin_hash[2][16];
 };
 
 static TouchCfg s_cfg;
@@ -215,6 +220,9 @@ static void cfgSetDefaults(TouchCfg& c) {
   c.web_terminal       = 0;     // OFF: web mesh terminal is opt-in (runtime; mutually exclusive with VNC)
   c.map_tile_debug     = 0;     // OFF: map tile-pipeline diagnostic overlay is opt-in (developer)
   c.hist_sync_after    = 2;     // chat flush: 2 failed background writes -> synchronous loop-task fallback
+  c.kid_mode           = 0;
+  memset(c.profile_pin_salt, 0, sizeof(c.profile_pin_salt));
+  memset(c.profile_pin_hash, 0, sizeof(c.profile_pin_hash));
 }
 
 // Update the whole blob using the same end()/begin(RW)/put/end()/begin(RO)
@@ -292,6 +300,11 @@ static void cfgLoadOrMigrate() {
         // it. Reset it once so upgrading cannot enlarge the UI without consent.
         if (s_cfg.ver < 43) s_cfg.ui_scale = 0;
 #endif
+        if (s_cfg.ver < 44) {
+          s_cfg.kid_mode = 0;
+          memset(s_cfg.profile_pin_salt, 0, sizeof(s_cfg.profile_pin_salt));
+          memset(s_cfg.profile_pin_hash, 0, sizeof(s_cfg.profile_pin_hash));
+        }
         s_cfg.ver = TOUCH_CFG_VER;
         s_cfg.magic = TOUCH_CFG_MAGIC;
         cfgFlush();                // rewrite with new fields defaulted-in
@@ -1138,6 +1151,86 @@ bool touchPrefsSetRxQueue(bool on) {
   if (!s_begun) touchPrefsBegin();
   s_cfg.rx_queue = on ? 1 : 0;
   return cfgFlush();
+}
+
+static bool profilePinValid(const char* pin) {
+  if (!pin) return false;
+  const size_t n = strlen(pin);
+  if (n < 4 || n > 8) return false;
+  for (size_t i = 0; i < n; ++i) {
+    if (pin[i] < '0' || pin[i] > '9') return false;
+  }
+  return true;
+}
+
+static void profilePinHash(uint8_t profile, const uint8_t salt[8],
+                           const char* pin, uint8_t out[16]) {
+  static const char context[] = "wadamesh-profile-pin-v1";
+  SHA256 sha;
+  sha.update(context, sizeof(context) - 1);
+  sha.update(&profile, 1);
+  sha.update(salt, 8);
+  sha.update(pin, strlen(pin));
+  uint8_t full[32];
+  sha.finalize(full, sizeof(full));
+  memcpy(out, full, 16);
+  memset(full, 0, sizeof(full));
+}
+
+bool touchPrefsProfilePinsReady() {
+  if (!s_begun) touchPrefsBegin();
+  uint8_t any0 = 0, any1 = 0;
+  for (size_t i = 0; i < sizeof(s_cfg.profile_pin_hash[0]); ++i) {
+    any0 |= s_cfg.profile_pin_hash[0][i];
+    any1 |= s_cfg.profile_pin_hash[1][i];
+  }
+  return any0 != 0 && any1 != 0;
+}
+
+bool touchPrefsGetKidMode() {
+  if (!s_begun) touchPrefsBegin();
+  return s_cfg.kid_mode != 0 && touchPrefsProfilePinsReady();
+}
+
+bool touchPrefsSetProfilePins(const char* parent_pin, const char* kid_pin) {
+  if (!s_begun) touchPrefsBegin();
+  if (!profilePinValid(parent_pin) || !profilePinValid(kid_pin) ||
+      strcmp(parent_pin, kid_pin) == 0) return false;
+  const TouchCfg previous = s_cfg;
+  esp_fill_random(s_cfg.profile_pin_salt, sizeof(s_cfg.profile_pin_salt));
+  profilePinHash(0, s_cfg.profile_pin_salt[0], parent_pin, s_cfg.profile_pin_hash[0]);
+  profilePinHash(1, s_cfg.profile_pin_salt[1], kid_pin, s_cfg.profile_pin_hash[1]);
+  s_cfg.kid_mode = 1;
+  if (cfgFlush()) return true;
+  s_cfg = previous;
+  return false;
+}
+
+bool touchPrefsDisableKidMode() {
+  if (!s_begun) touchPrefsBegin();
+  const TouchCfg previous = s_cfg;
+  s_cfg.kid_mode = 0;
+  memset(s_cfg.profile_pin_salt, 0, sizeof(s_cfg.profile_pin_salt));
+  memset(s_cfg.profile_pin_hash, 0, sizeof(s_cfg.profile_pin_hash));
+  if (cfgFlush()) return true;
+  s_cfg = previous;
+  return false;
+}
+
+int touchPrefsMatchProfilePin(const char* pin) {
+  if (!s_begun) touchPrefsBegin();
+  if (!s_cfg.kid_mode || !touchPrefsProfilePinsReady() || !profilePinValid(pin)) return -1;
+  for (uint8_t profile = 0; profile < 2; ++profile) {
+    uint8_t actual[16];
+    profilePinHash(profile, s_cfg.profile_pin_salt[profile], pin, actual);
+    uint8_t diff = 0;
+    for (size_t i = 0; i < sizeof(actual); ++i) {
+      diff |= actual[i] ^ s_cfg.profile_pin_hash[profile][i];
+    }
+    memset(actual, 0, sizeof(actual));
+    if (diff == 0) return profile;
+  }
+  return -1;
 }
 
 bool touchPrefsGetCompactChat() {

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -200,6 +200,15 @@ bool    touchPrefsSetCompactChat(bool on);
  * (the missed-messages class). Opt-in, default off = stock receive path. */
 bool    touchPrefsGetRxQueue();
 bool    touchPrefsSetRxQueue(bool on);
+
+/* Two-profile lock mode. PINs are 4-8 decimal digits and are stored as salted
+ * SHA-256 verifiers, never as plaintext. A matching PIN selects profile 0
+ * (parent) or profile 1 (kid). */
+bool touchPrefsGetKidMode();
+bool touchPrefsProfilePinsReady();
+bool touchPrefsSetProfilePins(const char* parent_pin, const char* kid_pin);
+bool touchPrefsDisableKidMode();
+int  touchPrefsMatchProfilePin(const char* pin);  // -1 = no match, otherwise 0 or 1
 uint32_t touchPrefsGetClockFloor();               // monotonic send-timestamp floor (#89)
 bool    touchPrefsSetClockFloor(uint32_t epoch);  // only ever grows; no-op below current
 

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -33,7 +33,7 @@
   #include <esp_sleep.h>   // esp_deep_sleep_start / ext0 wakeup for the power-off menu
   #include <driver/rtc_io.h>   // rtc_gpio_pullup_en — hold the wake pin's level in deep sleep
   #include "assets/lockscreen_placeholder_jpg.h"   // seeded to SPIFFS /lock/placeholder.jpg on first boot (PNG decode is broken on this board)
-  #if CAP_LOCK_SCREEN
+  #if CAP_LOCK_SCREEN || CAP_PROFILE_PIN
     #include "assets/lockscreen_wallpaper_rgb565.h"   // crisp pre-dithered default lock-screen wallpaper (no JPEG banding)
     #if defined(TLORA_PAGER)
       #include "assets/lockscreen_wallpaper_pager_rgb565.h"   // native 480x222 crop/layout for this board's wide/short panel
@@ -3133,6 +3133,7 @@ static void mapNudge(int dir);                 // (defined far below) map pan �
 static bool hwKeyDismissTopPopup();            // (defined far below) close the topmost modal/sheet
 static bool anyPopupOpen();                    // (defined below) is any modal/sheet currently up
 static void closeChatPanel(LvChatPanel* p);    // (defined far below) close an open chat/channel detail
+static bool lockscreenProfileKey(int key);     // two-profile PIN gate, defined with the lock screen
 static void toggleControlCenter();             // (defined far below) the top-bar "control center" dropdown
 static void homeKeyActivate();                 // (defined far below) green ○ tap: Home, or toggle drawer if already Home
 static uint32_t s_f4_down_ms = 0;              // green ○ press time — tap = Home, hold = control center
@@ -3788,7 +3789,7 @@ static void navPump() {
       if (fresh && g_lv.task) {
         if (g_lv.task->isManualLocked())          { g_lv.task->unlockScreen(); }
         else if (g_lv.task->isScreenOff())        { g_lv.task->wakeScreen();   }
-        else if (touchPrefsGetLockOnScreenOff())  { g_lv.task->lockScreen();   }
+        else if (touchPrefsGetLockOnScreenOff() || touchPrefsGetKidMode()) { g_lv.task->lockScreen(); }
         else                                      { g_lv.task->sleepScreen();  }
       }
       continue;
@@ -3808,6 +3809,12 @@ static void navPump() {
       continue;
     }
 #endif
+    if (g_lv.task && g_lv.task->isManualLocked() && touchPrefsGetKidMode()) {
+      g_lv.task->lockscreenReveal();
+      if (ev.type == INPUT_EVENT_TYPE_KEYBOARD)
+        lockscreenProfileKey((int)ev.args_keyboard.ascii);
+      continue;
+    }
     // Any key counts as activity: reset the idle timer, and if the screen idled
     // off, wake it and swallow this key (no touch on the Tanmatsu to wake it).
     if (g_lv.task) {
@@ -4485,8 +4492,14 @@ static void lvglTouchRead(lv_indev_drv_t* indev, lv_indev_data_t* data) {
     // several polls, so once the backlight is back on a still-down finger would
     // otherwise press the UI underneath and trigger the action before you see
     // it (issue #4). Applies to both boards (V4 + T-Deck).
-    if (g_lv.task && (g_lv.task->isScreenOff() || g_lv.task->isManualLock())) {
-      if (!g_lv.task->isManualLock()) g_lv.task->noteUserInput();
+    if (g_lv.task && g_lv.task->isManualLock() && touchPrefsGetKidMode() &&
+        !g_lv.task->isScreenOff()) {
+      // A lit two-profile lock screen is interactive: its full-screen overlay
+      // owns the pointer and exposes only the PIN pad. Continue into the normal
+      // pressed path below; the overlay prevents any tap from reaching the app.
+    } else if (g_lv.task && (g_lv.task->isScreenOff() || g_lv.task->isManualLock())) {
+      if (g_lv.task->isManualLock() && touchPrefsGetKidMode()) g_lv.task->lockscreenReveal();
+      else if (!g_lv.task->isManualLock()) g_lv.task->noteUserInput();
       s_wake_swallow = true;
       data->state = LV_INDEV_STATE_RELEASED;
       return;
@@ -4568,6 +4581,7 @@ static void copyLabelLongPressCb(lv_event_t* e);
 static void taClearSelection(lv_obj_t* ta);   // clear composer text-selection before an insert
 static lv_obj_t* createSettingsModal(const char* title, SettingsModalKind kind);
 static void chatDeleteApply();
+static bool lockscreenProfileKey(int key);   // two-profile PIN input (touch + physical keyboards)
 static void shareMyContactBtnCb(lv_event_t* e);
 static void openShareMyContactPopup();
 static void refreshMapInfoLabel();
@@ -4885,6 +4899,28 @@ static UITask::UIMessage* s_segsync_buf = nullptr;  // sync-drain jobs only
 // its snapshot predates the tombstone, so the segment must stay dirty when
 // the job commits (a second compaction picks the deletion up).
 static bool s_segjob_redirty = false;
+
+// A profile switch changes the directory namespace underneath the segmented
+// history store. The old profile is synchronously drained first; this clears
+// only the loop-owned bookkeeping so the loader can rebuild it from the newly
+// selected profile without reusing a stale job or durability watermark.
+static void uiHistoryStoreStateReset() {
+  s_hist_flush_req = false;
+  s_hist_flush_ok = true;
+  memset(s_seg, 0, sizeof(s_seg));
+  s_seg_count = 0;
+  s_seg_total_bytes = 0;
+  s_seg_resync = false;
+  s_seg_stale_purge = false;
+  s_seg_store_ready = false;
+  s_seg_flushed_seq = 0;
+  s_segjob_kind = SEGJOB_NONE;
+  s_segjob_first_seq = 0;
+  s_segjob_last_seq = 0;
+  s_segjob_create = false;
+  s_segjob_n = 0;
+  s_segjob_redirty = false;
+}
 // fwd decls — scheduler helpers live with the storage code below.
 static int  segBuildJob(const UITask::UIMessage* ring, int cap, int count, int head,
                         UITask::UIMessage* buf, SegJob* out);
@@ -9125,6 +9161,7 @@ static void discoveredAddCb(lv_event_t* e) {
 
   // Add the captured ContactInfo straight to the_mesh.
   if (the_mesh.addContact(e_disc.ci)) {
+    the_mesh.requestEncryptedBacklogRescan();
     the_mesh.uiPersistContacts();   // write /contacts3 so the add survives reboot
     e_disc.in_contacts = true;
     markDiscoveredDirty();
@@ -10943,6 +10980,54 @@ static void lockOnScreenOffToggleCb(lv_event_t* e) {
   if (g_lv.task) g_lv.task->showAlert(unlock_hint, 1600);
 }
 
+static lv_obj_t* s_kid_parent_pin_ta = nullptr;
+static lv_obj_t* s_kid_child_pin_ta = nullptr;
+
+static void kidModeApplyCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED || !g_lv.task ||
+      !s_kid_parent_pin_ta || !s_kid_child_pin_ta) return;
+  if (the_mesh.activeLocalProfile() != 0) {
+    g_lv.task->showAlert(TR("Parent profile required"), 1600);
+    return;
+  }
+  kbMirrorSyncToReal();
+  char parent[9];
+  char kid[9];
+  snprintf(parent, sizeof(parent), "%s", lv_textarea_get_text(s_kid_parent_pin_ta));
+  snprintf(kid, sizeof(kid), "%s", lv_textarea_get_text(s_kid_child_pin_ta));
+  setTextareaSynced(s_kid_parent_pin_ta, "");
+  setTextareaSynced(s_kid_child_pin_ta, "");
+  hideKb();
+  const size_t parent_len = strlen(parent);
+  const size_t kid_len = strlen(kid);
+  if (parent_len < 4 || parent_len > 8 || kid_len < 4 || kid_len > 8 ||
+      strcmp(parent, kid) == 0) {
+    memset(parent, 0, sizeof(parent));
+    memset(kid, 0, sizeof(kid));
+    g_lv.task->showAlert(TR("Use two different 4-8 digit PINs"), 2200);
+    return;
+  }
+  const bool ok = g_lv.task->enableKidMode(parent, kid);
+  memset(parent, 0, sizeof(parent));
+  memset(kid, 0, sizeof(kid));
+  if (!ok) {
+    g_lv.task->showAlert(TR("Could not allocate or save profile mode"), 2400);
+    return;
+  }
+  closeSettingsCategory();
+}
+
+static void kidModeDisableCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_CLICKED || !g_lv.task) return;
+  if (!g_lv.task->disableKidMode()) {
+    g_lv.task->showAlert(TR("Parent profile required"), 1600);
+    return;
+  }
+  hideKb();
+  closeSettingsCategory();
+  g_lv.task->showAlert(TR("Two-profile mode disabled"), 1500);
+}
+
 #if CAP_TRACKBALL
 // Invert the scrollball direction everywhere it drives motion (cursor, map pan,
 // emoji selector). Cached in s_tb_reverse so the per-tick poll never hits NVS.
@@ -12453,6 +12538,74 @@ static void buildDeviceSettings(int sec) {
   }
 
   if (sec == DSEC_LOCK) {   // --- Lock screen ---
+  // Two independent mesh identities share the encrypted RX queue but keep
+  // prefs, contacts/channels and plaintext chat history under separate roots.
+  // Only the parent profile can create/change the PIN pair or disable the gate.
+  {
+    y += settingsRowLabel(body, y, 0, TR("Two-profile kid mode"), COLOR_SUB, &g_font_12, 0) + 4;
+    const bool parent_profile = the_mesh.activeLocalProfile() == 0;
+    const bool enabled = touchPrefsGetKidMode();
+    if (!parent_profile) {
+      y += settingsRowLabel(body, y, 2, TR("Parent profile required to change PINs"),
+                            COLOR_TEXT, &g_font_12, 0) + 10;
+    } else {
+      lv_obj_t* state = lv_label_create(body);
+      lv_label_set_text(state, enabled ? TR("Enabled - enter new PINs to change them")
+                                       : TR("Two different PINs select Parent or Kid"));
+      lv_label_set_long_mode(state, LV_LABEL_LONG_WRAP);
+      lv_obj_set_width(state, lv_pct(100));
+      lv_obj_set_style_text_color(state, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+      lv_obj_set_style_text_font(state, &g_font_12, LV_PART_MAIN);
+      lv_obj_set_pos(state, 2, y);
+      y += SC(34);
+
+      s_kid_parent_pin_ta = lv_textarea_create(body);
+      lv_obj_set_size(s_kid_parent_pin_ta, lv_pct(100), SC(34));
+      lv_obj_set_pos(s_kid_parent_pin_ta, 2, y);
+      lv_textarea_set_one_line(s_kid_parent_pin_ta, true);
+      lv_textarea_set_password_mode(s_kid_parent_pin_ta, true);
+      lv_textarea_set_accepted_chars(s_kid_parent_pin_ta, "0123456789");
+      lv_textarea_set_max_length(s_kid_parent_pin_ta, 8);
+      lv_textarea_set_placeholder_text(s_kid_parent_pin_ta, TR("Parent PIN (4-8 digits)"));
+      attachSettingsTaEvents(s_kid_parent_pin_ta);
+      y += SC(40);
+
+      s_kid_child_pin_ta = lv_textarea_create(body);
+      lv_obj_set_size(s_kid_child_pin_ta, lv_pct(100), SC(34));
+      lv_obj_set_pos(s_kid_child_pin_ta, 2, y);
+      lv_textarea_set_one_line(s_kid_child_pin_ta, true);
+      lv_textarea_set_password_mode(s_kid_child_pin_ta, true);
+      lv_textarea_set_accepted_chars(s_kid_child_pin_ta, "0123456789");
+      lv_textarea_set_max_length(s_kid_child_pin_ta, 8);
+      lv_textarea_set_placeholder_text(s_kid_child_pin_ta, TR("Kid PIN (4-8 digits)"));
+      attachSettingsTaEvents(s_kid_child_pin_ta);
+      y += SC(42);
+
+      lv_obj_t* apply = lv_btn_create(body);
+      lv_obj_set_size(apply, lv_pct(100), SC(34));
+      lv_obj_set_pos(apply, 2, y);
+      styleButton(apply);
+      lv_obj_add_event_cb(apply, kidModeApplyCb, LV_EVENT_CLICKED, nullptr);
+      lv_obj_t* apply_l = lv_label_create(apply);
+      lv_label_set_text(apply_l, enabled ? TR("Change profile PINs") : TR("Enable two profiles"));
+      lv_obj_center(apply_l);
+      y += SC(42);
+
+      if (enabled) {
+        lv_obj_t* disable = lv_btn_create(body);
+        lv_obj_set_size(disable, lv_pct(100), SC(34));
+        lv_obj_set_pos(disable, 2, y);
+        styleButton(disable);
+        lv_obj_set_style_bg_color(disable, lv_color_hex(0x7A3038), LV_PART_MAIN);
+        lv_obj_add_event_cb(disable, kidModeDisableCb, LV_EVENT_CLICKED, nullptr);
+        lv_obj_t* disable_l = lv_label_create(disable);
+        lv_label_set_text(disable_l, TR("Disable two profiles"));
+        lv_obj_center(disable_l);
+        y += SC(42);
+      }
+    }
+    y += 6;
+  }
 #if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)
   /* Lock screen: pick the wallpaper (internal /lock/ or SD) and the colour of
      the clock + lock text drawn over it. */
@@ -18308,6 +18461,7 @@ static void webPushDiscovered() {
 static void webAddDiscovered(int i) {
   if (!s_discovered || i < 0 || i >= DISCOVERED_MAX || !s_discovered[i].used || s_discovered[i].in_contacts) return;
   if (the_mesh.addContact(s_discovered[i].ci)) {   // same path the on-device "Add" button uses
+    the_mesh.requestEncryptedBacklogRescan();
     the_mesh.uiPersistContacts();
     s_discovered[i].in_contacts = true;
     markDiscoveredDirty();
@@ -28952,6 +29106,10 @@ static void settingsCatBuild(int cat) {
 static void closeSettingsCategory() {
   if (!s_settings_sheet && s_settings_open_cat < 0) return;
   hideKb();
+  if (s_settings_open_cat == CAT_LOCK) {
+    s_kid_parent_pin_ta = nullptr;
+    s_kid_child_pin_ta = nullptr;
+  }
   if (s_settings_open_cat == CAT_ABOUT) {   // null the live-label ptrs (freed with the sheet)
     s_sysinfo_lbl = nullptr; s_sysinfo_rest_lbl = nullptr; s_update_about_lbl = nullptr; s_ota_status_lbl = nullptr;
 #if defined(HAS_TDECK_GT911) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
@@ -29093,9 +29251,6 @@ static void makeSettings(lv_obj_t* tab) {
   const lv_coord_t card_h = landscape ? 54 : 46;
 
   for (int c = 0; c < CAT_COUNT; ++c) {
-#if !CAP_LOCK_SCREEN
-    if (c == CAT_LOCK) continue;   // lock screen is a T-Deck / Tanmatsu feature
-#endif
 #if !defined(HAS_EXPANSION_KIT)
     if (c == CAT_SENSORS) continue;   // Sensors page only exists with the V4 Expansion Kit
 #endif
@@ -33359,6 +33514,7 @@ static void updatePagerSpaceHold(unsigned long now) {
 // exactly the state it's meant to end.
 static void updatePagerBackspaceUnlockHold(unsigned long now) {
   if (!g_lv.task || !g_lv.task->isManualLock()) return;
+  if (touchPrefsGetKidMode()) return;   // PIN submission is the only unlock path in two-profile mode
   const bool held = pagerKeyboardBackspaceHeld();
   static constexpr uint32_t kLongPressMs = 1000;
   static bool     s_was_held    = false;
@@ -33784,7 +33940,7 @@ static int tabForKey(int key) {
 }
 #endif  // HAS_TDECK_KEYBOARD || HAS_PAGER_KEYBOARD || HAS_M9_KEYBOARD (keyboard helpers; the lock screen below is top-level)
 
-#if CAP_LOCK_SCREEN
+#if CAP_LOCK_SCREEN || CAP_PROFILE_PIN
 // ---- Lock screen -------------------------------------------------------------
 // A full-screen overlay (wallpaper + live clock + lock-state text) shown while
 // the T-Deck is hard-locked. The wallpaper is a JPEG decoded to RGB565; the
@@ -33811,6 +33967,124 @@ static const unsigned long kLockUnlockHoldMs = 1000;
 // while the trackball is held on the lock screen.
 static lv_obj_t* s_unlock_popup = nullptr;
 static lv_obj_t* s_unlock_count = nullptr;
+static lv_obj_t* s_profile_pin_dots = nullptr;
+static lv_obj_t* s_profile_pin_status = nullptr;
+static lv_obj_t* s_profile_pin_btnm = nullptr;
+static char s_profile_pin[9] = "";
+static uint8_t s_profile_pin_len = 0;
+static uint8_t s_profile_pin_failures = 0;
+static uint32_t s_profile_pin_block_until = 0;
+
+static void lockscreenProfileDotsUpdate() {
+  if (!s_profile_pin_dots) return;
+  char dots[24];
+  size_t p = 0;
+  for (uint8_t i = 0; i < s_profile_pin_len && p + 2 < sizeof(dots); ++i) {
+    if (p) dots[p++] = ' ';
+    dots[p++] = '*';
+  }
+  dots[p] = '\0';
+  lv_label_set_text(s_profile_pin_dots, p ? dots : "-");
+}
+
+static void lockscreenProfileReset() {
+  memset(s_profile_pin, 0, sizeof(s_profile_pin));
+  s_profile_pin_len = 0;
+  lockscreenProfileDotsUpdate();
+  if (s_profile_pin_status) {
+    lv_label_set_text(s_profile_pin_status,
+                      the_mesh.profileModeEnabled() ? TR("Parent or kid PIN")
+                                                    : TR("PIN - message backlog unavailable"));
+  }
+  if (s_profile_pin_btnm) lv_obj_clear_state(s_profile_pin_btnm, LV_STATE_DISABLED);
+}
+
+static void lockscreenProfileUnlockAsync(void* arg) {
+  const uint8_t profile = (uint8_t)(uintptr_t)arg;
+  if (!g_lv.task || !g_lv.task->unlockProfile(profile)) {
+    if (s_profile_pin_status)
+      lv_label_set_text(s_profile_pin_status, TR("Could not open profile"));
+    if (s_profile_pin_btnm) lv_obj_clear_state(s_profile_pin_btnm, LV_STATE_DISABLED);
+  }
+}
+
+static void lockscreenProfileSubmit() {
+  const uint32_t now = millis();
+  if ((int32_t)(now - s_profile_pin_block_until) < 0) {
+    if (s_profile_pin_status) {
+      const uint32_t secs = (s_profile_pin_block_until - now + 999u) / 1000u;
+      lv_label_set_text_fmt(s_profile_pin_status, TR("Try again in %u s"), (unsigned)secs);
+    }
+    return;
+  }
+  if (s_profile_pin_len < 4) {
+    if (s_profile_pin_status) lv_label_set_text(s_profile_pin_status, TR("PIN must be 4-8 digits"));
+    return;
+  }
+
+  char candidate[sizeof(s_profile_pin)];
+  memcpy(candidate, s_profile_pin, sizeof(candidate));
+  lockscreenProfileReset();
+  const int profile = touchPrefsMatchProfilePin(candidate);
+  memset(candidate, 0, sizeof(candidate));
+  if (profile < 0) {
+    if (s_profile_pin_failures < 8) ++s_profile_pin_failures;
+    uint32_t wait_s = 1u << (s_profile_pin_failures > 5 ? 5 : s_profile_pin_failures);
+    if (wait_s > 30u) wait_s = 30u;
+    s_profile_pin_block_until = now + wait_s * 1000u;
+    if (s_profile_pin_status)
+      lv_label_set_text_fmt(s_profile_pin_status, TR("Wrong PIN - wait %u s"), (unsigned)wait_s);
+    return;
+  }
+
+  s_profile_pin_failures = 0;
+  s_profile_pin_block_until = 0;
+  if (s_profile_pin_status) lv_label_set_text(s_profile_pin_status, TR("Opening profile..."));
+  if (s_profile_pin_btnm) lv_obj_add_state(s_profile_pin_btnm, LV_STATE_DISABLED);
+  lv_refr_now(nullptr);
+  lv_async_call(lockscreenProfileUnlockAsync, (void*)(uintptr_t)profile);
+}
+
+static bool lockscreenProfileKey(int key) {
+  if (!touchPrefsGetKidMode() || !g_lv.task || !g_lv.task->isManualLock()) return false;
+  if (key >= '0' && key <= '9') {
+    if ((int32_t)(millis() - s_profile_pin_block_until) < 0) {
+      lockscreenProfileSubmit();
+      return true;
+    }
+    if (s_profile_pin_len < 8) {
+      s_profile_pin[s_profile_pin_len++] = (char)key;
+      s_profile_pin[s_profile_pin_len] = '\0';
+      lockscreenProfileDotsUpdate();
+      if (s_profile_pin_status) lv_label_set_text(s_profile_pin_status, TR("Parent or kid PIN"));
+    }
+    return true;
+  }
+  if (key == 0x08 || key == 0x7F) {
+    if (s_profile_pin_len > 0) {
+      s_profile_pin[--s_profile_pin_len] = '\0';
+      lockscreenProfileDotsUpdate();
+    }
+    return true;
+  }
+  if (key == '\r' || key == '\n') {
+    lockscreenProfileSubmit();
+    return true;
+  }
+  return true;   // consume every other key while the PIN gate is active
+}
+
+static void lockscreenProfileBtnCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  lv_obj_t* btnm = lv_event_get_target(e);
+  const uint16_t idx = lv_btnmatrix_get_selected_btn(btnm);
+  if (idx == LV_BTNMATRIX_BTN_NONE) return;
+  const char* txt = lv_btnmatrix_get_btn_text(btnm, idx);
+  if (!txt) return;
+  if (txt[0] >= '0' && txt[0] <= '9' && txt[1] == '\0') lockscreenProfileKey(txt[0]);
+  else if (strcmp(txt, "OK") == 0) lockscreenProfileKey('\r');
+  else lockscreenProfileKey(0x08);
+}
 
 // Decode the configured wallpaper (internal SPIFFS path, or an "sd:"-prefixed SD
 // path) into a fresh RGB565 buffer; fall back to the embedded placeholder.
@@ -34122,6 +34396,68 @@ static void lockscreenShow() {
 #else
   lv_obj_align(hint, LV_ALIGN_BOTTOM_MID, 0, -8);
 #endif
+
+  if (touchPrefsGetKidMode()) {
+    lv_obj_add_flag(st, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(hint, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_lock_unread, LV_OBJ_FLAG_HIDDEN);
+    if (sw < 420) lv_obj_add_flag(s_lock_clock, LV_OBJ_FLAG_HIDDEN);
+
+    const lv_coord_t card_w = sw >= 420 ? 238 : (sw > 236 ? 220 : sw - 12);
+    const lv_coord_t card_h = sh >= 300 ? 260 : sh - 16;
+    lv_obj_t* card = lv_obj_create(s_lock_root);
+    lv_obj_remove_style_all(card);
+    lv_obj_set_size(card, card_w, card_h);
+    if (sw >= 420) lv_obj_align(card, LV_ALIGN_RIGHT_MID, -8, 0);
+    else lv_obj_align(card, LV_ALIGN_CENTER, 0, 5);
+    lv_obj_set_style_bg_color(card, lv_color_hex(COLOR_PANEL), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(card, LV_OPA_90, LV_PART_MAIN);
+    lv_obj_set_style_radius(card, 12, LV_PART_MAIN);
+    lv_obj_set_style_border_width(card, 1, LV_PART_MAIN);
+    lv_obj_set_style_border_color(card, lv_color_hex(COLOR_ACCENT), LV_PART_MAIN);
+    lv_obj_set_style_pad_all(card, 8, LV_PART_MAIN);
+    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* title = lv_label_create(card);
+    lv_label_set_text(title, TR("Enter profile PIN"));
+    lv_obj_set_style_text_font(title, &g_font_16, LV_PART_MAIN);
+    lv_obj_set_style_text_color(title, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 0);
+
+    s_profile_pin_dots = lv_label_create(card);
+    lv_obj_set_style_text_font(s_profile_pin_dots, &g_font_16, LV_PART_MAIN);
+    lv_obj_set_style_text_color(s_profile_pin_dots, lv_color_hex(COLOR_ACCENT), LV_PART_MAIN);
+    lv_obj_align(s_profile_pin_dots, LV_ALIGN_TOP_MID, 0, 24);
+
+    s_profile_pin_status = lv_label_create(card);
+    lv_obj_set_width(s_profile_pin_status, card_w - 16);
+    lv_obj_set_style_text_align(s_profile_pin_status, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+    lv_obj_set_style_text_font(s_profile_pin_status, &g_font_12, LV_PART_MAIN);
+    lv_obj_set_style_text_color(s_profile_pin_status, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
+    lv_obj_align(s_profile_pin_status, LV_ALIGN_TOP_MID, 0, 45);
+
+    static const char* pin_map[] = {
+      "1", "2", "3", "\n",
+      "4", "5", "6", "\n",
+      "7", "8", "9", "\n",
+      LV_SYMBOL_BACKSPACE, "0", "OK", ""
+    };
+    s_profile_pin_btnm = lv_btnmatrix_create(card);
+    lv_btnmatrix_set_map(s_profile_pin_btnm, pin_map);
+    lv_obj_set_size(s_profile_pin_btnm, card_w - 16, card_h - 72);
+    lv_obj_align(s_profile_pin_btnm, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_bg_opa(s_profile_pin_btnm, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_border_width(s_profile_pin_btnm, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(s_profile_pin_btnm, 2, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(s_profile_pin_btnm, 3, LV_PART_MAIN);
+    lv_obj_set_style_pad_column(s_profile_pin_btnm, 3, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(s_profile_pin_btnm, lv_color_hex(0x25282D), LV_PART_ITEMS);
+    lv_obj_set_style_bg_color(s_profile_pin_btnm, lv_color_hex(COLOR_ACCENT), LV_PART_ITEMS | LV_STATE_PRESSED);
+    lv_obj_set_style_text_color(s_profile_pin_btnm, lv_color_hex(COLOR_TEXT), LV_PART_ITEMS);
+    lv_obj_set_style_radius(s_profile_pin_btnm, 7, LV_PART_ITEMS);
+    lv_obj_add_event_cb(s_profile_pin_btnm, lockscreenProfileBtnCb, LV_EVENT_VALUE_CHANGED, nullptr);
+    lockscreenProfileReset();
+  }
 }
 
 static void lockscreenHide() {
@@ -34134,6 +34470,11 @@ static void lockscreenHide() {
   if (s_lock_wall) { lv_img_cache_invalidate_src(&s_lock_wall_dsc); lvglPsramFree(s_lock_wall); s_lock_wall = nullptr; }
   s_lock_clock_min = -1;
   s_lock_unread_n  = -1;
+  s_profile_pin_dots = nullptr;
+  s_profile_pin_status = nullptr;
+  s_profile_pin_btnm = nullptr;
+  memset(s_profile_pin, 0, sizeof(s_profile_pin));
+  s_profile_pin_len = 0;
   // Restore the status bar's normal opaque background + accent border.
   if (g_statusbar.root) {
     lv_obj_set_style_bg_opa(g_statusbar.root, LV_OPA_COVER, LV_PART_MAIN);
@@ -34151,9 +34492,21 @@ static void serviceLockscreen() {
   if (t > 0) { time_t tt = (time_t)t; struct tm v; localtime_r(&tt, &v); mm = v.tm_min; }
   if (mm != s_lock_clock_min) lockscreenUpdateClock();
   unsigned long now = millis();
-  if (now - s_lock_unread_ms >= 1000) { s_lock_unread_ms = now; lockscreenUpdateUnread(); }
+  if (now - s_lock_unread_ms >= 1000) {
+    s_lock_unread_ms = now;
+    lockscreenUpdateUnread();
+    if (s_profile_pin_status && s_profile_pin_block_until) {
+      if ((int32_t)(now - s_profile_pin_block_until) >= 0) {
+        s_profile_pin_block_until = 0;
+        lv_label_set_text(s_profile_pin_status, TR("Parent or kid PIN"));
+      } else {
+        const uint32_t secs = (s_profile_pin_block_until - now + 999u) / 1000u;
+        lv_label_set_text_fmt(s_profile_pin_status, TR("Try again in %u s"), (unsigned)secs);
+      }
+    }
+  }
 }
-#endif  // core lock screen (HAS_TDECK_GT911 || HAS_TANMATSU)
+#endif  // lock screen and two-profile PIN gate
 
 #if CAP_SOUND_FILES   // custom WAV notification sounds -- T-Deck (SD/SPIFFS) or pager (SPIFFS only)
 // ---- Notification-sound chooser (Settings -> Sound) ------------------------
@@ -35074,6 +35427,11 @@ static bool m9HandleArrowKey(int key, lv_obj_t* ta) {
 static void handleHwKey(int key) {
   if (!g_lv.keyboard) return;
 if (g_lv.task && g_lv.task->isManualLock()) {
+    if (touchPrefsGetKidMode()) {
+      g_lv.task->lockscreenReveal();
+      lockscreenProfileKey(key);
+      return;
+    }
 #if defined(HAS_M9_KEYBOARD)
     // M9 has no trackball to hold — the keyboard controller's own long-press
     // detection (M9_KEY_ENTER_LONG, a distinct byte from a normal Enter tap)
@@ -42154,8 +42512,30 @@ void UITask::flushHistoryIfDue(unsigned long now) {
 // found" spam — the history flush runs every ~2 s, and re-calling SPIFFS.begin()
 // each time both logged the error and, under Launcher, never actually persisted
 // the chat to the SD card.
-static fs::FS* s_ui_data_fs       = nullptr;
-static char    s_ui_data_root[16] = "";
+static fs::FS* s_ui_data_fs            = nullptr;
+static char    s_ui_data_base_root[16] = "";
+static char    s_ui_data_root[40]      = "";
+static uint8_t s_ui_data_profile       = 0;
+
+static void uiDataApplyProfileRoot() {
+  if (s_ui_data_profile == 0) {
+    snprintf(s_ui_data_root, sizeof(s_ui_data_root), "%s", s_ui_data_base_root);
+  } else {
+    snprintf(s_ui_data_root, sizeof(s_ui_data_root), "%s/profile1", s_ui_data_base_root);
+    if (s_ui_data_fs) s_ui_data_fs->mkdir(s_ui_data_root);
+  }
+}
+
+static void uiDataSetBaseRoot(const char* root) {
+  snprintf(s_ui_data_base_root, sizeof(s_ui_data_base_root), "%s", root ? root : "");
+  uiDataApplyProfileRoot();
+}
+
+static void uiDataSelectProfile(uint8_t profile) {
+  s_ui_data_profile = profile > 1 ? 0 : profile;
+  uiDataApplyProfileRoot();
+}
+
 static bool uiDataFsReady() {
   if (s_ui_data_fs != nullptr) return true;   // cache SUCCESS only — a failed resolve MUST stay retryable
 #if defined(HAS_TANMATSU) || defined(HAS_TDISPLAY_P4)
@@ -42170,12 +42550,12 @@ static bool uiDataFsReady() {
   // (see the storage note in tdisplay_p4/main/main.cpp). SD = degraded fallback only;
   // tiles keep using the SD via their own selector.
   extern bool g_fs_ok;
-  if (g_fs_ok) { s_ui_data_fs = &LittleFS; s_ui_data_root[0] = '\0'; return true; }
+  if (g_fs_ok) { s_ui_data_fs = &LittleFS; uiDataSetBaseRoot(""); return true; }
   extern bool g_sd_ok;
   if (g_sd_ok) {
     SD_MMC.mkdir("/meshcomod");
     s_ui_data_fs = &SD_MMC;
-    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+    uiDataSetBaseRoot("/meshcomod");
     return true;
   }
 #elif defined(HAS_TDECK_GT911)
@@ -42187,17 +42567,17 @@ static bool uiDataFsReady() {
     s_sd_mounted = true;
     SD.mkdir("/meshcomod");
     s_ui_data_fs = &SD;
-    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+    uiDataSetBaseRoot("/meshcomod");
     return true;
   }
-  if (SPIFFS.begin(false)) { s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0'; return true; }
+  if (SPIFFS.begin(false)) { s_ui_data_fs = &SPIFFS; uiDataSetBaseRoot(""); return true; }
 #else
   // V4 (no SD): internal SPIFFS. Format-on-fail so a fresh / never-formatted
   // partition becomes usable — that's the V4 history-loss fix. Safe: only formats
   // an unmountable partition (contents were inaccessible anyway), and only when
   // begin(false) already failed.
   if (SPIFFS.begin(false) || SPIFFS.begin(true)) {
-    s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0';
+    s_ui_data_fs = &SPIFFS; uiDataSetBaseRoot("");
     return true;
   }
 #endif
@@ -44213,6 +44593,15 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   _sensors    = sensors;
   _node_prefs = node_prefs;
 
+#if defined(ESP32)
+  const bool kid_mode_enabled = touchPrefsGetKidMode();
+  const bool profile_backlog_ready =
+      !kid_mode_enabled || the_mesh.setProfileModeEnabled(true);
+#else
+  const bool kid_mode_enabled = false;
+  const bool profile_backlog_ready = true;
+#endif
+
   // #161 one-time heal: presets used to write airtime_factor = pct/100 (a 10% preset
   // configured ~91% duty). Exact-preset matches with the old value get the correct
   // factor rewritten + persisted; see healPresetAirtimeFactor for the guard.
@@ -44569,7 +44958,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   // internal-flash devices keep 500. Decided once, before the alloc; the loader
   // linearizes a history file written under either capacity.
 #if defined(ESP32)
-  _ui_msg_cap = uiDataFsIsSdCard() ? MAX_UI_MESSAGES_SD : MAX_UI_MESSAGES;
+  uiDataSelectProfile(the_mesh.activeLocalProfile());
+  _ui_msg_cap = kid_mode_enabled
+                    ? (profile_backlog_ready ? MAX_UI_MESSAGES_KID : MAX_UI_MESSAGES)
+                    : (uiDataFsIsSdCard() ? MAX_UI_MESSAGES_SD : MAX_UI_MESSAGES);
   uiDataEnsureDirs();   // segment dir exists before the loader scans / the first append
 #endif
   size_t msgs_bytes          = sizeof(UIMessage) * (size_t)_ui_msg_cap;
@@ -44579,6 +44971,11 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     if (!_ui_msgs && _ui_msg_cap > MAX_UI_MESSAGES) {
       // PSRAM can't fit the deep ring (unexpected) — drop to the base size rather
       // than strand 1.3 MB in internal RAM via the fallback below.
+      // In profile mode, the encrypted queue and the 2,000-entry UI ring are a
+      // single feature: replaying the full queue into a 500-entry ring would
+      // silently discard most of it. Free the queue and leave the PIN screen's
+      // explicit "backlog unavailable" warning active instead.
+      if (kid_mode_enabled) the_mesh.setProfileModeEnabled(false);
       _ui_msg_cap = MAX_UI_MESSAGES;
       msgs_bytes  = sizeof(UIMessage) * (size_t)_ui_msg_cap;
       _ui_msgs = (UIMessage*)heap_caps_malloc(msgs_bytes, MALLOC_CAP_SPIRAM);
@@ -45034,6 +45431,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
 #if defined(ESP32)
     if (!s_setup_root) crashReportMaybePrompt();   // a panic coredump is waiting -> proactively offer to send it
 #endif
+    // A stale/reset setup-complete flag must not expose the setup wizard over a
+    // previously configured profile gate. The verified PIN unlock simply
+    // reveals the wizard underneath when one is present.
+    if (kid_mode_enabled) lockScreen();
   }
   g_lv.dirty_threads      = true;
   g_lv.dirty_timeline     = true;
@@ -45162,7 +45563,11 @@ void UITask::rebuildThreadHistoryFlags() const {
 // oldest end finds them immediately for the chat that is actually over the cap (it is the one
 // filling the ring), so the common case is a couple of steps, not a full scan.
 void UITask::enforceHistoryCap(int thread_idx) {
-  const uint16_t cap = touchPrefsGetHistPerChat();
+  // Profile unlock can legitimately release a whole queued burst into one
+  // channel. Preserve all of it up to the profile ring's 2,000-message limit;
+  // the normal per-chat preference resumes when two-profile mode is disabled.
+  const uint16_t cap = touchPrefsGetKidMode() ? (uint16_t)MAX_UI_MESSAGES_KID
+                                               : touchPrefsGetHistPerChat();
   if (!cap || thread_idx < 0 || thread_idx >= MAX_UI_THREADS || !_ui_threads[thread_idx].used) return;
   if (_thread_hist_dirty) rebuildThreadHistoryFlags();
   if (_thread_msgs[thread_idx] <= cap) return;
@@ -45906,6 +46311,10 @@ void UITask::noteUserInput() {
 }
 
 void UITask::wakeScreen() {
+  if (_manual_lock && touchPrefsGetKidMode() && !_profile_pin_authorized) {
+    lockscreenReveal();
+    return;
+  }
   if (!_screen_off) return;
   setCpuForScreen(true);     // back to 240 MHz before we render
   touchScreenBacklight(true);
@@ -45917,6 +46326,21 @@ void UITask::wakeScreen() {
 void UITask::lockScreen() {
   // Backlight off + manual lock so touch is ignored (noteUserInput()
   // early-returns) until a deliberate unlock.
+  _profile_pin_authorized = false;
+#if CAP_LOCK_SCREEN || CAP_PROFILE_PIN
+  if (touchPrefsGetKidMode()) {
+    the_mesh.lockEncryptedBacklog();
+    lockscreenProfileReset();
+    _manual_lock = true;
+    _screen_off = false;
+    setCpuForScreen(true);
+    touchScreenBacklight(true);
+    lockscreenShow();
+    _lock_lit_ms = millis();
+    _last_input_ms = millis();
+    return;
+  }
+#endif
 #if defined(HAS_TANMATSU)
   // Tanmatsu: a Vol- LONG-press locks. Light the screen + build/show the lock-screen overlay (so the
   // wallpaper + clock are visible the moment you lock) and block app input (_manual_lock). Another
@@ -45943,7 +46367,7 @@ void UITask::lockScreen() {
 }
 
 void UITask::lockscreenReveal() {
-#if CAP_LOCK_SCREEN
+#if CAP_LOCK_SCREEN || CAP_PROFILE_PIN
   if (!_manual_lock) return;
   if (_screen_off) {
     lockscreenShow();               // build + foreground FIRST
@@ -45958,13 +46382,18 @@ void UITask::lockscreenReveal() {
 }
 
 void UITask::unlockScreen() {
+  if (_manual_lock && touchPrefsGetKidMode() && !_profile_pin_authorized) {
+    lockscreenReveal();
+    return;
+  }
   _manual_lock = false;
   _screen_off  = false;
   setCpuForScreen(true);
   touchScreenBacklight(true);
-#if CAP_LOCK_SCREEN
+#if CAP_LOCK_SCREEN || CAP_PROFILE_PIN
   lockscreenHide();
 #endif
+  _profile_pin_authorized = false;
   _last_input_ms = millis();
 }
 
@@ -46059,6 +46488,151 @@ void UITask::persistHistoryNow() {
   saveMsgsToStorage();
 }
 
+bool UITask::enableKidMode(const char* parent_pin, const char* kid_pin) {
+  const bool profile_mode_was_enabled = the_mesh.profileModeEnabled();
+  if (!the_mesh.setProfileModeEnabled(true)) return false;
+
+  // Drain the current profile before changing the logical ring geometry. A
+  // worker that is still stuck after the bounded wait owns an old-root file
+  // handle, so changing profiles/capacity while it is alive is unsafe.
+  persistHistoryNow();
+  if (s_hist_flush_busy) {
+    if (!profile_mode_was_enabled) the_mesh.setProfileModeEnabled(false);
+    return false;
+  }
+
+  UIMessage* resized = nullptr;
+  int keep = _ui_msg_count;
+  if (keep > MAX_UI_MESSAGES_KID) keep = MAX_UI_MESSAGES_KID;
+  if (_ui_msg_cap != MAX_UI_MESSAGES_KID) {
+    const size_t bytes = sizeof(UIMessage) * (size_t)MAX_UI_MESSAGES_KID;
+    resized = (UIMessage*)heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM);
+    if (!resized) resized = (UIMessage*)heap_caps_malloc(bytes, MALLOC_CAP_8BIT);
+    if (!resized) {
+      if (!profile_mode_was_enabled) the_mesh.setProfileModeEnabled(false);
+      return false;
+    }
+    memset(resized, 0, bytes);
+    const int skip = _ui_msg_count - keep;
+    for (int i = 0; i < keep; ++i) {
+      const int slot = (_ui_msg_head - _ui_msg_count + skip + i + _ui_msg_cap) % _ui_msg_cap;
+      resized[i] = _ui_msgs[slot];
+    }
+  }
+
+  if (!touchPrefsSetProfilePins(parent_pin, kid_pin)) {
+    if (resized) heap_caps_free(resized);
+    if (!profile_mode_was_enabled) the_mesh.setProfileModeEnabled(false);
+    return false;
+  }
+
+  if (resized) {
+    UIMessage* previous = _ui_msgs;
+    _ui_msgs = resized;
+    _ui_msg_cap = MAX_UI_MESSAGES_KID;
+    _ui_msg_count = keep;
+    _ui_msg_head = keep % _ui_msg_cap;
+    if (previous) heap_caps_free(previous);
+    _thread_hist_dirty = true;
+
+    // Rewrite the active profile's segmented store from the retained 2,000 and
+    // purge segment files that only contained evicted older records.
+    uiHistoryStoreStateReset();
+    s_seg_store_ready = true;
+    s_seg_resync = true;
+    _msgs_dirty = true;
+    saveThreadsToStorage();
+    saveMsgsToStorage();
+  }
+
+  refreshThreadsFromMesh();
+  refreshThreadLists();
+  lockScreen();
+  return true;
+}
+
+bool UITask::disableKidMode() {
+  if (the_mesh.activeLocalProfile() != 0) return false;
+  if (!touchPrefsDisableKidMode()) return false;
+  the_mesh.setProfileModeEnabled(false);
+  _profile_pin_authorized = false;
+  return true;
+}
+
+bool UITask::unlockProfile(uint8_t profile) {
+  if (!touchPrefsGetKidMode() || profile > 1) return false;
+
+  if (profile != the_mesh.activeLocalProfile()) {
+    persistHistoryNow();
+    if (s_hist_flush_busy) return false;
+
+    hideKb();
+    if (g_lv.dm.detail_open) closeChatPanel(&g_lv.dm);
+    if (g_lv.ch.detail_open) closeChatPanel(&g_lv.ch);
+    for (int i = 0; i < 12 && anyPopupOpen(); ++i) popupRegistryDismissTop();
+    closeSettingsCategory();
+
+    if (!the_mesh.selectLocalProfile(profile)) return false;
+
+    uiDataSelectProfile(profile);
+    uiDataEnsureDirs();
+    uiHistoryStoreStateReset();
+
+    _msgcount = 0;
+    _ui_seq_next = 1;
+    _ui_msg_count = 0;
+    _ui_msg_head = 0;
+    _next_thread_seed = 0;
+    _active_thread_idx = -1;
+    _active_thread_is_channel = false;
+    _thread_scroll = 0;
+    _composer_mode = false;
+    _composer_char_idx = 0;
+    _composer_action_idx = 0;
+    _compose_buf[0] = '\0';
+    _active_dm_contact_set = false;
+    memset(_active_dm_contact_pub, 0, sizeof(_active_dm_contact_pub));
+    memset(_thread_msgs, 0, sizeof(_thread_msgs));
+    _thread_hist_dirty = true;
+    _threads_dirty = false;
+    _msgs_dirty = false;
+    _next_threads_flush_ms = 0;
+    _next_msgs_flush_ms = 0;
+    if (_ui_msgs) memset(_ui_msgs, 0, sizeof(UIMessage) * (size_t)_ui_msg_cap);
+    if (_ui_threads) {
+      memset(_ui_threads, 0, sizeof(UIThread) * MAX_UI_THREADS);
+      for (int i = 0; i < MAX_UI_THREADS; ++i) {
+        _ui_threads[i].mesh_contact_idx = -1;
+        _ui_threads[i].mesh_channel_slot = -1;
+      }
+    }
+    chatVirtReset(&g_lv.dm);
+    chatVirtReset(&g_lv.ch);
+    loadHistoryFromStorage();
+    refreshThreadsFromMesh();
+  }
+
+  const int replayed = the_mesh.replayEncryptedBacklog();
+  refreshThreadsFromMesh();
+  refreshThreadLists();
+  contactsListForceRefresh();
+  goToTab(HOME_TAB_INDEX);
+  refreshStatusLabels();
+  updateGlobalStatusBar();
+
+  _profile_pin_authorized = true;
+  unlockScreen();
+  char msg[64];
+  if (replayed > 0) {
+    snprintf(msg, sizeof(msg), profile == 0 ? "Parent profile - %d messages unlocked"
+                                             : "Kid profile - %d messages unlocked", replayed);
+  } else {
+    snprintf(msg, sizeof(msg), profile == 0 ? "Parent profile" : "Kid profile");
+  }
+  showAlert(msg, 1600);
+  return true;
+}
+
 void UITask::rebootDevice() {
   // Persist chat history synchronously before we reboot — the periodic
   // flush is rate-capped, so without this a reboot could drop the most
@@ -46125,6 +46699,7 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
       : (channel
       ? (parsed_sender[0] ? parsed_sender : (from_name && from_name[0] ? from_name : "node"))
       : (from_name && from_name[0] ? from_name : "node"));
+  const bool replaying_backlog = the_mesh.replayingEncryptedBacklog();
 
 #if defined(ESP32)
   // Blocked-by-name sender: a channel/room bot we have no pubkey to target via
@@ -46149,7 +46724,7 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
     const bool is_mention = channel && text && textMentionsMe(text);
     const bool is_dm = (g_last_event == UIEventType::contactMessage);   // private/direct message
     const uint8_t cmute = channel ? touchPrefsGetChannelMute(thread) : 0;
-    if (!isBuzzerQuiet() && !dndActive()) {   // master Sound switch / Do Not Disturb: either silences everything
+    if (!replaying_backlog && !isBuzzerQuiet() && !dndActive()) {   // unlock replay stays silent
       if (is_mention && touchPrefsGetSoundMentions() && !(cmute & TOUCH_CHMUTE_MEN)) uiPlaySlot(TOUCH_SND_MEN);
       else if (is_dm) { if (touchPrefsGetSoundDirect()) uiPlaySlot(TOUCH_SND_DM); }
       else if (touchPrefsGetSoundMessages() && !(cmute & TOUCH_CHMUTE_MSG))          uiPlaySlot(TOUCH_SND_MSG);
@@ -46191,7 +46766,7 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
 #if defined(HAS_TDECK_GT911)
   // Mirror incoming traffic into the terminal live feed (only while it's open).
   // Runs on the mesh thread (core 1, same as the UI loop) so the append is safe.
-  if (s_term_log_box) {
+  if (s_term_log_box && !replaying_backlog) {
     char line[200];
     const bool  has_snr = (meta_flags & MSG_META_HAS_RX);
     const float snr     = snr_q4 / 4.0f;
@@ -46322,6 +46897,12 @@ void UITask::notify(UIEventType t) {
   // even while a companion app is connected (issue #73). Flag it; UITask::loop does
   // the rebuild on the LVGL thread (refreshContactsList no-op's when nothing changed).
   if (t == UIEventType::newContactMessage) s_ct_contacts_dirty = true;
+  // Backlog replay still needs g_last_event so newMsg() routes each decoded packet
+  // into the correct DM/channel thread. Do not turn a profile unlock into as many
+  // as 2,000 LEDs, wakeups, toasts, and diagnostic lines, though.
+  if (the_mesh.replayingEncryptedBacklog() &&
+      (t == UIEventType::contactMessage || t == UIEventType::channelMessage ||
+       t == UIEventType::roomMessage)) return;
   const char* msg = nullptr;
   switch (t) {
     case UIEventType::contactMessage:    msg = TR("New DM");          break;
@@ -46671,7 +47252,7 @@ void UITask::loop() {
         lockscreenReveal();          // light the lock screen, don't unlock
         s_tb_hold_start = now;
       }
-      if (tb_pressed && s_tb_hold_start && !_screen_off) {
+      if (!touchPrefsGetKidMode() && tb_pressed && s_tb_hold_start && !_screen_off) {
         const unsigned long held = now - s_tb_hold_start;
         if (held >= kLockUnlockHoldMs) {
           unlockScreen();            // hides the "Unlocking…" popup too
@@ -46747,6 +47328,7 @@ void UITask::loop() {
         setCpuForScreen(false);
         _screen_off  = true;
         _manual_lock = true;  // touch cannot unlock until BOOT pressed again
+        if (touchPrefsGetKidMode()) the_mesh.lockEncryptedBacklog();
       }
     }
 #endif
@@ -46784,7 +47366,7 @@ void UITask::loop() {
     // The P4 has no unlock path (no button/overlay), so it must NEVER hard-lock, even if an old
     // pref left the flag set — it always takes the plain screen-off branch below, which wakes on
     // touch. (Guards the trap; the "Lock when screen off" toggle is also hidden on the P4.)
-    if (s_lock_on_screen_off && !_manual_lock) {
+    if ((s_lock_on_screen_off || touchPrefsGetKidMode()) && !_manual_lock) {
       // "Lock when screen off": idle dim also hard-locks, so the touchscreen is
       // inert until a deliberate unlock (trackball hold on the T-Deck, BOOT
       // press on the V4) — Tim's request to stop pocket-taps while dark. The
@@ -47072,11 +47654,14 @@ void UITask::loop() {
     // very next tick right after waking.
     bool any = false;
     bool saw_backspace = false;
+    int locked_keys[12];
+    int locked_key_count = 0;
     for (int kbi = 0; kbi < 12; ++kbi) {
       int k = pagerKeyboardReadKey();
       if (k <= 0) break;
       any = true;
       if (k == 0x08) saw_backspace = true;
+      locked_keys[locked_key_count++] = k;
     }
     // Discard any Alt tap / Alt+Shift / Alt+Backspace chord picked up while
     // idle-dimmed -- none of them may fire (NEXT / Caps toggle / jump Home)
@@ -47096,7 +47681,12 @@ void UITask::loop() {
     // while the screen was actually dark did nothing (reported bug) even
     // though holding it through to unlockScreen worked fine.
     if (g_lv.task->isManualLock()) {
-      if (saw_backspace) g_lv.task->lockscreenReveal();
+      if (touchPrefsGetKidMode()) {
+        if (any) g_lv.task->lockscreenReveal();
+        for (int i = 0; i < locked_key_count; ++i) lockscreenProfileKey(locked_keys[i]);
+      } else if (saw_backspace) {
+        g_lv.task->lockscreenReveal();
+      }
     } else if (any) {
       g_lv.task->wakeScreen();
     }
@@ -47133,6 +47723,9 @@ void UITask::loop() {
   }
   serviceLockscreen();
   serviceLockingCountdown(now);
+#endif
+#if !CAP_KEYBOARD
+  serviceLockscreen();
 #endif
 #if defined(ATTAKY_MESH_SERIES)
   // POWER_BTN (AW9523 @0x59 P07) toggles the panel. Polled before the screen-off

--- a/src/ui-touch/UITask.h
+++ b/src/ui-touch/UITask.h
@@ -30,6 +30,8 @@ enum class TouchUiScreen : uint8_t { Home = 0, ChatInbox = 1, Contacts = 2, Sett
 class UITask : public AbstractUITask {
 public:
   static const int MAX_UI_MESSAGES = 500;
+  /** Two-profile mode keeps the complete decrypted unlock backlog visible. */
+  static const int MAX_UI_MESSAGES_KID = 2000;
   /** Deep ring for devices whose chat history lives on an SD card (T-Deck with a
    *  card, Tanmatsu SD_MMC): 10x the internal-flash ring. Chosen at begin() into
    *  _ui_msg_cap; PSRAM cost ~5000 * sizeof(UIMessage) ≈ 1.3 MB (of 8 MB). */
@@ -123,6 +125,10 @@ private:
    * unlock from this state, only another BOOT button press. False = the
    * screen turned off from idle timeout, in which case touch wakes it. */
   bool _manual_lock;
+  // A normal unlock gesture is never sufficient while two-profile mode is
+  // enabled. This is armed only by a matching parent/kid PIN and consumed by
+  // unlockScreen().
+  bool _profile_pin_authorized = false;
   // Burn-in guard for the lit lock screen (#55): stamped when the lock screen goes from off->lit;
   // the loop dims a hard-locked LIT panel a bounded time after this, independent of the screen-timeout
   // setting and of held/ghost touches that keep re-revealing it. 0 = not currently lit-locked.
@@ -143,9 +149,9 @@ private:
   uint32_t _ui_seq_next = 1;
   int _ui_msg_count;
   int _ui_msg_head;
-  /** Runtime ring capacity: MAX_UI_MESSAGES_SD when history lives on an SD card,
-   *  else MAX_UI_MESSAGES. Fixed for the whole boot (chosen before the PSRAM
-   *  alloc in begin()); the loader linearizes files written under another cap. */
+  /** Runtime ring capacity: 2000 in two-profile mode, MAX_UI_MESSAGES_SD when
+   *  normal history lives on an SD card, else MAX_UI_MESSAGES. The loader
+   *  linearizes files written under another cap. */
   int _ui_msg_cap = MAX_UI_MESSAGES;
   /** "Does this thread have any stored message?", answered in O(1).
    *
@@ -364,7 +370,7 @@ public:
     if (idx < 0 || idx >= MAX_UI_THREADS || !_ui_threads[idx].used || !_ui_threads[idx].channel) return -1;
     return _ui_threads[idx].mesh_channel_slot;
   }
-  /** Message-ring capacity this boot (500, or 5000 with SD-backed history). */
+  /** Message-ring capacity this boot (500, 2000 in profile mode, or 5000 on SD). */
   int  msgCap() const { return _ui_msg_cap; }
   /** DM thread's full contact pubkey (32 B) — for the chat sheet's "Reset path".
    *  False for channels, unused slots, or a thread with no pubkey mapping yet. */
@@ -516,6 +522,12 @@ public:
   void lockscreenReveal();
   /** Release a manual lock: hide the lock screen and turn the panel back on. */
   void unlockScreen();
+  /** Configure two PIN-selected local profiles and enter the PIN lock. */
+  bool enableKidMode(const char* parent_pin, const char* kid_pin);
+  /** Disable two-profile mode. Only profile 0 is permitted to call this. */
+  bool disableKidMode();
+  /** Switch/load the profile selected by a verified PIN, then unlock it. */
+  bool unlockProfile(uint8_t profile);
   /** True while the panel backlight is off (idle-dimmed or manually locked). */
   bool isScreenOff() const { return _screen_off; }
   bool isManualLocked() const { return _manual_lock; }   // hard screen lock engaged

--- a/src/ui-touch/device_caps.h
+++ b/src/ui-touch/device_caps.h
@@ -140,6 +140,11 @@
   #define CAP_LOCK_SCREEN  0
 #endif
 
+// Every touch-UI target has either a touchscreen or a physical keyboard, so it
+// can present the profile PIN gate even when the legacy wallpaper lock screen
+// was not exposed for that board.
+#define CAP_PROFILE_PIN 1
+
 // Persisted, restart-to-apply UI-size selector. Large-screen boards already
 // expose it; the Pager adds font-only presets because its 480x222 viewport is
 // wide enough for larger type but too short for global geometry scaling.


### PR DESCRIPTION
Different PIN codes open different local MeshCore profiles, keeping the parent and kid identities, contacts, channels, settings, and messages separate.

It keeps a 2,000-entry encrypted RX log while locked, then decodes what the selected profile has keys for when its PIN is entered.

Tested on T-Deck and both T-Pager radio builds.
