### PR TITLE
fix(touch): stabilize virtualized chat teardown and render scheduling

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -4117,6 +4117,29 @@ static lv_obj_t* s_nav_prev_scr = nullptr;
 static uint32_t  s_nav_prev_sig = 0xFFFFFFFFu;
 static void navMarkDirty() { s_nav_dirty = true; }
 
+// A virtualized chat rebuild destroys the currently-materialized row objects.
+// Detach the navigation group while every object (and every descendant label
+// remembered by navInvertText) is still alive. Letting lv_obj_del() remove the
+// focused row itself is unsafe: LVGL has already torn down that row's styles and
+// animations when lv_group_remove_obj() auto-focuses a survivor and calls
+// navFocusCb(), which then tries to restore styles on the half-destructed row.
+// The caller must rebuild the group after recreating the object tree.
+static bool navDetachBeforeTreeMutation() {
+  if (!s_nav_group) return false;
+  if (s_nav_styled) {
+    navUnstyle(s_nav_styled);
+    s_nav_styled = nullptr;
+  } else {
+    navRestoreText();
+  }
+  lv_group_remove_all_objs(s_nav_group);
+  s_nav_first = s_nav_last = nullptr;
+  s_nav_count = 0;
+  for (int i = 0; i < kNavMax; ++i) s_nav_objs[i] = nullptr;
+  navMarkDirty();
+  return true;
+}
+
 // Repopulate the focus group when the visible screen actually changes (screen
 // swap, modal open/close, or a within-screen content rebuild). A 2-level
 // child-count signature avoids reshuffling focus during steady-state navigation.
@@ -31169,18 +31192,16 @@ static void chatVirtFreeOffsets() {
 
 #if defined(TLORA_PAGER)
 // Encoder-nav focus survival across the virtualized re-render. The render
-// deletes and recreates every bubble row — LVGL hands focus of a deleted
-// object to the next surviving group entry (the chat header/composer once
-// every bubble is gone), which is how focus "fell out" of the message list
-// mid-history on this no-touch board. The pending logical index below is the
-// message the encoder is steering toward: chatVirtRenderWindow re-aims focus
-// at the matching recreated row via the existing one-shot s_nav_focus_hint
-// rebuild mechanism, and pagerEncoderChatEdgeScroll both sets it (edge detent
-// = neighbor index) and folds further detents into it while a render is in
-// flight — fast turning otherwise stepped focus out from the transiently
-// wrong focus position before the load landed. -1 = idle. The timestamp
-// expires a stale pending target (see the clamp) so a render that never
-// fires can't wedge encoder nav.
+// deletes and recreates every bubble row, so a row pointer cannot preserve
+// focus across the rebuild. The pending logical index below is the message the
+// encoder is steering toward: chatVirtRenderWindow safely detaches the group
+// before destruction, then re-aims focus at the matching recreated row via the
+// existing one-shot s_nav_focus_hint mechanism. pagerEncoderChatEdgeScroll sets
+// the target (an edge detent selects the neighboring logical index) and folds
+// further detents into it while a render is in flight — fast turning otherwise
+// stepped focus out from the transiently wrong focus position before the load
+// landed. -1 = idle. The timestamp expires a stale pending target (see the
+// clamp) so a render that never fires can't wedge encoder nav.
 static int      s_pager_chat_focus_i  = -1;
 static uint32_t s_pager_chat_focus_ms = 0;
 #endif
@@ -31593,15 +31614,37 @@ static void chatVirtClearBubbleWidgets(LvChatPanel* p) {
 }
 
 // Sync purge — only call from lv_async_call / timer context, not indev handlers.
-static void chatVirtPurgeMsgsChildrenSync(LvChatPanel* p) {
-  if (!p || !p->msgs) return;
+// Returns true when keypad navigation was detached and must be rebuilt after the
+// replacement tree (normally a placeholder) has been created.
+static bool chatVirtPurgeMsgsChildrenSync(LvChatPanel* p) {
+  if (!p || !p->msgs) return false;
   chatVirtCancelRenderTimer();
+#if CAP_KEYPAD_NAV
+  const bool nav_detached = navDetachBeforeTreeMutation();
+#else
+  constexpr bool nav_detached = false;
+#endif
+  chatVirtResetInputForMsgs(p);
+  chatVirtBeforeMassDelete();
   for (int i = static_cast<int>(lv_obj_get_child_cnt(p->msgs)) - 1; i >= 0; --i) {
     lv_obj_t* ch = lv_obj_get_child(p->msgs, i);
     if (ch) lv_obj_del(ch);
   }
   s_chat_virt.spacer  = nullptr;
   s_chat_virt.divider = nullptr;
+  return nav_detached;
+}
+
+static void chatVirtResetToPlaceholder(LvChatPanel& p, const char* text) {
+  lv_indev_reset(nullptr, nullptr);
+  chatVirtReset(&p);
+  const bool nav_detached = chatVirtPurgeMsgsChildrenSync(&p);
+  chatDetailShowPlaceholder(p, text);
+#if CAP_KEYPAD_NAV
+  if (nav_detached) navMaybeRebuild();
+#else
+  (void)nav_detached;
+#endif
 }
 
 static void chatVirtEnsureSpacer(LvChatPanel* p, lv_coord_t total_h) {
@@ -32396,20 +32439,26 @@ static void chatVirtRenderWindow(LvChatPanel* p, lv_coord_t scroll_y, lv_coord_t
     chatVirtLogScrollTransition(p, old_i0, old_i1, i0, i1);
 #endif
 
+#if CAP_KEYPAD_NAV
+  // Preserve focus without letting lv_obj_del() remove a focused group member.
+  // Rows are recreated, so remember them by logical index; header/composer
+  // controls survive the rebuild and can be retained by pointer.
+  int refocus_i = -1;
 #if defined(TLORA_PAGER)
-  // Capture where encoder focus should land after the rebuild BEFORE the clear
-  // deletes the focused row (see s_pager_chat_focus_i above). An explicit
-  // pending target from the encoder clamp wins; otherwise preserve the row
-  // that has focus right now (covers renders the encoder didn't cause, e.g. an
-  // incoming message re-render yanking focus off the list mid-read).
-  int refocus_i = s_pager_chat_focus_i;
-  if (refocus_i < 0 && s_nav_group) {
+  // An explicit pending target from the Pager encoder edge clamp wins.
+  refocus_i = s_pager_chat_focus_i;
+#endif
+  lv_obj_t* stable_focus = nullptr;
+  if (s_nav_group) {
     lv_obj_t* foc = lv_group_get_focused(s_nav_group);
     if (foc && lv_obj_get_parent(foc) == p->msgs) {
       const intptr_t ud = reinterpret_cast<intptr_t>(lv_obj_get_user_data(foc));
-      if (ud >= 0) refocus_i = (int)ud;   // rows carry their logical index; dividers are negative
+      if (refocus_i < 0 && ud >= 0) refocus_i = (int)ud;
+    } else if (foc && lv_obj_is_valid(foc)) {
+      stable_focus = foc;
     }
   }
+  const bool nav_detached = navDetachBeforeTreeMutation();
 #endif
 
   const lv_coord_t saved_scroll_y = scroll_y;
@@ -32440,14 +32489,10 @@ static void chatVirtRenderWindow(LvChatPanel* p, lv_coord_t scroll_y, lv_coord_t
   chatVirtSyncBubblePositions(p);
   CHAT_SCROLL_TRACE_DO(chatVirtCheckStoreEdges(p));
 
-#if defined(TLORA_PAGER)
-  // Re-aim focus at the recreated row for the captured/pending logical index
-  // (clamped into the freshly materialized window — a fast multi-detent target
-  // can briefly run past it; landing on the window edge keeps the traversal
-  // moving and the next render catches up). Uses the one-shot
-  // s_nav_focus_hint: the recreated rows change the nav tree signature, so
-  // navMaybeRebuild fires on the next pump and consumes the hint — same
-  // mechanism settings toggles use to hold focus across their own rebuilds.
+#if CAP_KEYPAD_NAV
+  // Re-aim focus at the recreated row for the captured logical index. A fast
+  // Pager encoder target can briefly run past the materialized window, so clamp
+  // it to the nearest fresh row and let the next reflow continue from there.
   if (refocus_i >= 0) {
     if (refocus_i < i0) refocus_i = i0;
     if (refocus_i > i1) refocus_i = i1;
@@ -32460,18 +32505,17 @@ static void chatVirtRenderWindow(LvChatPanel* p, lv_coord_t scroll_y, lv_coord_t
         break;
       }
     }
+#if defined(TLORA_PAGER)
     s_pager_chat_focus_i = -1;   // consumed (whether or not the row was found)
-    // Land the re-aim NOW, not on the next loop-tick nav pump: deleting the
-    // focused row above already made LVGL auto-focus a survivor (the header
-    // gear / a bottom element), and this function runs in an lv_async_call —
-    // LVGL paints right after it returns, so waiting for the pump let that
-    // wrong focus reach the glass for a frame or two (reported: focus visibly
-    // hops out of the list and back on every edge load). A forced synchronous
-    // rebuild consumes the hint before the next paint, so the hop never shows.
-    if (s_nav_focus_hint) {
-      navMarkDirty();
-      navMaybeRebuild();
-    }
+#endif
+  } else if (stable_focus && lv_obj_is_valid(stable_focus)) {
+    s_nav_focus_hint = stable_focus;
+  }
+  // The group was deliberately empty throughout destruction. Recollect once,
+  // consume the focus hint, and land the final focus before LVGL paints.
+  if (nav_detached) {
+    navMarkDirty();
+    navMaybeRebuild();
   }
 #endif
 }
@@ -32628,16 +32672,16 @@ static void refreshChatDetail(LvChatPanel& p) {
 
   if (!g_lv.task->hasActiveThread() ||
       g_lv.task->activeThreadIsChannel() != p.channel_mode) {
-    lv_indev_reset(nullptr, nullptr);
-    chatVirtReset(&p);
-    lv_obj_clean(p.msgs);
-    chatDetailShowPlaceholder(p, "No thread selected.\n\nTap a chat to open it.");
+    chatVirtResetToPlaceholder(p, "No thread selected.\n\nTap a chat to open it.");
     return;
   }
   if (p.detail_open) g_lv.task->markActiveThreadRead();
 
   chatVirtEnsureMsgIdx();
-  if (!s_chat_msg_idx || s_chat_msg_idx_cap <= 0) { chatDetailShowPlaceholder(p, "Low memory"); return; }
+  if (!s_chat_msg_idx || s_chat_msg_idx_cap <= 0) {
+    chatVirtResetToPlaceholder(p, "Low memory");
+    return;
+  }
 
   const int n = g_lv.task->getActiveThreadMessageCount(s_chat_msg_idx, s_chat_msg_idx_cap, false);
 #if TRACE_MESSAGE_SCROLL_ACTIVITY
@@ -32651,10 +32695,7 @@ static void refreshChatDetail(LvChatPanel& p) {
   }
 #endif
   if (n <= 0) {
-    lv_indev_reset(nullptr, nullptr);
-    chatVirtReset(&p);
-    lv_obj_clean(p.msgs);
-    chatDetailShowPlaceholder(p, "No messages yet.\nSay hello!");
+    chatVirtResetToPlaceholder(p, "No messages yet.\nSay hello!");
     return;
   }
 
@@ -32680,16 +32721,21 @@ static void refreshChatDetail(LvChatPanel& p) {
                            !s_chat_virt.offsets || ring_changed ||
                            s_chat_virt.compact_chat != compact_chat;
   const bool divider_rebuild = !need_layout && divider_i >= 0 && s_chat_virt.divider_y < 0;
-  if (opening || need_layout || divider_rebuild)
-    chatVirtPurgeMsgsChildrenSync(&p);
-  if (opening || (need_layout && s_chat_virt.panel != &p))
+  const bool changing_panel = s_chat_virt.panel != &p;
+  if (opening || need_layout || divider_rebuild) chatVirtCancelRenderTimer();
+  if (opening || changing_panel) {
+    // The next protected render clears every stale child. Drop these aliases so
+    // it cannot preserve/reuse a spacer owned by a previous panel or thread.
+    s_chat_virt.spacer = nullptr;
+    s_chat_virt.divider = nullptr;
     s_chat_virt.scroll_virt_valid = false;
+  }
   if (need_layout) {
     lv_indev_reset(nullptr, nullptr);
     s_chat_virt.last_i0 = -1;
     s_chat_virt.last_i1 = -1;
     if (!chatVirtRebuildLayout(&p, n, divider_i)) {
-      chatDetailShowPlaceholder(p, "Low memory");
+      chatVirtResetToPlaceholder(p, "Low memory");
       return;
     }
   } else {
@@ -32699,7 +32745,7 @@ static void refreshChatDetail(LvChatPanel& p) {
       s_chat_virt.last_i0 = -1;
       s_chat_virt.last_i1 = -1;
       if (!chatVirtRebuildLayout(&p, n, divider_i)) {
-        chatDetailShowPlaceholder(p, "Low memory");
+        chatVirtResetToPlaceholder(p, "Low memory");
         return;
       }
     }

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -31160,11 +31160,13 @@ static bool chatVirtNeedReflow(int new_i0, int new_i1) {
 }
 
 static void chatVirtCancelRenderTimer() {
-  if (s_chat_virt_render_timer) {
-    lv_timer_del(s_chat_virt_render_timer);
-    s_chat_virt_render_timer = nullptr;
-  }
   s_chat_virt_render_panel = nullptr;
+  // Keep one timer allocation for the lifetime of the UI.  This path is hit
+  // repeatedly while a fast scroll crosses virtual-window boundaries. Two
+  // matching dumps reached lv_timer_exec through an invalid callback (#251), so
+  // do not churn this timer's list node in the reproducing path. Pausing keeps
+  // its callback allocation stable while still cancelling the pending work.
+  if (s_chat_virt_render_timer) lv_timer_pause(s_chat_virt_render_timer);
 }
 
 static void chatVirtResetInputForMsgs(LvChatPanel* p) {
@@ -32552,16 +32554,18 @@ static void chatVirtRenderAsyncCb(void*) {
 
 static void chatVirtRenderTimerCb(lv_timer_t* t) {
   LvChatPanel* p = s_chat_virt_render_panel;
-  s_chat_virt_render_timer = nullptr;
-  s_chat_virt_render_panel = nullptr;
-  lv_timer_del(t);
-  if (!p || !p->detail_open || s_chat_virt.panel != p || s_chat_virt.n <= 0) return;
-  if (chatVirtIndevStillScrolling(p)) {
-    s_chat_virt_render_panel = p;
-    s_chat_virt_render_timer = lv_timer_create(chatVirtRenderTimerCb, 16, nullptr);
-    lv_timer_set_repeat_count(s_chat_virt_render_timer, 1);
+  if (!p || !p->detail_open || s_chat_virt.panel != p || s_chat_virt.n <= 0) {
+    s_chat_virt_render_panel = nullptr;
+    lv_timer_pause(t);
     return;
   }
+  if (chatVirtIndevStillScrolling(p)) {
+    lv_timer_set_period(t, 16);
+    lv_timer_reset(t);
+    return;
+  }
+  s_chat_virt_render_panel = nullptr;
+  lv_timer_pause(t);
   if (s_chat_virt_render_async_busy) return;
   s_chat_virt_render_async_panel = p;
   s_chat_virt_render_async_busy  = true;
@@ -32575,13 +32579,18 @@ static void chatVirtRenderTimerCb(lv_timer_t* t) {
 
 static void chatVirtScheduleRender(LvChatPanel* p) {
   if (!p || !p->detail_open || s_chat_virt.panel != p || s_chat_virt.n <= 0) return;
-  if (s_chat_virt_render_timer) {
-    lv_timer_reset(s_chat_virt_render_timer);
-    return;
-  }
   s_chat_virt_render_panel = p;
-  s_chat_virt_render_timer = lv_timer_create(chatVirtRenderTimerCb, 1, nullptr);
-  lv_timer_set_repeat_count(s_chat_virt_render_timer, 1);
+  if (!s_chat_virt_render_timer) {
+    s_chat_virt_render_timer = lv_timer_create(chatVirtRenderTimerCb, 1, nullptr);
+    if (!s_chat_virt_render_timer) {
+      s_chat_virt_render_panel = nullptr;
+      return;
+    }
+  } else {
+    lv_timer_set_period(s_chat_virt_render_timer, 1);
+    lv_timer_reset(s_chat_virt_render_timer);
+    lv_timer_resume(s_chat_virt_render_timer);
+  }
 }
 
 static void chatVirtOnScrollEnd(LvChatPanel* p) {


### PR DESCRIPTION
Closes #233. Related: #251.

## Problem

The T-Pager can panic while rapidly scrolling a virtualized chat across message-window boundaries. The matching dumps all fail in LVGL through an invalid callback:

- the original #233 dumps reached corrupted LVGL animation callbacks;
- the beta_60 dump in #251 reaches `lv_timer_exec -> lv_timer_handler` through callback `0x00020000`;
- a fresh Pager dump from the first revision of this PR reaches the same timer call site through callback `0x00000066`.

The fresh dump matters: it was produced by an integration build that already contained the focus-detach change below. That proves the first diagnosis and fix were incomplete. The failure is still not rooted in SD, LoRa, Wi-Fi, BLE, watchdog expiry, or task-stack exhaustion; it is an invalid LVGL callback reached from `loopTask` while scrolling a chat.

Raw dumps remain local because a core dump can contain arbitrary RAM and private identity material. Matching firmware ELFs, hashes, registers, and symbolized call chains are preserved.

## Application-level lifetime hazards

The chat virtualizer had two independent high-churn lifetime paths:

1. **Focused row teardown.** A materialized Pager row could remain in the LVGL navigation group while the virtualizer synchronously deleted it. LVGL could auto-refocus another object during the partially-complete teardown, re-entering application focus styling against objects being destroyed.
2. **Render timer churn.** Every virtual-window boundary scheduled a one-shot chat render timer. Its callback deleted its own LVGL timer node, and while kinetic scrolling continued it immediately allocated another timer. Fast scrolling repeatedly exercised that delete/recreate path in the same timer-list walk where #251 and the new dump fail.

The second dump does not expose heap contents, so this PR deliberately does not claim which individual freed allocation held the bad callback. It removes both application-owned lifetime hazards without patching LVGL.

## Implementation

- Capture the focused logical message index, or a stable non-row target, before a virtualized reflow.
- Restore application focus styling while referenced objects and descendant labels are still alive.
- Empty the LVGL navigation group before deleting rows, then recreate the visible window, recollect navigation once, and restore focus before the next paint.
- Route empty-thread and low-memory replacements through the same protected teardown.
- Stop pre-deleting rows during chat refreshes; replace stale rows only inside the protected virtualizer pass.
- Allocate the chat render timer once, pause it to cancel or idle it, and resume/reset that same timer for later boundaries. It no longer deletes and recreates its LVGL list node during scrolling.
- Keep the existing deferred `lv_async_call` for tree mutation after display refresh.
- Keep existing touch/encoder behavior. No LVGL or dependency patch is required.

## Validation gate

- [x] Rebased on current `main` after beta_61.
- [x] Build `tlora_pager_sx1262_companion_radio_touch`.
- [x] Build `LilyGo_TDeck_companion_radio_touch` as a second keypad-navigation target.
- [x] Build an integration containing only beta_61, #198, and this PR.
- [x] Flash app only at `0x10000`, verify the on-device digest, and boot through `[BOOT] ui ready`.
- [ ] Confirm encoder focus stays inside long chats across virtualized window boundaries.
- [x] Confirm composer, header actions, message actions, and back navigation retain correct focus.
- [x] Exercise compact and full chat rows across Pager UI-size presets.
- [x] Burn in sustained rapid up/down scrolling with incoming messages.
- [x] Repeat with normal SD-backed history and radio activity.
- [x] Confirm no new crash report is generated.

## Current state

PR head `cbdd6d2` is installed as part of local integration `d403ff3` on the T-Pager and boots cleanly. The PR remains a draft until the on-device scrolling and burn-in checks above pass.
