### PR TITLE
ThinkNode M9 + Heltec V4-R8: 2026-08 audit passes (nav soft-locks, storage, deep sleep, Spectrum at spec)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -27,8 +27,9 @@ USB) and the [GitHub releases](https://github.com/ALLFATHER-BV/wadamesh/releases
   microSD for all persistent data. Ships through the Tanmatsu launcher store,
   updates arrive as store updates.
 - **ThinkNode M9**: keyboard plus d-pad navigation (no touch), same feature set
-  as the other boards where the hardware allows. New in beta_38; expect rough
-  edges and report them.
+  as the other boards where the hardware allows. Every key and mode is covered
+  in the [keyboard & d-pad guide](THINKNODE_M9_SHORTCUTS.md). New in beta_38;
+  report anything that feels off.
 - **RAK WisMesh Tap V2**: newest port, touch-driven. The browser-flash path is
   fresh; if the flasher cannot open the serial port, put the board in download
   mode manually and retry, and please report it.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ per-board status.
 - LilyGo T-Deck / T-Deck Plus — env `LilyGo_TDeck_companion_radio_touch` (stable)
 - Heltec V4 + TFT + CHSC6x touch — env `heltec_v4_tft_companion_radio_usb_tcp_touch` (stable)
 - Tanmatsu (ESP32-P4) — built from `tanmatsu/` (ESP-IDF), ships via the Tanmatsu app store
-- Elecrow ThinkNode M9 — env `ThinkNode_M9_companion_radio_touch` (beta)
+- Elecrow ThinkNode M9 — env `ThinkNode_M9_companion_radio_touch` (beta) — [keyboard & d-pad guide](THINKNODE_M9_SHORTCUTS.md)
 - RAK WisMesh Tap V2 (RAK3312) — env `rak_tap_v2_companion_radio_touch` (beta)
 
 ## Architecture

--- a/THINKNODE_M9_SHORTCUTS.md
+++ b/THINKNODE_M9_SHORTCUTS.md
@@ -1,0 +1,97 @@
+# ThinkNode M9: Keyboard & D-pad Guide
+
+The Elecrow ThinkNode M9 has **no touchscreen** — every screen, every setting,
+and every chat is driven by the d-pad, the dedicated function keys, and the
+QWERTY keyboard. If you're coming from the T-Deck or Heltec V4 (touch-first),
+this page is the five-minute tour that makes the board feel native.
+
+## The inputs
+
+- **D-pad** — four arrows around a centre button (**OK**). Arrows move the
+  on-screen focus highlight; OK activates whatever is focused. **Holding OK**
+  is the board's long-press: it fires the held item's long-press action (a
+  chat message's context menu, the SD row's hold-to-format) and unlocks the
+  lock screen.
+- **Function row** — dedicated keys for Chats, Home, Mentions, Advert, Map,
+  Back, Mic and Ctrl (see the table below).
+- **QWERTY keyboard** — the keyboard controller resolves Shift/symbol layers
+  itself, so keys always deliver their final character. It latches one key at
+  a time, which is why there are no chords on this board — long-press carries
+  the second layer instead. Start typing in a chat and the composer focuses
+  itself; any key wakes the screen from idle.
+
+## The one rule: Back closes what you see
+
+**Back** always closes the *top* layer, one per press: map pan mode → an open
+dropdown → the power menu → the Control Center → a full-screen app → a dialog
+→ any popup → an open chat → back out of the page. Nothing ever closes
+invisibly beneath something else. The only exception is deliberate: progress
+overlays (SD format, bulk delete) block all keys until the operation finishes.
+
+## Function keys
+
+| Key | Press | Hold |
+|---|---|---|
+| **MSG** | Jump to the Chats tab (closes an open app first) | — |
+| **HOME** | Peel one layer off an open app; on the Home tab, toggle the app drawer; otherwise jump Home | — |
+| **@ (Mentions)** | Open the Mentions screen | — |
+| **ADV** | Open the Send Advert page | **Toggle GPS on/off** |
+| **MAP** | Jump to the Map tab — press again *on* the map to toggle pan mode | — |
+| **BACK** | Close the top layer (see above) | — |
+| **CTRL** | Open the Control Center (quick toggles, incl. the keyboard light: off / on / auto) | — |
+| **MIC** | Nothing yet — deliberately reserved | — |
+| **OK / Enter** | Activate the focused item; send a message; run a terminal command; newline in the editor | **Long-press the focused item / unlock the lock screen** |
+
+## Map pan mode
+
+On the Map tab, press **MAP** again: the arrows now pan the map instead of
+moving focus. **MAP** or **BACK** exits. Pan mode switches itself off whenever
+you leave the map or anything opens over it, so a stale pan can never eat a
+key press later. Auto-follow pauses while you pan and resumes when you exit.
+Entering the map fresh always starts in normal navigation.
+
+## Typing & editing
+
+Inside a text field the left/right arrows move the caret — and when the caret
+is already at the edge of the text, the same press steps focus *out* of the
+field, so you're never stuck. Enter sends (toggleable under Settings), Back
+leaves the field. In the Terminal, Enter runs the command; in the text editor
+it inserts a newline.
+
+## Lock screen
+
+**Hold OK** to unlock — the keyboard's hardware long-press stands in for the
+hold-to-unlock other boards do by touch. With "Flash on new message" enabled,
+an incoming message wakes (or lock-reveals) the screen and pulses the keyboard
+backlight.
+
+## Inside apps
+
+Store apps (Snake and friends) get the d-pad natively: arrows steer, OK taps
+the centre — start, steer, and tap-to-retry all work. Display-only apps
+(Airtime, RF Monitor) keep normal navigation: arrows move between the app's
+own buttons or scroll the feed. **Back and Home always escape an app** — no
+app can trap the keys, even while the screen is locked.
+
+## Recent improvements (beta_66 branch)
+
+If you last used the M9 on an earlier beta, the notable navigation changes:
+
+- **Back restored and made consistent** — it had regressed to doing nothing
+  outside text fields, and could close hidden popups beneath the Control
+  Center. Both fixed; the close-what-you-see rule above now holds everywhere.
+- **Apps can't strand you** — opening Advert/Mentions over a running app used
+  to orphan it with no key path back; app permission dialogs are now
+  answerable with the d-pad.
+- **Map pan cleans up after itself** (see above — it used to leak across tab
+  jumps).
+- **Keyboard light "On" applies at boot**, not after the first dim cycle.
+- **Terminal chat shows incoming replies**, not just your own sent lines.
+- **GPS works from a cold boot** — the toggle (and ADV-hold) no longer depends
+  on a boot-time detection race.
+- **Spectrum analyzer** sweeps roughly twice as fast, survives read glitches
+  without flattening the trace, and waits for an in-flight transmission
+  instead of cutting it off when opened mid-send.
+
+The engineering record behind these lives in
+[`variants/thinknode_m9/M9_PORT.md`](variants/thinknode_m9/M9_PORT.md).

--- a/include/SdFastClock.h
+++ b/include/SdFastClock.h
@@ -1,0 +1,94 @@
+#pragma once
+// Post-mount micro-SD operating-clock raise (perf pass 2026-08-20; Heltec V4-R8 first).
+//
+// Every SPI-SD board mounts the card with a conservative ladder that tops out at 4 MHz,
+// and SD.begin()'s clock is the operating clock for the whole session — so the card that
+// is the PRIMARY store on the R8 (contacts, chat history, sync log, file manager) ran at
+// ~400 KB/s on traces that carry the display at 80 MHz. Standard SD bring-up is "initialise
+// slow, then raise": once the 4 MHz mount has proved the card, re-begin at SD_SPI_FAST_HZ
+// and READ-VERIFY it — a probe file's first 512 bytes are read at the proven clock first
+// and compared byte-for-byte after the raise (SPI-mode SD has no data CRC by default, so a
+// bare "mount succeeded" would not catch a marginal clock). Any mismatch or failure drops
+// straight back to the clock that just worked. Boards that do not define SD_SPI_FAST_HZ
+// (or set it <= 4 MHz) get a no-op — nothing changes for the T-Deck/M9/Pager ladders.
+//
+// Returns the operating clock after the call (cur_hz if the raise was refused or failed),
+// or 0 if the card could not be re-mounted at all (the caller treats that as unmounted).
+
+#include <Arduino.h>
+
+#if defined(ESP32)
+#include <SD.h>
+#include <SPI.h>
+#include <string.h>
+
+#ifndef SD_SPI_FAST_HZ
+  #define SD_SPI_FAST_HZ 0
+#endif
+
+static inline uint32_t sdTryFastClock(uint8_t cs_pin, SPIClass& spi, uint32_t cur_hz, const char* tag) {
+#if SD_SPI_FAST_HZ > 4000000
+  if (cur_hz == 0 || cur_hz >= (uint32_t)SD_SPI_FAST_HZ) return cur_hz;
+
+  // 1) Pick a probe file and capture its head at the proven clock.
+  char    probe_path[96] = {0};
+  uint8_t ref[512];
+  size_t  ref_len = 0;
+  {
+    File root = SD.open("/");
+    if (root && root.isDirectory()) {
+      for (int i = 0; i < 16; ++i) {
+        File e = root.openNextFile();
+        if (!e) break;
+        if (!e.isDirectory() && e.size() > 0 && e.path() && strlen(e.path()) < sizeof probe_path) {
+          strlcpy(probe_path, e.path(), sizeof probe_path);
+          ref_len = e.size() < sizeof ref ? e.size() : sizeof ref;
+          if (e.read(ref, ref_len) != ref_len) { probe_path[0] = 0; ref_len = 0; }
+          e.close();
+          break;
+        }
+        e.close();
+      }
+      root.close();
+    }
+  }
+
+  // 2) Re-begin at the fast clock.
+  SD.end();
+  delay(20);
+  bool ok = SD.begin(cs_pin, spi, SD_SPI_FAST_HZ, "/sd", 6) && SD.cardType() != CARD_NONE;
+
+  // 3) Verify: directory walk always; byte-compare of the probe head when we have one.
+  if (ok) {
+    File root = SD.open("/");
+    ok = root && root.isDirectory();
+    if (ok) { File e = root.openNextFile(); if (e) e.close(); root.close(); }
+  }
+  if (ok && probe_path[0]) {
+    uint8_t now[512];
+    File p = SD.open(probe_path, FILE_READ);
+    ok = p && p.read(now, ref_len) == ref_len && memcmp(now, ref, ref_len) == 0;
+    if (p) p.close();
+  }
+  if (ok) {
+    Serial.printf("[%s] SD clock %lu -> %lu Hz (%s)\n", tag, (unsigned long)cur_hz,
+                  (unsigned long)SD_SPI_FAST_HZ, probe_path[0] ? "read-verified" : "dir-verified, no probe file");
+    return (uint32_t)SD_SPI_FAST_HZ;
+  }
+
+  // 4) Fall back to the clock that just worked.
+  Serial.printf("[%s] SD %lu Hz verify FAILED; back to %lu Hz\n", tag,
+                (unsigned long)SD_SPI_FAST_HZ, (unsigned long)cur_hz);
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    SD.end();
+    delay(attempt == 0 ? 60 : 150);
+    if (SD.begin(cs_pin, spi, cur_hz, "/sd", 6) && SD.cardType() != CARD_NONE) return cur_hz;
+  }
+  Serial.printf("[%s] SD remount at %lu Hz failed\n", tag, (unsigned long)cur_hz);
+  return 0;
+#else
+  (void)cs_pin; (void)spi; (void)tag;
+  return cur_hz;
+#endif
+}
+#endif  // ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -257,6 +257,16 @@ build_flags =
   -D PIN_VEXT_EN_ACTIVE=LOW
   -D PIN_GPS_EN=42
   -D PIN_GPS_RESET=-1
+  ; GPS pins probed on real hardware 2026-08-19: with EN active-LOW asserted
+  ; the module streams NMEA on GPIO39 (~6.9k edges/3 s); GPIO38 is silent.
+  ; NAMING TRAP: EnvironmentSensorManager does Serial1.setPins(PIN_GPS_TX,
+  ; PIN_GPS_RX) and Arduino's first setPins arg is OUR RX — i.e. the
+  ; PIN_GPS_TX macro is the pin we RECEIVE on (module's TX). So the module's
+  ; TX=GPIO39 belongs in PIN_GPS_TX, matching the inherited plain-V4 values.
+  ; Restated explicitly here (with this note) so nobody "fixes" the apparent
+  ; swap again. EN polarity active-LOW also hardware-confirmed.
+  -D PIN_GPS_RX=38
+  -D PIN_GPS_TX=39
   -D PIN_ADC_CTRL=-1
   -D ADC_MULTIPLIER=5.07
   ; TFT on hardware SPI (LovyanGFX), shared with the micro-SD
@@ -1159,7 +1169,11 @@ build_flags =
   ; app Serial logs go to a ttyACM* port this board doesn't expose and
   ; appear completely silent.
   -D ARDUINO_USB_CDC_ON_BOOT=0
-  -D PIN_USER_BTN=0
+  ; PIN_USER_BTN deliberately NOT defined: the M9 has no user/BOOT button at
+  ; all (schematic-confirmed — only a power-cut slider and a reset button,
+  ; neither a GPIO). Defining it as 0 put UITask's screen-lock poll on a
+  ; floating strapping pin (phantom-lock risk) and armed the Power-off menu's
+  ; deep-sleep wake on a button that can never be pressed.
   -D RADIO_CLASS=CustomLR1110
   -D WRAPPER_CLASS=CustomLR1110Wrapper
   -D LORA_TX_POWER=22
@@ -1173,10 +1187,8 @@ build_flags =
   ; schematic's "VTCXO rail" feeding Y1 is evidently the LR1110's own
   ; TCXO-supply output, so the chip must drive it.
   -D LR11X0_DIO3_TCXO_VOLTAGE=3.3
-  ; Bring-up only: RadioLib's own boot prints (found-chip line with the
-  ; transceiver/WiFi/GNSS FW versions, calibration errors). Goes to Serial =
-  ; UART0 on this board. Low volume; drop once the radio is proven.
-  -D RADIOLIB_DEBUG_BASIC=1
+  ; (RADIOLIB_DEBUG_BASIC was a bring-up flag, dropped now that the radio is
+  ; proven on hardware — target.cpp's own LR1110 version print stays.)
   -D RX_BOOSTED_GAIN=true
   ; DIO5/DIO6 -> RFSW0_V1/RFSW1_V2 confirmed against the V1.0 schematic (LR1110
   ; block, U7 pins 19/20 -> R19/R20 -> U8 V1/V2) — see target.cpp for the table
@@ -1281,8 +1293,8 @@ build_flags =
   -D PIN_KB_SDA=20
   -D PIN_KB_SCL=21
   -D PIN_KB_ADDR=0x6c
-  ; --- touch UI / companion stack (M9 has no touch — keyboard + d-pad text
-  ;     entry only; keypad-nav focus traversal is NOT wired yet, see
+  ; --- touch UI / companion stack (M9 has no touch — keyboard + d-pad only;
+  ;     both text entry and keypad-nav focus traversal are wired, see
   ;     M9_PORT.md) ---
   -I include
   -I src

--- a/platformio.ini
+++ b/platformio.ini
@@ -252,6 +252,17 @@ build_flags =
   ${env:heltec_v4_tft_companion_radio_usb_tcp_touch.build_flags}
   ; --- V4-R8 deltas (later -D wins on the GCC command line) ---
   -D HELTEC_LORA_V4_R8
+  ; Boot at the S3's full clock. The base env's ESP32_CPU_FREQ=80 is applied in
+  ; ESP32Board::begin(), so ALL of setup() — radio init, the SD mount ladder, the
+  ; store load, mesh begin, Wi-Fi bring-up — ran at a third speed until UITask::begin
+  ; bumped it to 240. The screen-off DFS drop to 80 MHz (setCpuForScreen) is unaffected.
+  -D ESP32_CPU_FREQ=240
+  ; micro-SD operating clock (perf pass 2026-08-20): after the conservative 4 MHz mount
+  ; succeeds, re-begin at this clock with a directory + file READ verify and fall back
+  ; to 4 MHz if it fails (include/SdFastClock.h). The same traces already carry the
+  ; display at 80 MHz, and the card is the primary store on this board (contacts, chat
+  ; history, sync log) — 4 MHz was the M9 ladder's value, never re-tuned here.
+  -D SD_SPI_FAST_HZ=20000000
   -D P_LORA_TX_LED=46
   -D PIN_VEXT_EN=40
   -D PIN_VEXT_EN_ACTIVE=LOW

--- a/platformio.ini
+++ b/platformio.ini
@@ -1164,6 +1164,10 @@ build_flags =
   -I variants/thinknode_m9
   -D HAS_THINKNODE_M9
   -D BOARD_HAS_PSRAM=1
+  ; 0 = silence ARDUHAL [E] spam, same rationale as the other envs — worse here:
+  ; with the UART bridge (below), Serial is UART0, which doubles as the
+  ; MULTI_TRANSPORT_COMPANION frame stream, so the spam lands mid-frame.
+  -D CORE_DEBUG_LEVEL=0
   ; M9 uses the UART bridge (ttyUSB0), not native USB-CDC — confirmed during
   ; Specter bring-up. With ARDUINO_USB_CDC_ON_BOOT=1 (the T-Deck's setting)
   ; app Serial logs go to a ttyACM* port this board doesn't expose and
@@ -1211,6 +1215,10 @@ build_flags =
   -D PIN_VBAT_READ=13
   ; --- GPS (CC1167Q, UART1) ---
   -D ENV_INCLUDE_GPS=1
+  ; The GPS is soldered on, so skip the boot-time detect probe: a cold-booting
+  ; CC1167Q can miss the 1 s NMEA window, leaving gps_detected false — which
+  ; kills the GPS setting (and the GPS_LONG key) until reboot.
+  -D ENV_SKIP_GPS_DETECT=1
   -D PIN_GPS_RX=3
   -D PIN_GPS_TX=2
   -D PIN_GPS_EN=11

--- a/scripts/build/patch_radiolib_lr11x0.py
+++ b/scripts/build/patch_radiolib_lr11x0.py
@@ -12,9 +12,15 @@
 #
 # Idempotent. Each PlatformIO env has its own libdeps copy, so this only
 # affects envs that list this script in extra_scripts (the M9 env).
-# NOTE: on a completely fresh checkout the first build may run before
-# RadioLib is downloaded - the script then warns and the patch lands on the
-# next build. Re-run `pio run` once if you see the warning.
+#
+# Fail-closed: an unpatched binary boots to a fatal -706 radio-init screen on
+# preprod units, indistinguishable from a good build except by its build log —
+# so any state where the patch can't land ABORTS the build instead of warning.
+# The one soft case is a completely fresh checkout: pre-scripts run before the
+# LDF fetches lib_deps, so there is nothing to patch yet, and aborting here
+# would stop the build before RadioLib can even be downloaded. For that case a
+# pre-link check (below) patches late and fails the link, so the NEXT `pio run`
+# compiles the patched source — no linked binary can ever ship unpatched.
 Import("env")
 import os
 
@@ -35,18 +41,58 @@ NEW = """  state = this->driveDiosInSleepMode(true);
 path = os.path.join(env.subst("$PROJECT_LIBDEPS_DIR"), env.subst("$PIOENV"),
                     "RadioLib", "src", "modules", "LR11x0", "LR11x0.cpp")
 
-if not os.path.isfile(path):
-    print("[patch_radiolib_lr11x0] WARNING: %s not found (libdeps not fetched yet?)" % path)
-    print("[patch_radiolib_lr11x0] WARNING: RadioLib NOT patched - re-run the build once libdeps exist")
-else:
+
+def apply_patch():
+    """Patch LR11x0.cpp in place. Returns an error string, or None on success
+    (including already-patched)."""
     with open(path) as f:
         src = f.read()
     if MARKER in src:
         print("[patch_radiolib_lr11x0] already patched")
-    elif OLD in src:
-        with open(path, "w") as f:
-            f.write(src.replace(OLD, NEW, 1))
-        print("[patch_radiolib_lr11x0] patched LR11x0::config() for old-FW tolerance")
-    else:
-        print("[patch_radiolib_lr11x0] WARNING: pattern not found - RadioLib version drift?")
-        print("[patch_radiolib_lr11x0] WARNING: check LR11x0::config() by hand, NOT patched")
+        return None
+    if OLD not in src:
+        # lib_deps uses a caret range (^7.6.0), so a `pio pkg update` can pull
+        # a RadioLib whose config() no longer matches the expected shape.
+        return ("LR11x0::config() doesn't match the expected shape (RadioLib "
+                "version drift?) - port the old-FW patch by hand, or pin "
+                "lib_deps back to a known-good version")
+    with open(path, "w") as f:
+        f.write(src.replace(OLD, NEW, 1))
+    print("[patch_radiolib_lr11x0] patched LR11x0::config() for old-FW tolerance")
+    return None
+
+
+if os.path.isfile(path):
+    error = apply_patch()
+    if error is not None:
+        print("[patch_radiolib_lr11x0] ERROR: %s" % error)
+        env.Exit(1)
+else:
+    # Fresh checkout: RadioLib isn't fetched yet. Let the build proceed so the
+    # LDF can download it; the pre-link check below is what keeps this run from
+    # producing an unpatched binary.
+    print("[patch_radiolib_lr11x0] RadioLib not fetched yet - patch deferred to pre-link check")
+
+
+def verify_patched(target, source, env):
+    # Runs right before the link, after libdeps exist and every RadioLib object
+    # has been compiled. A missing marker here means those objects came from
+    # UNPATCHED source: patch now (SCons's content signatures then recompile
+    # LR11x0.cpp on the next run) and fail this link. Non-zero return = SCons
+    # build failure, so no .elf/.bin is produced.
+    if not os.path.isfile(path):
+        print("[patch_radiolib_lr11x0] ERROR: %s still missing at link time" % path)
+        return 1
+    with open(path) as f:
+        if MARKER in f.read():
+            return 0
+    error = apply_patch()
+    if error is not None:
+        print("[patch_radiolib_lr11x0] ERROR: %s" % error)
+        return 1
+    print("[patch_radiolib_lr11x0] ERROR: RadioLib was fetched during this build and is")
+    print("[patch_radiolib_lr11x0] ERROR: now patched - re-run `pio run` to compile it in")
+    return 1
+
+
+env.AddPreAction("$BUILD_DIR/${PROGNAME}.elf", verify_patched)

--- a/src/DataStore.cpp
+++ b/src/DataStore.cpp
@@ -216,6 +216,29 @@ bool DataStore::removeFile(FILESYSTEM* fs, const char* filename) {
   return fs->remove(filename);
 }
 
+#if defined(ESP32)
+File DataStore::openAppend(FILESYSTEM* fs, const char* filename) {
+  return fs->open(_rp(filename), "a", true);
+}
+
+bool DataStore::fileExists(FILESYSTEM* fs, const char* filename) {
+  return fs->exists(_rp(filename));
+}
+
+bool DataStore::removeRooted(FILESYSTEM* fs, const char* filename) {
+  return fs->remove(_rp(filename));
+}
+
+bool DataStore::renameFile(FILESYSTEM* fs, const char* from, const char* to) {
+  // _rp() hands back ONE shared scratch buffer, so the two paths must be built
+  // into independent buffers (same trap savePrefs documents).
+  char from_path[80], to_path[80];
+  snprintf(from_path, sizeof(from_path), "%s%s", _root, from);
+  snprintf(to_path,   sizeof(to_path),   "%s%s", _root, to);
+  return fs->rename(from_path, to_path);
+}
+#endif
+
 bool DataStore::formatFileSystem() {
 #if defined(NRF52_PLATFORM) || defined(STM32_PLATFORM)
   if (_fsExtra == nullptr) {

--- a/src/DataStore.h
+++ b/src/DataStore.h
@@ -98,6 +98,18 @@ public:
   // _root; setSecondaryFS sets _fsExtra) — FAT has no such GC. Lets callers coalesce
   // the advert-driven contacts save on card-less devices without changing SD boards.
   bool contactsOnInternalFlash() const { return _root[0] == '\0' && _fsExtra == nullptr; }
+
+  // Root-aware file helpers for the app-level stores that live beside the core
+  // data files (MyMesh's companion sync-history log, see MyMesh::loadSyncHistory).
+  // getHotDataFS() is whichever filesystem already takes the frequently-rewritten
+  // contacts/channels — the SD card when one is routed, else the primary FS — so
+  // an often-appended log never lands on GC-prone internal flash while a card
+  // exists. NB removeFile(fs, name) above is NOT root-aware (legacy); these are.
+  FILESYSTEM* getHotDataFS() const { return _getContactsChannelsFS(); }
+  File openAppend(FILESYSTEM* fs, const char* filename);             // create if missing
+  bool fileExists(FILESYSTEM* fs, const char* filename);
+  bool removeRooted(FILESYSTEM* fs, const char* filename);
+  bool renameFile(FILESYSTEM* fs, const char* from, const char* to);
 #endif
 
 private:

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -140,6 +140,20 @@ static int s_companion_ota_pinned_reply_target = -1;
 #define DIRECT_SEND_PERHOP_FACTOR       6.0f
 #define DIRECT_SEND_PERHOP_EXTRA_MILLIS 250
 #define LAZY_CONTACTS_WRITE_DELAY       5000
+// Companion sync-history persistence pacing (see serviceSyncHistory). The log append
+// is a ~180 B write per message, so it lands quickly — the coalesce is the hard-cut
+// loss window. Cursor rewrites (tmp + swap of a ~300 B file) happen on every synced
+// or live-pushed message while an app is connected, so they coalesce longer; a stale
+// cursor only costs the app a few re-delivered (already-seen) messages, never loss.
+#define SYNC_HIST_LOG_COALESCE_MS       3000
+#define SYNC_HIST_LOG_MAX_LATENCY_MS    10000
+#define SYNC_HIST_CUR_COALESCE_MS       5000
+#define SYNC_HIST_CUR_MAX_LATENCY_MS    30000
+#define SYNC_HIST_RETRY_MS              30000   // storage unavailable / write failed
+#define SYNC_HIST_LOG_FILE              "/synchist"
+#define SYNC_HIST_LOG_TMP               "/synchist.tmp"
+#define SYNC_HIST_CUR_FILE              "/synccur"
+#define SYNC_HIST_CUR_TMP               "/synccur.tmp"
 // On card-less (internal-flash) devices, coalesce advert-refresh contacts saves to
 // at most once per this window — a full rewrite can trigger a multi-second SPIFFS GC
 // that freezes the loop, and re-adverts (last-heard/path refreshes) otherwise churn
@@ -1162,7 +1176,228 @@ uint32_t MyMesh::addToHistoryRing(const uint8_t frame[], int len) {
   if (history_count < HISTORY_RING_SIZE) {
     history_count++;
   }
+  // Every add counts as unflushed (appendSyncLog walks the newest N ring slots and
+  // skips non-message codes itself); only message frames arm a write.
+  if (_synchist_unflushed < HISTORY_RING_SIZE) _synchist_unflushed++;
+  if (isSyncMessageCode(frame[0])) markSyncLogDirty();
   return assigned;
+}
+
+// ---------------------------------------------------------------------------
+// Companion sync-history persistence (ring + per-client cursors). File formats:
+//   /synchist : "WSH" 0x01, then records { u32 seq, u8 len, u8 buf[len] } oldest first.
+//   /synccur  : "WSC" 0x01, u32 next_seq, u8 n, then n x { char id[MAX_CLIENT_ID_LEN+1], u32 last_seq }.
+// Little-endian, packed by hand (no struct dumps) so the layout is explicit.
+// ---------------------------------------------------------------------------
+static const uint8_t kSyncHistMagic[4] = { 'W', 'S', 'H', 1 };
+static const uint8_t kSyncCurMagic[4]  = { 'W', 'S', 'C', 1 };
+
+bool MyMesh::isSyncMessageCode(uint8_t code) {
+  return code == RESP_CODE_CONTACT_MSG_RECV || code == RESP_CODE_CONTACT_MSG_RECV_V3 ||
+         code == RESP_CODE_CHANNEL_MSG_RECV || code == RESP_CODE_CHANNEL_MSG_RECV_V3;
+}
+
+void MyMesh::markSyncLogDirty() {
+  unsigned long now = millis();
+  if (!_synchist_log_dirty) _synchist_log_first = now;
+  _synchist_log_dirty = true;
+  _synchist_log_due = now + SYNC_HIST_LOG_COALESCE_MS;
+}
+
+void MyMesh::markSyncCursorsDirty() {
+  unsigned long now = millis();
+  if (!_synchist_cur_dirty) _synchist_cur_first = now;
+  _synchist_cur_dirty = true;
+  _synchist_cur_due = now + SYNC_HIST_CUR_COALESCE_MS;
+}
+
+static size_t syncHistWriteRecord(File& f, const uint8_t* frame, uint8_t len, uint32_t seq) {
+  uint8_t hdr[5];
+  memcpy(hdr, &seq, 4);
+  hdr[4] = len;
+  size_t n = f.write(hdr, sizeof(hdr));
+  n += f.write(frame, len);
+  return n;
+}
+
+// Adopt a fully-written temp when the live file is missing (swap interrupted by a
+// power cut); drop a stale temp that sits beside an intact live file.
+static void syncHistRecoverSwap(DataStore* store, FILESYSTEM* fs, const char* live, const char* tmp) {
+  if (!store->fileExists(fs, tmp)) return;
+  if (!store->fileExists(fs, live)) store->renameFile(fs, tmp, live);
+  else                              store->removeRooted(fs, tmp);
+}
+
+void MyMesh::loadSyncHistory() {
+  FILESYSTEM* fs = _store->getHotDataFS();
+  syncHistRecoverSwap(_store, fs, SYNC_HIST_LOG_FILE, SYNC_HIST_LOG_TMP);
+  syncHistRecoverSwap(_store, fs, SYNC_HIST_CUR_FILE, SYNC_HIST_CUR_TMP);
+
+  uint32_t last_seq = 0;
+  bool any = false;
+  File f = _store->openRead(fs, SYNC_HIST_LOG_FILE);
+  if (f) {
+    uint8_t magic[4];
+    if (f.read(magic, 4) == 4 && memcmp(magic, kSyncHistMagic, 4) == 0) {
+      size_t pos = 4, size = f.size();
+      while (pos + 5 <= size) {
+        uint8_t hdr[5];
+        if (f.read(hdr, 5) != 5) { _synchist_need_compact = true; break; }
+        uint32_t seq; memcpy(&seq, hdr, 4);
+        uint8_t len = hdr[4];
+        if (len == 0 || len > MAX_FRAME_SIZE || pos + 5 + len > size) { _synchist_need_compact = true; break; }  // torn tail
+        uint8_t buf[MAX_FRAME_SIZE];
+        if (f.read(buf, len) != len) { _synchist_need_compact = true; break; }
+        pos += 5 + len;
+        _synchist_file_recs++;
+        if ((any && seq <= last_seq) || !isSyncMessageCode(buf[0])) { _synchist_need_compact = true; continue; }
+        HistoryEntry& e = history_ring[history_head];
+        e.len = len;
+        memcpy(e.buf, buf, len);
+        e.seq = seq;
+        history_head = (history_head + 1) % HISTORY_RING_SIZE;
+        if (history_count < HISTORY_RING_SIZE) history_count++;
+        last_seq = seq;
+        any = true;
+      }
+      if (pos != size) _synchist_need_compact = true;   // trailing partial record
+    } else {
+      _synchist_need_compact = true;   // foreign / corrupt header: rewrite from RAM on the next flush
+    }
+    f.close();
+  }
+  if (any) history_next_seq = last_seq + 1;
+  if (_synchist_file_recs > 2u * HISTORY_RING_SIZE) _synchist_need_compact = true;
+  _synchist_unflushed = 0;
+
+  File c = _store->openRead(fs, SYNC_HIST_CUR_FILE);
+  if (c) {
+    uint8_t magic[4];
+    uint32_t next_seq = 0;
+    uint8_t n = 0;
+    if (c.read(magic, 4) == 4 && memcmp(magic, kSyncCurMagic, 4) == 0 &&
+        c.read((uint8_t*)&next_seq, 4) == 4 && c.read(&n, 1) == 1) {
+      if (next_seq > history_next_seq) history_next_seq = next_seq;
+      if (n > MAX_HISTORY_CLIENTS) n = MAX_HISTORY_CLIENTS;
+      for (uint8_t i = 0; i < n; i++) {
+        char id[MAX_CLIENT_ID_LEN + 1];
+        uint32_t last = 0;
+        if (c.read((uint8_t*)id, sizeof(id)) != sizeof(id) || c.read((uint8_t*)&last, 4) != 4) break;
+        id[MAX_CLIENT_ID_LEN] = '\0';
+        if (history_next_seq > 0 && last > history_next_seq - 1) last = history_next_seq - 1;  // never point past the ring
+        ClientHistoryState& st = history_clients[history_num_clients++];
+        strncpy(st.client_id, id, MAX_CLIENT_ID_LEN);
+        st.client_id[MAX_CLIENT_ID_LEN] = '\0';
+        st.last_delivered_seq = last;
+      }
+    }
+    c.close();
+  }
+  if (any || history_num_clients > 0) {
+    MESH_DEBUG_PRINTLN("sync history restored: %d msgs, %d clients, next_seq=%lu%s",
+                       history_count, history_num_clients, (unsigned long)history_next_seq,
+                       _synchist_need_compact ? " (log needs compaction)" : "");
+  }
+}
+
+bool MyMesh::appendSyncLog() {
+  int n = _synchist_unflushed;
+  if (n > history_count) n = history_count;
+  FILESYSTEM* fs = _store->getHotDataFS();
+  File f = _store->openAppend(fs, SYNC_HIST_LOG_FILE);
+  if (!f) return false;
+  bool ok = true;
+  if (f.size() == 0) ok = (f.write(kSyncHistMagic, 4) == 4);
+  int tail = (history_head - history_count + HISTORY_RING_SIZE) % HISTORY_RING_SIZE;
+  uint32_t recs = 0;
+  for (int i = history_count - n; ok && i < history_count; i++) {
+    const HistoryEntry& e = history_ring[(tail + i) % HISTORY_RING_SIZE];
+    if (!isSyncMessageCode(e.buf[0])) continue;
+    ok = (syncHistWriteRecord(f, e.buf, e.len, e.seq) == (size_t)(5 + e.len));
+    if (ok) recs++;
+  }
+  f.close();
+  if (!ok) {
+    _synchist_need_compact = true;   // a short append left a torn tail: rewrite next time
+    return false;
+  }
+  _synchist_file_recs += recs;
+  _synchist_unflushed = 0;
+  return true;
+}
+
+bool MyMesh::compactSyncLog() {
+  FILESYSTEM* fs = _store->getHotDataFS();
+  WdtHeavyGuard idle_wdt_guard;   // up to HISTORY_RING_SIZE x ~180 B in one go; SPIFFS may GC
+  File f = _store->openWrite(fs, SYNC_HIST_LOG_TMP);
+  if (!f) return false;
+  bool ok = (f.write(kSyncHistMagic, 4) == 4);
+  int tail = (history_head - history_count + HISTORY_RING_SIZE) % HISTORY_RING_SIZE;
+  uint32_t recs = 0;
+  for (int i = 0; ok && i < history_count; i++) {
+    const HistoryEntry& e = history_ring[(tail + i) % HISTORY_RING_SIZE];
+    if (!isSyncMessageCode(e.buf[0])) continue;
+    ok = (syncHistWriteRecord(f, e.buf, e.len, e.seq) == (size_t)(5 + e.len));
+    if (ok) recs++;
+  }
+  f.close();
+  if (!ok) { _store->removeRooted(fs, SYNC_HIST_LOG_TMP); return false; }   // keep the old log
+  _store->removeRooted(fs, SYNC_HIST_LOG_FILE);
+  if (!_store->renameFile(fs, SYNC_HIST_LOG_TMP, SYNC_HIST_LOG_FILE)) return false;  // loader adopts the tmp
+  _synchist_file_recs = recs;
+  _synchist_unflushed = 0;
+  _synchist_need_compact = false;
+  return true;
+}
+
+bool MyMesh::saveSyncCursors() {
+  FILESYSTEM* fs = _store->getHotDataFS();
+  File f = _store->openWrite(fs, SYNC_HIST_CUR_TMP);
+  if (!f) return false;
+  uint8_t n = (uint8_t)history_num_clients;
+  bool ok = (f.write(kSyncCurMagic, 4) == 4) &&
+            (f.write((const uint8_t*)&history_next_seq, 4) == 4) &&
+            (f.write(&n, 1) == 1);
+  for (int i = 0; ok && i < history_num_clients; i++) {
+    const ClientHistoryState& st = history_clients[i];
+    ok = (f.write((const uint8_t*)st.client_id, sizeof(st.client_id)) == sizeof(st.client_id)) &&
+         (f.write((const uint8_t*)&st.last_delivered_seq, 4) == 4);
+  }
+  f.close();
+  if (!ok) { _store->removeRooted(fs, SYNC_HIST_CUR_TMP); return false; }
+  _store->removeRooted(fs, SYNC_HIST_CUR_FILE);
+  return _store->renameFile(fs, SYNC_HIST_CUR_TMP, SYNC_HIST_CUR_FILE);
+}
+
+void MyMesh::serviceSyncHistory() {
+  unsigned long now = millis();
+  // An app disconnecting is the natural sync point: land its cursor right away so a
+  // power cut before the coalesce window closes cannot make it re-receive, on the
+  // next connect, the messages it just pulled.
+  bool connected = _serial && _serial->isConnected();
+  if (_synchist_was_connected && !connected && _synchist_cur_dirty) _synchist_cur_due = now;
+  _synchist_was_connected = connected;
+  if (_synchist_log_dirty &&
+      (millisHasNowPassed(_synchist_log_due) || now - _synchist_log_first >= SYNC_HIST_LOG_MAX_LATENCY_MS)) {
+    bool ok = (_synchist_need_compact || _synchist_file_recs > 2u * HISTORY_RING_SIZE)
+                ? compactSyncLog() : appendSyncLog();
+    if (ok) _synchist_log_dirty = false;
+    else    _synchist_log_due = now + SYNC_HIST_RETRY_MS;   // card missing / write failed: keep in RAM, retry later
+  }
+  if (_synchist_cur_dirty &&
+      (millisHasNowPassed(_synchist_cur_due) || now - _synchist_cur_first >= SYNC_HIST_CUR_MAX_LATENCY_MS)) {
+    if (saveSyncCursors()) _synchist_cur_dirty = false;
+    else                   _synchist_cur_due = now + SYNC_HIST_RETRY_MS;
+  }
+}
+
+void MyMesh::persistSyncHistoryNow() {
+  if (_synchist_log_dirty) {
+    bool ok = (_synchist_need_compact || _synchist_file_recs > 2u * HISTORY_RING_SIZE)
+                ? compactSyncLog() : appendSyncLog();
+    if (ok) _synchist_log_dirty = false;
+  }
+  if (_synchist_cur_dirty && saveSyncCursors()) _synchist_cur_dirty = false;
 }
 
 static bool clientIdEqual(const char* a, const char* b) {
@@ -1233,6 +1468,7 @@ int MyMesh::getNextFromHistoryForClient(const char* client_id, uint8_t frame[], 
     history_clients[slot].client_id[MAX_CLIENT_ID_LEN] = '\0';
     history_clients[slot].last_delivered_seq = history_next_seq > (uint32_t)history_count
       ? history_next_seq - (uint32_t)history_count : 0;
+    markSyncCursorsDirty();
   }
 
   uint32_t last = history_clients[slot].last_delivered_seq;
@@ -1267,8 +1503,10 @@ void MyMesh::commitHistoryForClient(const char* client_id, uint32_t seq) {
   const char* cid = (client_id && client_id[0]) ? client_id : "";
   for (int i = 0; i < history_num_clients; i++) {
     if (clientIdEqual(history_clients[i].client_id, cid)) {
-      if (seq > history_clients[i].last_delivered_seq)
+      if (seq > history_clients[i].last_delivered_seq) {
         history_clients[i].last_delivered_seq = seq;
+        markSyncCursorsDirty();
+      }
       return;
     }
   }
@@ -1278,8 +1516,10 @@ void MyMesh::advanceHistoryClientsAfterV3Broadcast(uint32_t seq) {
   for (int i = 0; i < history_num_clients; i++) {
     if (!shouldAdvanceClientAfterV3Broadcast(history_clients[i].client_id))
       continue;
-    if (seq > history_clients[i].last_delivered_seq)
+    if (seq > history_clients[i].last_delivered_seq) {
       history_clients[i].last_delivered_seq = seq;
+      markSyncCursorsDirty();
+    }
   }
 }
 
@@ -3437,6 +3677,7 @@ void MyMesh::begin(bool has_display) {
   bootstrapRTCfromContacts();
   addChannel("Public", PUBLIC_GROUP_PSK); // pre-configure Andy's public channel
   _store->loadChannels(this);
+  loadSyncHistory();   // app-sync replay ring + client cursors survive a reboot/power cut
 
   applyRadioFromPrefs();   // freq/bw/sf/cr + TX power + RX-boost (shared with the live UI apply)
 #if defined(DISPLAY_CLASS)
@@ -4176,6 +4417,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     // first — the same contract the on-device power menu honors. Skipping this
     // was the "read and unread messages deleted after a manual reboot" report.
     if (_ui) _ui->persistHistoryNow();
+    persistSyncHistoryNow();   // and the app-sync replay ring
     board.reboot();
   } else if (cmd_frame[0] == CMD_GET_BATT_AND_STORAGE) {
     uint8_t reply[11];
@@ -5271,6 +5513,7 @@ void MyMesh::loop() {
       dirty_contacts_expiry = 0;
     }
   }
+  serviceSyncHistory();   // coalesced app-sync ring / cursor writes
 
 #if defined(ENABLE_ADVERT_ON_BOOT) && ENABLE_ADVERT_ON_BOOT == 1
   // Fire the one-shot boot advert when the scheduled time passes. Flood so

--- a/src/MyMesh.h
+++ b/src/MyMesh.h
@@ -1021,6 +1021,12 @@ public:
   // shutdown/reboot, so the on-device power paths don't lose the last refresh
   // window on card-less devices (see MyMesh::loop). No-op when nothing is pending.
   void flushContactsIfDirty() { if (dirty_contacts_expiry) { saveContacts(); dirty_contacts_expiry = 0; } }
+  /** Flush the companion sync history (message ring + per-client cursors) to
+   *  storage synchronously. Call on every deliberate reboot/power-off path, next
+   *  to persistHistoryNow(): the periodic writes are coalesced (see
+   *  serviceSyncHistory), so a reset inside the window would otherwise drop the
+   *  newest messages from the app-sync replay. No-op when nothing is pending. */
+  void persistSyncHistoryNow();
 
   /** Remove a contact from a device-UI action and PERSIST it (mirrors the
    *  companion app's CMD_REMOVE_CONTACT). The base removeContact() only drops it
@@ -1268,6 +1274,34 @@ private:
   uint32_t history_next_seq;
   ClientHistoryState history_clients[MAX_HISTORY_CLIENTS];
   int history_num_clients;
+
+  // Companion sync-history persistence. The ring above is what CMD_SYNC_NEXT_MESSAGE /
+  // SyncSince replay to an app that (re)connects — and it used to be RAM-only, so any
+  // power cycle emptied it: an app that was not connected while messages arrived never
+  // got them after the reboot, while the on-device chat store (UITask) still showed them.
+  // Worst on boards whose only "off" is a hard power cut (ThinkNode M9 slider), but the
+  // V4/T-Deck power menus deep-sleep (RAM lost) just the same.
+  //   /synchist  append-only log of the sync-relevant frames (seq + raw frame); small
+  //              per-message appends, compacted (tmp + swap) once it holds > 2x the ring.
+  //   /synccur   next_seq + per-client last_delivered_seq (tiny, tmp + swap) so a
+  //              returning client resumes where it left off instead of re-receiving
+  //              everything. Both live on DataStore::getHotDataFS() (SD when routed).
+  bool     _synchist_log_dirty = false;    // ring entries appended since the last log write
+  bool     _synchist_cur_dirty = false;    // client cursors / next_seq changed since last write
+  bool     _synchist_need_compact = false; // torn/oversized log: rewrite from the ring instead of appending
+  int      _synchist_unflushed = 0;        // newest N ring entries not yet in the log
+  uint32_t _synchist_file_recs = 0;        // records currently in /synchist
+  unsigned long _synchist_log_due = 0, _synchist_log_first = 0;   // coalesce deadline / first-dirty time
+  unsigned long _synchist_cur_due = 0, _synchist_cur_first = 0;
+  bool     _synchist_was_connected = false; // disconnect edge -> flush cursors now
+  static bool isSyncMessageCode(uint8_t code);
+  void markSyncLogDirty();
+  void markSyncCursorsDirty();
+  void loadSyncHistory();      // MyMesh::begin(): restore ring + cursors from storage
+  bool appendSyncLog();        // land the newest _synchist_unflushed ring entries
+  bool compactSyncLog();       // rewrite the whole ring (tmp + swap)
+  bool saveSyncCursors();      // /synccur (tmp + swap)
+  void serviceSyncHistory();   // MyMesh::loop(): coalesced flushes
   ClientProtoState proto_clients[MAX_HISTORY_CLIENTS];
   int proto_num_clients;
 

--- a/src/helpers/esp32/MultiTransportCompanionInterface.cpp
+++ b/src/helpers/esp32/MultiTransportCompanionInterface.cpp
@@ -188,6 +188,15 @@ void MultiTransportCompanionInterface::prepareBle(const char* prefix, char* name
 void MultiTransportCompanionInterface::beginBle(const char* prefix, char* name, uint32_t pin_code) {
   prepareBle(prefix, name, pin_code);
   _ble.begin(prefix, name, pin_code);
+  // ATT notification payload is ATT_MTU-3, so SerialBLEInterface::begin()'s
+  // setMTU(MAX_FRAME_SIZE) leaves a full-length frame 3 bytes too big and NimBLE
+  // silently drops the overflow (ble_att_truncate_to_mtu()). MyMesh::queueMessage()
+  // clamps message text to exactly MAX_FRAME_SIZE, so a maximum-length message lost
+  // its last 3 bytes -- over BLE only; USB/TCP/WS were unaffected. Widen it here
+  // rather than in the core: that file is upstream MeshCore, this transport is
+  // vendored in our src/, and setMTU() is a public static, so no core change is
+  // needed. Verified on an M9: the app now negotiates ATT MTU 179 (was 176).
+  NimBLEDevice::setMTU(MAX_FRAME_SIZE + 3);
   _ble_begun = true;
   _ble_enabled = true;
   _ota_ble_released = false;
@@ -228,6 +237,7 @@ void MultiTransportCompanionInterface::enableBle() {
     strncpy(name, _ble_name, sizeof(name) - 1);
     name[sizeof(name) - 1] = '\0';
     _ble.begin(_ble_prefix, name, _ble_pin_code);
+    NimBLEDevice::setMTU(MAX_FRAME_SIZE + 3);   // see beginBle(): ATT payload is MTU-3
     _ble_begun = true;
   }
   _ble_enabled = true;

--- a/src/helpers/esp32/TouchPrefsSchema.h
+++ b/src/helpers/esp32/TouchPrefsSchema.h
@@ -9,7 +9,7 @@
 namespace TouchPrefsSchema {
 
 static constexpr uint16_t MAGIC = 0x5743;   // 'WC' (WadaCfg)
-static constexpr uint8_t CURRENT_VERSION = 48;
+static constexpr uint8_t CURRENT_VERSION = 50;   // v49: fem_lna default flip on the V4-R8; v50: map tile z/x/y line off by default (no new fields)
 static constexpr uint8_t BROKEN_MID_INSERT_VERSION = 44;
 
 // Persisted byte layout. New fields must be appended at the end: older blobs

--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -37,7 +37,7 @@ static bool s_begun = false;
 // short read (→ treat as absent → defaults); `ver` lets later builds add fields.
 static const char* KEY_CFG = "cfg";
 static const uint16_t TOUCH_CFG_MAGIC = TouchPrefsSchema::MAGIC;
-static const uint8_t  TOUCH_CFG_VER   = TouchPrefsSchema::CURRENT_VERSION;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab; v20 map_show_links; v21 map_style (0=OSM default, 1=OpenTopoMap); v22 tb_nav; v23 scope_direct (opt-in: scope direct/login floods to the region); v24 tb_nav default OFF (experimental); v25 fem_lna (Heltec V4.3 high-gain FEM LNA, opt-in); v26 msg_flash (flash keyboard backlight + wake screen on a new message, opt-in); v27 flood_adv_hrs + local_adv_min (periodic self-advert intervals, the standard MeshCore flood/local advert on a timer); v28 beta_updates (opt-in to test/beta firmware on the OTA update check + install); v29 ui_scale default -> Large/150% (Tanmatsu; bumps the old 100% default, leaves an explicit Large/Huge choice); v30 boot_advert (opt-in one-shot flood self-advert ~6s after boot, all boards, #76); v31 compact_chat (opt-in IRC-style dense chat rows instead of bubbles); v32 clock_floor (highest epoch handed out — monotonic send-timestamp floor across reboots, #89); v33 rx_queue (buffered LoRa receive: drain task + packet ring, experimental, default OFF); v34 web_mirror (web control panel: mirror the live UI to a phone browser + inject taps, opt-in, default OFF); v35 remote_mode (render the UI off-screen at a web resolution instead of the panel; boot mode, default OFF); v36 remote_landscape (remote mode orientation: landscape 800x480 vs portrait 480x800); v37 remote_landscape now defaults ON (remote mode = landscape/desktop by default; one-time flip of existing installs, portrait stays a toggle); v38 web_terminal (web mesh CLI terminal served on the device IP; runtime toggle, mutually exclusive with VNC, default OFF); v40 hist_sync_after (chat-history flush: consecutive off-thread write failures before the blocking loop-task fallback, 0 = never); v41 p4_antenna (T-Display P4 antenna select; now RESERVED/unused - the choice is session-only so every boot comes up on the on-board antenna); v42 hist_per_chat (max stored messages PER chat, default 250 - a busy public channel used to be able to fill the whole shared ring and drag the UI down); v43 Pager UI-size presets (reset the previously ignored large-screen default to Small once); v44 broken retry_echo mid-struct insertion; v45 moves retry_echo to the actual tail and resets the ambiguous v44 suffix
+static const uint8_t  TOUCH_CFG_VER   = TouchPrefsSchema::CURRENT_VERSION;  // v2 sig_probe/poll; v3 tz_zone; v4 hide_node_name; v5 map_night/map_zoom; v6 map text/marker visibility; v7 app_grid_large; v8 ui_scale; v9 tb_keypad; v10 sleep_idle; v11 nav_keys; v12 map_zoom_buttons; v13 nav_dir_keys; v14 home_is_drawer; v15 kbd_nav default ON (one-time migrate); v16 nav_scroll_keys; v17 notify_new_contact; v18 kbd_nav OFF by default (reverses v15; T-Deck/V4 only, Tanmatsu stays on); v19 show_sensors_tab; v20 map_show_links; v21 map_style (0=OSM default, 1=OpenTopoMap); v22 tb_nav; v23 scope_direct (opt-in: scope direct/login floods to the region); v24 tb_nav default OFF (experimental); v25 fem_lna (Heltec V4.3 high-gain FEM LNA, opt-in); v26 msg_flash (flash keyboard backlight + wake screen on a new message, opt-in); v27 flood_adv_hrs + local_adv_min (periodic self-advert intervals, the standard MeshCore flood/local advert on a timer); v28 beta_updates (opt-in to test/beta firmware on the OTA update check + install); v29 ui_scale default -> Large/150% (Tanmatsu; bumps the old 100% default, leaves an explicit Large/Huge choice); v30 boot_advert (opt-in one-shot flood self-advert ~6s after boot, all boards, #76); v31 compact_chat (opt-in IRC-style dense chat rows instead of bubbles); v32 clock_floor (highest epoch handed out — monotonic send-timestamp floor across reboots, #89); v33 rx_queue (buffered LoRa receive: drain task + packet ring, experimental, default OFF); v34 web_mirror (web control panel: mirror the live UI to a phone browser + inject taps, opt-in, default OFF); v35 remote_mode (render the UI off-screen at a web resolution instead of the panel; boot mode, default OFF); v36 remote_landscape (remote mode orientation: landscape 800x480 vs portrait 480x800); v37 remote_landscape now defaults ON (remote mode = landscape/desktop by default; one-time flip of existing installs, portrait stays a toggle); v38 web_terminal (web mesh CLI terminal served on the device IP; runtime toggle, mutually exclusive with VNC, default OFF); v40 hist_sync_after (chat-history flush: consecutive off-thread write failures before the blocking loop-task fallback, 0 = never); v41 p4_antenna (T-Display P4 antenna select; now RESERVED/unused - the choice is session-only so every boot comes up on the on-board antenna); v42 hist_per_chat (max stored messages PER chat, default 250 - a busy public channel used to be able to fill the whole shared ring and drag the UI down); v43 Pager UI-size presets (reset the previously ignored large-screen default to Small once); v44 broken retry_echo mid-struct insertion; v45 moves retry_echo to the actual tail and resets the ambiguous v44 suffix; v46 app_hide; v47 MQTT hidden by default; v48 lang_file; v49 fem_lna default ON on the V4-R8 (KCT8103L FEM; one-time flip of existing installs, no new field); v50 map_show_tilexyz default OFF (tile z/x/y line hidden; one-time flip, no new field)
 
 // Defaults (kept identical to the historical per-key defaults).
 static const uint16_t DEFAULT_SCREEN_TIMEOUT_S = 20;
@@ -106,7 +106,7 @@ static void cfgSetDefaults(TouchCfg& c) {
   c.map_night     = 0;          // default: normal (light) tiles
   c.map_zoom      = 0;          // 0 = unset -> auto-snap on first map open
   c.map_show_coords   = 1;      // default: show coords / tile line / contacts
-  c.map_show_tilexyz  = 1;
+  c.map_show_tilexyz  = 0;      // v50: the "z12  12/2105/1376" tile-path line is developer clutter on the map; opt-in via Map options
   c.map_show_contacts = 1;
   c.app_grid_large    = 0;      // default: compact app grid (T-Deck 4 cols / V4 3 cols)
 #if defined(TLORA_PAGER)
@@ -121,7 +121,13 @@ static void cfgSetDefaults(TouchCfg& c) {
 #endif
   c.tb_nav            = 0;      // T-Deck trackball: soft-cursor by default. D-pad UI nav is EXPERIMENTAL (opt-in)
   c.scope_direct      = 0;      // OFF: direct/login floods stay unscoped (cross-region safe). Opt-in per issue #64.
+#if defined(HELTEC_LORA_V4_R8)
+  c.fem_lna           = 1;      // ON (v49): the V4-R8 is a V4.3.1-generation board with the KCT8103L FEM, whose
+                                // switchable ~17 dB LNA is the whole point of that FEM revision — shipping it
+                                // bypassed left RX sensitivity on the table. Toggle stays in Radio & Mesh.
+#else
   c.fem_lna           = 0;      // OFF: V4.3 FEM LNA bypassed (matches the hardware default). Opt-in high-gain RX.
+#endif
   c.msg_flash         = 0;      // OFF: opt-in new-message keyboard/screen flash
   c.flood_adv_hrs     = 0;      // OFF: no periodic flood self-advert (advertise manually)
   c.local_adv_min     = 0;      // OFF: no periodic zero-hop self-advert
@@ -217,6 +223,13 @@ static void cfgLoadOrMigrate() {
         if (stored_version < 24) s_cfg.tb_nav = 0;
         // v25: new trailing field — V4.3 FEM LNA OFF on existing installs (matches hardware default).
         if (stored_version < 25) s_cfg.fem_lna = 0;
+#if defined(HELTEC_LORA_V4_R8)
+        // v49: FEM LNA ON by default on the V4-R8 (KCT8103L). One-time flip of existing
+        // installs so they match the new default; an explicit later off/on persists.
+        if (stored_version < 49) s_cfg.fem_lna = 1;
+#endif
+        // v50: map tile z/x/y overlay line OFF by default (one-time flip; the Map-options toggle persists afterwards).
+        if (stored_version < 50) s_cfg.map_show_tilexyz = 0;
         if (stored_version < 26) s_cfg.msg_flash = 0;
         if (stored_version < 27) { s_cfg.flood_adv_hrs = 0; s_cfg.local_adv_min = 0; }
         if (stored_version < 28) s_cfg.beta_updates = 0;

--- a/src/helpers/esp32/WifiRuntimeStore.cpp
+++ b/src/helpers/esp32/WifiRuntimeStore.cpp
@@ -17,6 +17,12 @@ static const char *WIFI_CONFIG_PWD_KEY = "wifi_pwd";
 static const char *WIFI_CONFIG_RADIO_EN_KEY = "wifi_radio_en";
 static const char *WIFI_CONFIG_WIFI_CHOSEN_KEY = "wifi_chosen";
 static const char *WIFI_CONFIG_BLE_EN_KEY = "ble_en";   // BLE radio on/off (default on)
+static const char *WIFI_CONFIG_PS_KEY = "wifi_ps";      // modem power save once associated
+#if defined(HELTEC_LORA_V4_R8)
+  #define WIFI_CONFIG_PS_DEFAULT 0   // USB-powered Expansion Kit: latency + link stability over mA
+#else
+  #define WIFI_CONFIG_PS_DEFAULT 1   // battery boards keep the DTIM sleep they always had
+#endif
 
 static SdNvsPrefs s_prefs;
 static bool s_begun = false;
@@ -139,6 +145,20 @@ void wifiConfigSetBleEnabled(bool enabled) {
   s_prefs.end();
   if (!s_prefs.begin(WIFI_CONFIG_NAMESPACE, false)) return;
   s_prefs.putUChar(WIFI_CONFIG_BLE_EN_KEY, enabled ? 1 : 0);
+  s_prefs.end();
+  s_begun = s_prefs.begin(WIFI_CONFIG_NAMESPACE, true);
+}
+
+bool wifiConfigGetPowerSave() {
+  if (!s_begun) wifiConfigBegin();
+  return s_prefs.getUChar(WIFI_CONFIG_PS_KEY, WIFI_CONFIG_PS_DEFAULT) != 0;
+}
+
+void wifiConfigSetPowerSave(bool enabled) {
+  if (!s_begun) wifiConfigBegin();
+  s_prefs.end();
+  if (!s_prefs.begin(WIFI_CONFIG_NAMESPACE, false)) return;
+  s_prefs.putUChar(WIFI_CONFIG_PS_KEY, enabled ? 1 : 0);
   s_prefs.end();
   s_begun = s_prefs.begin(WIFI_CONFIG_NAMESPACE, true);
 }

--- a/src/helpers/esp32/WifiRuntimeStore.cpp
+++ b/src/helpers/esp32/WifiRuntimeStore.cpp
@@ -17,12 +17,6 @@ static const char *WIFI_CONFIG_PWD_KEY = "wifi_pwd";
 static const char *WIFI_CONFIG_RADIO_EN_KEY = "wifi_radio_en";
 static const char *WIFI_CONFIG_WIFI_CHOSEN_KEY = "wifi_chosen";
 static const char *WIFI_CONFIG_BLE_EN_KEY = "ble_en";   // BLE radio on/off (default on)
-static const char *WIFI_CONFIG_PS_KEY = "wifi_ps";      // modem power save once associated
-#if defined(HELTEC_LORA_V4_R8)
-  #define WIFI_CONFIG_PS_DEFAULT 0   // USB-powered Expansion Kit: latency + link stability over mA
-#else
-  #define WIFI_CONFIG_PS_DEFAULT 1   // battery boards keep the DTIM sleep they always had
-#endif
 
 static SdNvsPrefs s_prefs;
 static bool s_begun = false;
@@ -145,20 +139,6 @@ void wifiConfigSetBleEnabled(bool enabled) {
   s_prefs.end();
   if (!s_prefs.begin(WIFI_CONFIG_NAMESPACE, false)) return;
   s_prefs.putUChar(WIFI_CONFIG_BLE_EN_KEY, enabled ? 1 : 0);
-  s_prefs.end();
-  s_begun = s_prefs.begin(WIFI_CONFIG_NAMESPACE, true);
-}
-
-bool wifiConfigGetPowerSave() {
-  if (!s_begun) wifiConfigBegin();
-  return s_prefs.getUChar(WIFI_CONFIG_PS_KEY, WIFI_CONFIG_PS_DEFAULT) != 0;
-}
-
-void wifiConfigSetPowerSave(bool enabled) {
-  if (!s_begun) wifiConfigBegin();
-  s_prefs.end();
-  if (!s_prefs.begin(WIFI_CONFIG_NAMESPACE, false)) return;
-  s_prefs.putUChar(WIFI_CONFIG_PS_KEY, enabled ? 1 : 0);
   s_prefs.end();
   s_begun = s_prefs.begin(WIFI_CONFIG_NAMESPACE, true);
 }

--- a/src/helpers/esp32/WifiRuntimeStore.h
+++ b/src/helpers/esp32/WifiRuntimeStore.h
@@ -27,6 +27,14 @@ void wifiConfigSetRadioEnabled(bool enabled);
 bool wifiConfigGetBleEnabled();
 void wifiConfigSetBleEnabled(bool enabled);
 
+/* Wi-Fi modem power save (DTIM sleep) once associated. ON saves power and gives BLE
+ * coexistence airtime; OFF keeps the RX chain up for a lower-latency companion-TCP /
+ * web-mirror link and holds a marginal association better. Default ON everywhere
+ * except the V4-R8 (USB-powered Expansion Kit form factor; perf pass 2026-08-20).
+ * Applied by the main loop after association and live by the Wi-Fi settings toggle. */
+bool wifiConfigGetPowerSave();
+void wifiConfigSetPowerSave(bool enabled);
+
 #if defined(TLORA_PAGER)
 /* Pager coexistence ownership. Wi-Fi intent alone cannot answer whether a
  * cold NimBLE start is safe: touch builds keep the STA scannable even with no

--- a/src/helpers/esp32/WifiRuntimeStore.h
+++ b/src/helpers/esp32/WifiRuntimeStore.h
@@ -27,14 +27,6 @@ void wifiConfigSetRadioEnabled(bool enabled);
 bool wifiConfigGetBleEnabled();
 void wifiConfigSetBleEnabled(bool enabled);
 
-/* Wi-Fi modem power save (DTIM sleep) once associated. ON saves power and gives BLE
- * coexistence airtime; OFF keeps the RX chain up for a lower-latency companion-TCP /
- * web-mirror link and holds a marginal association better. Default ON everywhere
- * except the V4-R8 (USB-powered Expansion Kit form factor; perf pass 2026-08-20).
- * Applied by the main loop after association and live by the Wi-Fi settings toggle. */
-bool wifiConfigGetPowerSave();
-void wifiConfigSetPowerSave(bool enabled);
-
 #if defined(TLORA_PAGER)
 /* Pager coexistence ownership. Wi-Fi intent alone cannot answer whether a
  * cold NimBLE start is safe: touch builds keep the STA scannable even with no

--- a/src/helpers/input/HeltecV4CapTouch.cpp
+++ b/src/helpers/input/HeltecV4CapTouch.cpp
@@ -83,23 +83,34 @@ void heltecV4CapTouchSetRotation(uint8_t lvgl_rot) { s_ui_rotation = lvgl_rot & 
 // ROT_90 (1) gets the 270-degree formula and vice-versa. Portrait stays
 // identity. (Verified on hardware — without the flip, taps landed at the
 // diagonally-opposite point.)
+#if defined(HELTEC_LORA_V4_R8)
+static uint8_t s_point_rotation_state();   // fwd: non-zero only when the PANEL is hardware-rotated
+#endif
 static void rotateSwipeDelta(int dx, int dy, int* odx, int* ody) {
 #if defined(HELTEC_LORA_V4_R8)
-  // R8: no +180 panel baseline (see applyPointRotation) -- plain rotations, V4 cases swapped.
-  switch (s_ui_rotation) {
-    case 1:  *odx =  dy; *ody = -dx; break;  // ROT_90  (baseline-0 panel)
-    case 2:  *odx = -dx; *ody = -dy; break;  // 180
-    case 3:  *odx = -dy; *ody =  dx; break;  // ROT_270
-    default: *odx =  dx; *ody =  dy; break;  // portrait
+  // R8: the swapped map below is justified by the PANEL baseline (LovyanGFX
+  // baseline-0 vs the V4 driver's rotation-2), so it applies only when the
+  // panel is actually hardware-rotated (s_point_rotation != 0). The transient
+  // keyboard landscape uses LVGL sw-rotate with the panel untouched — there
+  // the raw-touch geometry is identical to the plain V4, whose formulas are
+  // the hardware-verified ones (with the R8 map, left/right swipes inverted:
+  // swipe-back could close a chat unexpectedly).
+  if (s_point_rotation_state() != 0) {
+    switch (s_ui_rotation) {
+      case 1:  *odx =  dy; *ody = -dx; break;  // ROT_90  (baseline-0 panel)
+      case 2:  *odx = -dx; *ody = -dy; break;  // 180
+      case 3:  *odx = -dy; *ody =  dx; break;  // ROT_270
+      default: *odx =  dx; *ody =  dy; break;  // portrait
+    }
+    return;
   }
-#else
+#endif
   switch (s_ui_rotation) {
     case 1:  *odx = -dy; *ody =  dx; break;  // ROT_90  (panel-rot-2 baseline)
     case 2:  *odx = -dx; *ody = -dy; break;  // 180
     case 3:  *odx =  dy; *ody = -dx; break;  // ROT_270
     default: *odx =  dx; *ody =  dy; break;  // portrait
   }
-#endif
 }
 
 // Hardware-rotation touch-point transform. When the panel is rotated in
@@ -109,6 +120,9 @@ static void rotateSwipeDelta(int dx, int dy, int* odx, int* ody) {
 // it to LVGL. Stays 0 (identity) in portrait — there the keyboard's transient
 // landscape uses LVGL sw_rotate, which transforms the point itself.
 static uint8_t s_point_rotation = 0;
+#if defined(HELTEC_LORA_V4_R8)
+static uint8_t s_point_rotation_state() { return s_point_rotation; }   // fwd-declared above rotateSwipeDelta
+#endif
 void heltecV4CapTouchSetPointRotation(uint8_t r) { s_point_rotation = r & 3; }
 
 static void applyPointRotation(uint16_t* x, uint16_t* y) {
@@ -194,15 +208,18 @@ static void mapTouchToDisplay(uint16_t in_x, uint16_t in_y, uint16_t* out_x, uin
   if (out_y) *out_y = (uint16_t)y;
 }
 
-static bool probeTouchControllerAddress() {
-  // Known CHSC6x addresses seen across board variants/libraries.
+static uint8_t probeTouchControllerAddress() {
+  // Known CHSC6x addresses seen across board variants/libraries. Returns the
+  // ACKed address (0 if none) — the driver must READ from the address that
+  // actually answered: a variant at 0x15/0x14 used to pass this probe and then
+  // read the hardcoded 0x2E forever ("touch init ok", permanently dead touch).
   static const uint8_t kAddrCandidates[] = {0x2E, 0x15, 0x14};
   for (uint8_t i = 0; i < sizeof(kAddrCandidates); i++) {
     V4CAP_WIRE.beginTransmission(kAddrCandidates[i]);
     uint8_t rc = V4CAP_WIRE.endTransmission();
-    if (rc == 0) return true;
+    if (rc == 0) return kAddrCandidates[i];
   }
-  return false;
+  return 0;
 }
 
 bool heltecV4CapTouchBegin() {
@@ -220,7 +237,8 @@ bool heltecV4CapTouchBegin() {
   if (PIN_TOUCH_INT >= 0) pinMode(PIN_TOUCH_INT, INPUT_PULLUP);
 
   // If controller is absent or bus is unhealthy, skip init and keep UI alive.
-  if (!probeTouchControllerAddress()) {
+  const uint8_t found_addr = probeTouchControllerAddress();
+  if (!found_addr) {
     s_tp = nullptr;
     s_init_ok = false;
     return false;
@@ -229,6 +247,7 @@ bool heltecV4CapTouchBegin() {
   // Use our own INT pin handling above; avoid library-level attachInterrupt side effects.
   // Keep reset pin support so controller can still be hard-reset.
   static chsc6x instance_safe(&V4CAP_WIRE, PIN_TOUCH_SDA, PIN_TOUCH_SCL, -1, PIN_TOUCH_RST);
+  instance_safe._i2c_addr = found_addr;   // read from the address that actually ACKed
   s_tp = &instance_safe;
   s_tp->chsc6x_init();
   // chsc6x_init() re-runs Wire begin internally, so re-apply bounded bus settings.
@@ -404,14 +423,20 @@ bool heltecV4CapTouchPopSwipe(int8_t* x_dir, int8_t* y_dir) {
 static TaskHandle_t s_poll_task = nullptr;
 static uint32_t     s_poll_period_ms = 8;
 static volatile bool s_async_active = false;
+// Screen-off throttle (R8): the 8 ms poll is a ~2 ms blocking I2C read on the
+// SHARED sensor/RTC bus — 24/7, screen off included. 50 ms while dark keeps
+// wake-on-touch responsive enough (worst-case +42 ms to first reaction) and
+// cuts idle bus traffic ~6x. Only the R8 calls the setter; other boards keep
+// the fixed period.
+static volatile bool s_slow_poll = false;
+void heltecV4CapTouchSetSlowPoll(bool slow) { s_slow_poll = slow; }
 
 static void touchPollTaskFn(void* /*arg*/) {
   s_async_active = true;
-  const TickType_t period = pdMS_TO_TICKS(s_poll_period_ms ? s_poll_period_ms : 8);
   TickType_t last_wake = xTaskGetTickCount();
   for (;;) {
     (void)heltecV4CapTouchCheck();
-    vTaskDelayUntil(&last_wake, period);
+    vTaskDelayUntil(&last_wake, pdMS_TO_TICKS(s_slow_poll ? 50 : (s_poll_period_ms ? s_poll_period_ms : 8)));
   }
 }
 

--- a/src/helpers/input/HeltecV4CapTouch.h
+++ b/src/helpers/input/HeltecV4CapTouch.h
@@ -57,6 +57,7 @@ bool heltecV4CapTouchIsSwiping();
  * the display rotation changes (boot + on a rotation toggle). Default 0.
  */
 void heltecV4CapTouchSetRotation(uint8_t lvgl_rot);
+void heltecV4CapTouchSetSlowPoll(bool slow);   // screen-off poll throttle (R8 shared-bus)
 
 /**
  * Set the HARDWARE-rotation touch-point transform. When the panel is rotated

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ static uint32_t _atoi(const char* sp) {
   DataStore store(LittleFS, rtc_clock);
 #elif defined(ESP32)
   #include <SPIFFS.h>
-  #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+  #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
     #include <SD.h>
     #include <Preferences.h>
     #if defined(TLORA_PAGER)
@@ -246,10 +246,18 @@ void halt() {
   bool wifi_needs_reconnect = false;
   unsigned long last_wifi_reconnect_attempt = 0;
 #endif
+#if defined(ESP32)
+// Last STA disconnect reason (esp_wifi wifi_err_reason_t). The UI's coarse
+// "auth failed" (WL_CONNECT_FAILED) covers wrong password, WPA3-SAE handshake
+// failure and AP-side rejection alike — the reason number tells them apart
+// (15 = 4-way handshake timeout ≈ wrong password; 2/202 = auth expired/failed
+// ≈ WPA3-only or auth mismatch; 201 = AP not found).
+volatile uint8_t g_wifi_last_disc_reason = 0;
+#endif
 
 #include "esp_task_wdt.h"   // task-watchdog reconfigure — see setup() (GH #56)
 
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
 // ---- SPIFFS -> SD migration (fixes the beta_36 "lost my profile" upgrades) ----
 // Users who flipped "Store data on SD" before beta_36 ran with the toggle IGNORED
 // (the flag never survived a reboot), so their identity/prefs/contacts kept living
@@ -878,12 +886,14 @@ void setup() {
   // failure falls back to SPIFFS so the device always boots.
   bool spiffs_ok = SPIFFS.begin(false);   // try first WITHOUT auto-format
   bool sd_storage = false;
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
   {
    #if defined(TLORA_PAGER)
     extern SPIClass* tloraPagerSharedSPI();    // display/radio/SD shared bus
    #elif defined(HELTEC_LORA_V4_R8)
     extern SPIClass* heltecV4R8SharedSPI();   // FSPI, shared with the TFT (CS=3)
+   #elif defined(HAS_THINKNODE_M9)
+    extern SPIClass* m9SharedSPI();           // radio/display/SD shared bus
    #else
     extern SPIClass* tdeckSharedSPI();        // LoRa SPI bus
    #endif
@@ -913,6 +923,8 @@ void setup() {
     SPIClass* _spi = tloraPagerSharedSPI();
    #elif defined(HELTEC_LORA_V4_R8)
     SPIClass* _spi = heltecV4R8SharedSPI();
+   #elif defined(HAS_THINKNODE_M9)
+    SPIClass* _spi = m9SharedSPI();
    #else
     SPIClass* _spi = tdeckSharedSPI();
    #endif
@@ -1108,7 +1120,7 @@ void setup() {
   // Route touch settings + Wi-Fi creds to the active filesystem (SD when that's
   // the data store, else SPIFFS) instead of NVS. Old NVS values still load and
   // migrate on their next save, so this is a transparent in-place upgrade.
-  #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+  #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
     SdNvsPrefs::useFile(sd_storage ? (fs::FS*)&SD : (fs::FS*)&SPIFFS,
                         sd_storage ? "/meshcomod" : "/prefs");
   #else
@@ -1187,6 +1199,12 @@ void setup() {
                                    // exists so a later WPA re-auth cannot bypass Wi-Fi-first ordering
 #endif
     WiFi.persistent(false);
+    // Record WHY every STA disconnect happened — surfaced by the UI's Wi-Fi
+    // status string as "auth failed (rNN)" so failures are diagnosable on a
+    // device with no serial console. Additive: multiple onEvent handlers coexist.
+    WiFi.onEvent([](WiFiEvent_t, WiFiEventInfo_t info){
+        g_wifi_last_disc_reason = info.wifi_sta_disconnected.reason;
+      }, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
     // NOTE: do NOT enable modem-sleep here. On a fresh, *unassociated* STA (the
     // setup wizard, no creds yet) DTIM modem-sleep naps the radio through the
     // scan dwell, so WiFi.scanNetworks() comes back empty ("no networks found").
@@ -1370,6 +1388,19 @@ void setup() {
 }
 
 void loop() {
+#ifdef R8_DIAG_BATT
+  // TEMP diagnostic (build with -DR8_DIAG_BATT, remove after): raw battery mV
+  // every 5 s to Serial AND as an on-screen toast every 8 s — the R8's
+  // USB-Serial-JTAG resets into the ROM bootloader whenever a host opens the
+  // port, so the screen is the only reliable live readout on this board.
+  { static uint32_t s_batt_next = 0;
+    if (millis() > s_batt_next) { s_batt_next = millis() + 5000;
+      Serial.printf("[BATT] %u mV\n", (unsigned)board.getBattMilliVolts()); } }
+  { static uint32_t s_batt_ui_next = 0;
+    if (millis() > s_batt_ui_next && millis() > 15000) { s_batt_ui_next = millis() + 8000;
+      char b[28]; snprintf(b, sizeof b, "BATT %u mV", (unsigned)board.getBattMilliVolts());
+      ui_task.showAlert(b, 2500); } }
+#endif
   // Run UI first every iteration so splash can dismiss at 3s even if mesh/serial blocks later (was stuck on version screen when the_mesh.loop() ran before ui_task.loop()).
 #ifdef DISPLAY_CLASS
   // ---- beta_31 field-freeze tracer (see UITask.cpp): time each loop section ----

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ static uint32_t _atoi(const char* sp) {
   #include <SPIFFS.h>
   #if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
     #include <SD.h>
+    #include "SdFastClock.h"   // post-mount operating-clock raise (SD_SPI_FAST_HZ boards)
     #include <Preferences.h>
     #if defined(TLORA_PAGER)
       #include <mbedtls/sha256.h>
@@ -996,6 +997,7 @@ void setup() {
         delay(60);
         if (SD.begin(PIN_SD_CS, *_spi, 4000000, "/sd", 6) && SD.cardType() != CARD_NONE) {
           Serial.printf("[BOOT] SD renegotiated %lu -> 4000000 Hz\n", (unsigned long)mounted_hz);
+          mounted_hz = 4000000;
         } else {
           SD.end();
           delay(120);
@@ -1003,6 +1005,9 @@ void setup() {
           if (sd_mounted) Serial.printf("[BOOT] SD stays at %lu Hz (4 MHz renegotiation failed)\n", (unsigned long)mounted_hz);
         }
       }
+      // Operating-clock raise with read-verify (SD_SPI_FAST_HZ boards only; no-op elsewhere).
+      if (sd_mounted) { mounted_hz = sdTryFastClock(PIN_SD_CS, *_spi, mounted_hz, "BOOT"); sd_mounted = mounted_hz != 0; }
+      if (sd_mounted) { extern uint32_t g_sd_operating_hz; g_sd_operating_hz = mounted_hz; }   // About-page readout (UITask.cpp)
     }
 #endif
     if (sd_mounted) {
@@ -1686,8 +1691,16 @@ void loop() {
       // BLE coexistence airtime). Deferred to here on purpose: enabling it on the
       // unassociated STA naps the radio through a scan dwell and breaks the setup
       // wizard's WiFi.scanNetworks() ("no networks found"). One-shot.
+      // Persisted preference (Wi-Fi settings -> "Power save"): default ON, except the V4-R8
+      // where it defaults OFF (perf pass 2026-08-20 — lower-latency app link, steadier
+      // association on its weak 2.4 GHz path). The toggle also applies live once associated.
       static bool modem_sleep_set = false;
-      if (!modem_sleep_set) { WiFi.setSleep(true); modem_sleep_set = true; }
+      if (!modem_sleep_set) {
+        const bool ps = wifiConfigGetPowerSave();
+        WiFi.setSleep(ps);
+        Serial.printf("[wifi] modem power save %s\n", ps ? "on" : "off");
+        modem_sleep_set = true;
+      }
       if (!sntp_kicked) {
         /* Brussels timezone with DST rules baked in (POSIX "CET-1CEST,...").
          * On touch builds the base is shifted by the user's manual hour offset

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1691,14 +1691,19 @@ void loop() {
       // BLE coexistence airtime). Deferred to here on purpose: enabling it on the
       // unassociated STA naps the radio through a scan dwell and breaks the setup
       // wizard's WiFi.scanNetworks() ("no networks found"). One-shot.
-      // Persisted preference (Wi-Fi settings -> "Power save"): default ON, except the V4-R8
-      // where it defaults OFF (perf pass 2026-08-20 — lower-latency app link, steadier
-      // association on its weak 2.4 GHz path). The toggle also applies live once associated.
+      //
+      // Unconditional, and deliberately NOT a user preference. This was briefly
+      // configurable (default off on the V4-R8, for a lower-latency app link), but
+      // WIFI_PS_NONE is not a legal sleep mode while the BT controller is running --
+      // modem sleep is exactly what yields airtime to BLE, and the Wi-Fi PM blob
+      // aborts rather than refusing. An R8 with saved credentials and Bluetooth on
+      // crashed on association every time: task "wifi", abort() in pm_set_sleep_type.
+      // The latency it was buying did not exist either: profiling the companion link
+      // showed sync cost is round-trip COUNT (~40 CMD_GET_CHANNEL), with the firmware
+      // accounting for 0.3% of it. So there is nothing to trade away here.
       static bool modem_sleep_set = false;
       if (!modem_sleep_set) {
-        const bool ps = wifiConfigGetPowerSave();
-        WiFi.setSleep(ps);
-        Serial.printf("[wifi] modem power save %s\n", ps ? "on" : "off");
+        WiFi.setSleep(true);
         modem_sleep_set = true;
       }
       if (!sntp_kicked) {

--- a/src/ui-touch/LuaAppHost.cpp
+++ b/src/ui-touch/LuaAppHost.cpp
@@ -861,7 +861,7 @@ void sendKey(int key) {
     case LV_KEY_DOWN:  named = "down";  break;
     case LV_KEY_LEFT:  named = "left";  break;
     case LV_KEY_RIGHT: named = "right"; break;
-    case LV_KEY_ENTER: named = "enter"; break;
+    case LV_KEY_ENTER: case '\r': named = "enter"; break;   // '\r': physical keyboards send CR, not LV_KEY_ENTER
     case LV_KEY_ESC:   named = "esc";   break;
     case '\b': case 127: named = "backspace"; break;
     default: break;
@@ -1166,6 +1166,44 @@ void luaAppSteer(int dx, int dy) {
   if (!s_h) return;
   const char* dir = (dy < 0) ? "up" : (dy > 0) ? "down" : (dx < 0) ? "left" : (dx > 0) ? "right" : nullptr;
   if (dir) sendInput("swipe", dir, 0, 0);
+}
+
+// Synthetic centre tap (down then up) for boards with no touch: the select key
+// stands in for "tap to start / retry" flows that listen for type=="down".
+void luaAppPress() {
+  if (!s_h || !s_h->body) return;
+  const int x = lv_obj_get_width(s_h->body) / 2;
+  const int y = lv_obj_get_height(s_h->body) / 2;
+  sendInput("down", nullptr, x, y);
+  sendInput("up",   nullptr, x, y);
+}
+
+// True when the running app declares on_input. Touchless boards use this to
+// decide whether the d-pad belongs to the app (steer/press events) or should
+// keep its native meaning so it can drive the app page's own LVGL widgets —
+// display-only apps (Airtime, RF Monitor) otherwise ate every key into a
+// callback that doesn't exist.
+bool luaAppHasOnInput() {
+  if (!s_h || !s_h->L) return false;
+  if (!pushCallback(s_h, "on_input")) return false;
+  lua_pop(s_h->L, 1);
+  return true;
+}
+
+// Page-scroll the app body (display-only apps: RF Monitor's feed runs past the
+// screen and there is no touch to drag it). Returns true while an app is open
+// — even at the scroll edge the key belongs to the page, not to whatever is
+// underneath it.
+bool luaAppScroll(bool up) {
+  if (!s_h || !s_h->body) return false;
+  const lv_coord_t room = up ? lv_obj_get_scroll_top(s_h->body)
+                             : lv_obj_get_scroll_bottom(s_h->body);
+  if (room <= 0) return true;   // at the edge / page not scrollable
+  lv_coord_t step = (lv_coord_t)((s_h->body_h * 3) / 5);
+  if (step > room) step = room;
+  const lv_coord_t cur = lv_obj_get_scroll_y(s_h->body);
+  lv_obj_scroll_to_y(s_h->body, up ? cur - step : cur + step, LV_ANIM_ON);
+  return true;
 }
 
 static void luaAppRootDeletedCb(lv_event_t* e) {

--- a/src/ui-touch/LuaAppHost.h
+++ b/src/ui-touch/LuaAppHost.h
@@ -20,7 +20,10 @@ bool luaAppLaunchFile(const char* id, const char* title, const char* embedded, s
 bool luaAppIsOpen();
 void luaAppDismiss();                 // THE close path (AppPage back hook)
 void luaAppSteer(int dx, int dy);     // trackball/keypad direction -> on_input
+void luaAppPress();                   // synthetic centre tap (down+up) -> on_input, for touchless boards' select key
 bool luaAppKey(int key);              // hardware key -> on_input; true = app consumed it
+bool luaAppHasOnInput();              // app declares on_input? (touchless boards: app keys vs native d-pad)
+bool luaAppScroll(bool up);           // page-scroll the app body (display-only apps on touchless boards)
 void luaAppMessage(const char* channel, const char* sender, const char* text);  // -> on_message
 // Per-app permission bits, stored as a decimal mask in /apps/perms.kv.
 #define LUA_PERM_SEND  1
@@ -29,6 +32,9 @@ void luaAppMessage(const char* channel, const char* sender, const char* text);  
 inline bool luaAppIsOpen() { return false; }
 inline void luaAppDismiss() {}
 inline void luaAppSteer(int, int) {}
+inline void luaAppPress() {}
 inline bool luaAppKey(int) { return false; }
+inline bool luaAppHasOnInput() { return false; }
+inline bool luaAppScroll(bool) { return false; }
 inline void luaAppMessage(const char*, const char*, const char*) {}
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -11449,6 +11449,7 @@ static void sdRestoreRun() {
 
 #if defined(TLORA_PAGER)
   if (!meshcomodSdProfileMatchesInternal()) {
+  the_mesh.persistSyncHistoryNow();
     g_lv.task->showAlert(TR("Copy blocked: SD card holds a different or unreadable profile"), 3600);
     return;
   }
@@ -38478,6 +38479,7 @@ static void rebootToDownloadMode() {
 #endif
 
 static void powerDownloadCb(lv_event_t* e) {
+    the_mesh.persistSyncHistoryNow();      // and the app-sync replay ring (RAM is lost in deep sleep)
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   closePowerMenu();
 #if defined(ESP32)
@@ -38552,6 +38554,7 @@ static void openPowerMenu() {
     }
     lv_obj_add_event_cb(b, cb, LV_EVENT_CLICKED, nullptr);
     lv_obj_t* l = lv_label_create(b);
+    the_mesh.persistSyncHistoryNow(); // and the app-sync replay ring
     lv_label_set_text(l, TR(txt));
     lv_obj_set_style_text_font(l, &g_font_14, LV_PART_MAIN);
     lv_obj_set_style_text_color(l, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
@@ -50564,6 +50567,7 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
   if (touchPrefsGetIgnoreTinyMsgs()) {
     const char* b = body ? body : "";
     while (*b == ' ' || *b == '\t' || *b == '\r' || *b == '\n') b++;   // whitespace is not content
+  the_mesh.persistSyncHistoryNow();  // and the app-sync replay ring
     size_t blen = strlen(b);
     while (blen > 0 && (b[blen-1] == ' ' || b[blen-1] == '\t' ||
                         b[blen-1] == '\r' || b[blen-1] == '\n')) blen--;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -75,7 +75,6 @@
   #endif
 #endif
 #if defined(HAS_THINKNODE_M9)
-  extern void m9SetBacklight(bool on);
   extern SPIClass* m9SharedSPI();
 #endif
 #if defined(HAS_TDECK_GT911)
@@ -6585,6 +6584,15 @@ static void accentBoxCellCb(lv_event_t* e) {
 }
 static void accentBoxMaybeShow() {
   accentBoxHide();                          // each new keystroke clears the last box
+#if defined(HAS_M9_KEYBOARD)
+  // Never on the M9: the box is tap-to-pick (its cells are NAV_SKIP_FLAG by
+  // design) and the key-selection machinery is pager-only (encoder walk +
+  // Enter) — with no touch and no nav path here it would float over the
+  // composer as dead chrome nothing can select. Deliberately suppressed
+  // until an M9 d-pad selection path is built; the Accent-popups settings
+  // row is hidden there for the same reason.
+  return;
+#endif
   if (!s_accent_popups) return;             // user turned accent popups off in settings
   if (!g_lv.keyboard) return;
   lv_obj_t* ta = lv_keyboard_get_textarea(g_lv.keyboard);
@@ -6736,6 +6744,9 @@ static void mentionBoxCellCb(lv_event_t* e) {
 // when a picker is shown (so the caller suppresses the accent box).
 static bool mentionBoxMaybeShow() {
   mentionBoxHide();
+#if defined(HAS_M9_KEYBOARD)
+  return false;   // suppressed like the accent box (see accentBoxMaybeShow): touch-only cells, no key path here
+#endif
   if (!g_lv.keyboard) return false;
   lv_obj_t* ta = lv_keyboard_get_textarea(g_lv.keyboard);
   if (!ta) return false;
@@ -11733,6 +11744,9 @@ static void showSensorsTabToggleCb(lv_event_t* e) {
 
 // Accent-popup picker on/off. Persisted + live: gates accentBoxMaybeShow() so
 // the tap-to-pick accent box stops appearing as you type. Default ON.
+// (Not compiled on the M9 — the pickers are suppressed there and its settings
+// row is hidden, see accentBoxMaybeShow.)
+#if !defined(HAS_M9_KEYBOARD)
 static void accentPopupsToggleCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
   const bool on = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
@@ -11743,6 +11757,7 @@ static void accentPopupsToggleCb(lv_event_t* e) {
   if (!on) accentBoxHide();   // dismiss any box already on screen
   if (g_lv.task) g_lv.task->showAlert(on ? TR("Accent popups: on") : TR("Accent popups: off"), 1100);
 }
+#endif
 
 // One handler for every per-language switch in the multi-select list. The
 // layout id is stashed in the switch's user_data. Flipping a switch updates the
@@ -12890,8 +12905,11 @@ static void buildDeviceSettings(int sec) {
     }
   }
 
+#if !defined(HAS_M9_KEYBOARD)
   /* Accent popups. Typing a Latin letter that has accented variants pops up a
-     tap-to-pick box; turn this off for plain typing. Default on. */
+     tap-to-pick box; turn this off for plain typing. Default on. Not on the
+     M9: the pickers are suppressed there (no touch and no key-selection path
+     — see accentBoxMaybeShow), so the switch would control nothing. */
   {
     int h = settingsRowLabel(body, y, 4, TR("Accent popups"), COLOR_TEXT, &g_font_12, 56);
     lv_obj_t* sw = lv_switch_create(body);
@@ -12907,6 +12925,7 @@ static void buildDeviceSettings(int sec) {
     y += settingsRowLabel(body, y, 0, TR("pick accented letters as you type; off = plain typing"),
                           COLOR_SUB, &g_font_12, 0) + 2;
   }
+#endif
 
 #if defined(HAS_TDECK_KEYBOARD) || defined(HAS_M9_KEYBOARD)
   /* Enter sends the message (default) vs. inserts a newline so you send only via
@@ -12975,7 +12994,7 @@ static void buildDeviceSettings(int sec) {
 #endif
 
 #if CAP_TRACKBALL
-#if defined(HAS_TDECK_KEYBOARD) || defined(HAS_M9_KEYBOARD)
+#if defined(HAS_TDECK_KEYBOARD)   // never the M9: nav is force-set on at boot there (the board's only input) and must not grow an off-switch
   /* Keyboard navigation: off (default) vs on. When no text field is focused, the
      WASDZ cluster moves focus so the whole UI is reachable from the keyboard (incl.
      Settings), and the tab hotkeys below jump straight to a tab. The trackball
@@ -20738,7 +20757,7 @@ static void fmSetWallpaperCb(lv_event_t* e) {
   if (s_fm_img_on_sd) snprintf(pref, sizeof pref, "sd:%s", s_fm_img_path);
   else                snprintf(pref, sizeof pref, "%s", s_fm_img_path);
   touchPrefsSetLockWallpaper(pref);
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)   // the set of boards that declare s_lockwall_btn_lbl
   if (s_lockwall_btn_lbl && lv_obj_is_valid(s_lockwall_btn_lbl)) {   // update the settings button if still around
     char disp[64]; lockwallDisplayName(pref, disp, sizeof disp);
     lv_label_set_text(s_lockwall_btn_lbl, disp);
@@ -27522,9 +27541,11 @@ static void renderMapTiles() {
   } else
 #endif
   if (!s_tiles_fs_ready) {
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
     // Pager included: under the launcher there's no "tiles" partition, so point the user at the
     // microSD fallback rather than the (launcher-wrong) "reflash the tiles partition" advice.
+    // M9 included: its cache PREFERS the built-in 16 GB microSD (every unit ships with one), so
+    // this state almost always means the card didn't mount — reflash advice would be the wrong fix.
     if (SD.cardType() != CARD_NONE)
       lv_label_set_text(s_map_status_lbl,
           TR("Map storage error.\n\nSD card detected but the\ntile cache didn't mount.\nReboot to retry."));
@@ -37071,18 +37092,34 @@ static bool m9HandleNavKey(int key) {
       // s_ct_select_mode is a flags=0 registry row (a MODE, not "a popup is
       // open"), so anyPopupOpen() alone would never let Back leave it.
       if (s_setup_root) return true;   // wizard: nothing to back out of
+      // Pan is only the innermost "thing open" while the bare map is frontmost.
+      // A popup stacked over it (CTRL) or a tab jump that missed a clear makes
+      // the flag stale — drop it silently so THIS press acts on what the user
+      // sees, instead of a "Map pan off" toast reading as a dead Back key.
+      if (s_m9_map_pan && (getActiveTab() != MAP_TAB_INDEX || anyPopupOpen()))
+        s_m9_map_pan = false;
       if (s_m9_map_pan) {              // pan mode is the innermost "thing open" on the map
         s_m9_map_pan = false;
         if (g_lv.task) g_lv.task->showAlert(TR("Map pan off"), 900);
       }
       else if (navOpenDropdown())                    navPushTap(LV_KEY_ESC);
-      // An open app page covers everything EXCEPT the Control Center / power
-      // menu (the only popups a key can open OVER an app page here). The app
-      // drawer it was launched from stays open BENEATH it by design — the
-      // generic registry dismiss used to eat that invisible drawer first, so
-      // Back looked dead inside every app (reported bug). Close the page
-      // itself; the drawer is then the next, visible Back target.
-      else if (s_apppage_close && !s_cc_root && !s_power_menu) s_apppage_close();
+      // CTRL stacks the Control Center (and its power menu) over ANY popup,
+      // but both sit near the BOTTOM of the popup registry — the generic
+      // dismiss would close whatever popup is buried BENEATH them (a Files
+      // rename prompt, typed name and all) while the screen looks unchanged.
+      // They are always frontmost when open: close them explicitly, power
+      // menu first (it opens over the CC).
+      else if (s_power_menu)                         closePowerMenu();
+      else if (s_cc_root)                            closeControlCenter();
+      // An open app page covers everything EXCEPT the CC / power menu (peeled
+      // above) and a confirm modal — the Lua send-permission ask is raised
+      // OVER the requesting app's page, and closing the page under the
+      // question would orphan it. The app drawer the page was launched from
+      // stays open BENEATH it by design — the generic registry dismiss used
+      // to eat that invisible drawer first, so Back looked dead inside every
+      // app (reported bug). Close the page itself; the drawer is then the
+      // next, visible Back target.
+      else if (s_apppage_close && !s_confirm_modal)  s_apppage_close();
       else if (anyPopupOpen() || s_ct_select_mode)   hwKeyDismissTopPopup();
       else if (LvChatPanel* cp = navOpenChatPanel()) closeChatPanel(cp);
       else                                           navPushTap(LV_KEY_ESC);
@@ -37101,6 +37138,10 @@ static bool m9HandleNavKey(int key) {
       // never chord — bind the standalone press to the Control Center, a
       // one-press quick-settings key matching its label.
       if (s_setup_root) return true;
+      // The CC must never stack OVER the power menu: Back's ladder peels
+      // power first and would close it invisibly beneath the CC (the reverse
+      // stacking is fine — openPowerMenu() closes the CC itself).
+      if (s_power_menu) closePowerMenu();
       openControlCenter();
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_HOME:
@@ -37109,7 +37150,13 @@ static bool m9HandleNavKey(int key) {
         // A full-screen app page (Lua app, Snake, Web…) isn't a popup-registry
         // row — close it and stop: one action per press, so HOME on the Home
         // tab doesn't also toggle the drawer underneath the closing page.
-        s_apppage_close();
+        // CTRL can stack the CC / power menu over the page, and the Lua
+        // send-permission confirm opens over its requesting app — peel the
+        // frontmost layer instead of yanking the page out from under it.
+        if      (s_power_menu)    closePowerMenu();
+        else if (s_cc_root)       closeControlCenter();
+        else if (s_confirm_modal) confirmDismiss();
+        else                      s_apppage_close();
         s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
       }
       if (getActiveTab() == HOME_TAB_INDEX) {
@@ -37117,16 +37164,27 @@ static bool m9HandleNavKey(int key) {
         for (int i = 0; i < 8 && anyPopupOpen(); i++) hwKeyDismissTopPopup();   // still closes anything else on top (registry untouched, Back/etc. keep working)
         setHomeDrawer(!was_open);                            // decide from the snapshot, not the now-mutated flag
       } else {
+        s_m9_map_pan = false;   // leaving the Map: pan must not outlive the tab (a stale flag ate the next Back press)
         navGoToMainTab(HOME_TAB_INDEX);
       }
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_LEFT_MESSAGE:
       if (s_setup_root) return true;
+      s_m9_map_pan = false;   // leaving the Map: same stale-pan clear as HOME
       if (s_apppage_close) s_apppage_close();   // close an open app page — else the jump lands invisibly beneath it
       navGoToMainTab(CHAT_INBOX_TAB_INDEX);
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_SUB_MESSAGE:
       if (s_setup_root) return true;
+      s_m9_map_pan = false;   // the overlay covers the map: arrows must drive the list, not pan under it
+      // NOTHING may stay open beneath the overlay — mentions sits near the
+      // bottom of the popup registry, so any row left open (CC, a Files
+      // rename prompt, …) becomes Back's silent (invisible) next target.
+      // Same bounded loop as HOME; a null-close progress row stops the walk
+      // (blocker semantics), in which case don't stack the overlay either.
+      for (int i = 0; i < 8 && anyPopupOpen(); i++) { if (!hwKeyDismissTopPopup()) break; }
+      if (anyPopupOpen()) { if (g_lv.task) g_lv.task->noteUserInput(); return true; }
+      if (s_apppage_close) s_apppage_close();
       openMentionsScreen();
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_MAP:
@@ -37145,6 +37203,14 @@ static bool m9HandleNavKey(int key) {
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_SUB_MAP:
       if (s_setup_root) return true;
+      s_m9_map_pan = false;   // the page covers the map: same stale-pan clear as SUB_MESSAGE
+      // Same full dismiss as SUB_MESSAGE: nothing may stay open beneath.
+      for (int i = 0; i < 8 && anyPopupOpen(); i++) { if (!hwKeyDismissTopPopup()) break; }
+      if (anyPopupOpen()) { if (g_lv.task) g_lv.task->noteUserInput(); return true; }
+      // Close an open app page first — openAdvertPage() takes the single
+      // s_apppage_close slot, so opening OVER a Lua app would steal its only
+      // key-exit and strand the app unreachable behind the advert page.
+      if (s_apppage_close) s_apppage_close();
       openAdvertPage();
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     default: return false;
@@ -37171,9 +37237,12 @@ static bool m9HandleArrowKey(int key, lv_obj_t* ta) {
     return true;
   }
   // Map pan mode (toggled by the Map key on the Map tab): arrows pan the map
-  // instead of moving focus. Self-clears if the user somehow left the tab.
+  // instead of moving focus. Self-clears if the user somehow left the tab or
+  // a popup got stacked over the map (CTRL's Control Center opens without
+  // changing the active tab) — the arrows must drive what's frontmost, not
+  // nudge the map buried beneath it.
   if (s_m9_map_pan) {
-    if (getActiveTab() != MAP_TAB_INDEX || ta) {
+    if (getActiveTab() != MAP_TAB_INDEX || ta || anyPopupOpen()) {
       s_m9_map_pan = false;
     } else {
       switch (key) {
@@ -37266,6 +37335,11 @@ static void handleHwKey(int key) {
       // ENTER_LONG (this board's only unlock) is eaten by the app and the
       // device can never be unlocked again without the power slider.
       && !(g_lv.task && (g_lv.task->isManualLock() || g_lv.task->isScreenOff()))
+      // A confirm modal (the Lua send-permission ask) is a question for the
+      // USER: arrows/Enter must reach its Allow/Deny buttons, not the app
+      // that raised it — forwarded keys would make the dialog unanswerable
+      // on a board with no touch to tap it.
+      && !s_confirm_modal
       // Display-only apps (no on_input — Airtime, RF Monitor): forward nothing;
       // the d-pad keeps its native meaning so it can focus the page's own
       // buttons (Airtime's Reset), click them with Enter, and page-scroll the
@@ -37599,6 +37673,7 @@ if (g_lv.task && g_lv.task->isManualLock()) {
     s_nav_ta_editing = false;
     s_nav_show = true;
     accentBoxHide();
+    mentionBoxHide();   // leaving edit mode tears down BOTH typing popups, like Enter does
     if (g_lv.task) g_lv.task->noteUserInput();
     return;
   }
@@ -41891,7 +41966,7 @@ static void updateGlobalStatusBar() {
   {
     int htab = (g_lv.tabview) ? (int)lv_tabview_get_tab_act(g_lv.tabview) : -1;
     bool home_zone = (s_settings_open_cat < 0) && !s_apppage_title && (s_chat_title[0] == '\0') && (htab == HOME_TAB_INDEX);
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)
     if (s_fullscreen_view && s_fullscreen_title[0]) home_zone = false;
 #endif
     if (!home_zone && s_left_home_cfg) {
@@ -41966,7 +42041,7 @@ static void updateGlobalStatusBar() {
       lv_label_set_text(g_statusbar.left_label, s_chat_title);
     }
   } else
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)
   if (s_fullscreen_view && s_fullscreen_title[0]) {
     // A fullscreen tool view (Terminal / Files) borrows the left zone for its
     // title, so it can drop its own header row and use the full height.
@@ -50451,9 +50526,11 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
     if (emb_ts > 1700000000 && emb_ts < 2000000000) _ui_msgs[msg_slot].ts = emb_ts;
   }
   syncThreadMeshSlots(thread, channel);
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)
   // Mirror incoming traffic into the terminal live feed (only while it's open).
   // Runs on the mesh thread (core 1, same as the UI loop) so the append is safe.
+  // M9 included: its terminal (and the chat mode's "to <name>"/"send") is fully
+  // wired, so without the mirror a console conversation showed only the TX side.
   if (s_term_log_box) {
     char line[200];
     const bool  has_snr = (meta_flags & MSG_META_HAS_RX);
@@ -51621,8 +51698,23 @@ void UITask::loop() {
     else if (s_kb_bl_mode == 2 && (now - s_kb_last_key_ms) < kKbBacklightIdleMs) kb_bl = 255;
     if (_screen_off || _manual_lock) kb_bl = 0;   // dark/locked screen -> keyboard dark too
     else if (s_msgflash_until && (int32_t)(now - s_msgflash_until) < 0) kb_bl = 255;   // notify pulse
-    static uint8_t s_kb_bl_last = 0xFF;
-    if (kb_bl != s_kb_bl_last) { s_kb_bl_last = kb_bl; m9KeyboardSetBacklight(kb_bl); }
+    // Cache the last duty the controller ACTUALLY took, not the last one
+    // computed: the write is dropped while the controller (its own MCU on the
+    // switched rail) is still booting, or on a NACK — latching a dropped
+    // write would leave the controller on its power-on default until the
+    // next mode/lock change. And 255 is a normal FIRST value (mode "On"
+    // restored from prefs; auto during the first idle window), so a 0xFF
+    // "never written" sentinel would swallow it — use -1, which no real duty
+    // can equal. A failed write stays pending but retries at a calm 250 ms
+    // cadence, not every free-running loop pass: a found-then-wedged bus
+    // would otherwise pay a real I2C transaction (worst case the full Wire
+    // timeout) per pass.
+    static int s_kb_bl_last = -1;
+    static uint32_t s_kb_bl_retry_ms = 0;
+    if ((int)kb_bl != s_kb_bl_last && (int32_t)(now - s_kb_bl_retry_ms) >= 0) {
+      if (m9KeyboardSetBacklight(kb_bl)) s_kb_bl_last = kb_bl;
+      else s_kb_bl_retry_ms = now + 250;
+    }
   }
   serviceLockscreen();
   serviceLockingCountdown(now);
@@ -52157,7 +52249,14 @@ static bool popupRegistryAny() {
 }
 static bool popupRegistryDismissTop() {
   for (const auto& e : k_popup_registry)
-    if (e.close && e.is_open()) { e.close(); return true; }
+    if (e.is_open()) {
+      // Stop at the first OPEN row either way: a null-close row is a key
+      // BLOCKER (progress overlay) — walking past it would dismiss whatever
+      // sits BENEATH the overlay mid-operation (e.g. the fullscreen Files
+      // view under a running SD format).
+      if (e.close) { e.close(); return true; }
+      return false;
+    }
   return false;
 }
 static bool popupRegistryBlocksSwipe() {

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -22639,8 +22639,9 @@ static void openDiscoverPage() {
 // ============================================================
 // Spectrum app  (app-drawer tile -> APPACT_SPECTRUM)
 // ============================================================
-// A handheld swept-tuned spectrum analyzer built on the SX126x. While open it
-// BORROWS the radio from the mesh: main.cpp stops calling the_mesh.loop() (it
+// A handheld swept-tuned spectrum analyzer built on the mesh radio (SX126x on
+// most boards, LR1110 on the ThinkNode M9). While open it BORROWS the radio
+// from the mesh: main.cpp stops calling the_mesh.loop() (it
 // checks spectrumOwnsRadio()) so the mesh never re-arms RX on the home channel
 // while we are hopping the modem across the band. On close we re-apply the
 // mesh's saved radio params and clear the flag, so the next the_mesh.loop()
@@ -22662,11 +22663,23 @@ static void openDiscoverPage() {
 // the radio while we own it.
 static const int   SPEC_BINS      = 160;     // frequency bins across the span
 static const int   SPEC_WF_ROWS   = 48;      // waterfall height (rows of history; zoomed to fit width)
-static const int   SPEC_CHUNK     = 8;       // bins swept per timer tick (~5 ms/bin -> ~42 ms UI block)
+static const int   SPEC_CHUNK     = 8;       // bins swept per timer tick (~5.5 ms/bin -> ~44 ms UI block)
+// Honest-coverage note: 24 MHz / 160 bins = 150 kHz of bin pitch, but each bin
+// listens through a 62.5 kHz channel filter — only ~42% of the span is inside a
+// filter on any sweep, so a narrowband carrier sitting between bin centers is
+// attenuated or invisible. That is the deliberate resolution-vs-coverage trade
+// of a swept analyzer at these constants: 62.5 kHz is the narrowest LoRa RBW the
+// chips offer (adjacent bins resolve crisply); an RBW >= the 150 kHz pitch would
+// close the gap but blur every peak across neighbouring bins.
 static const float SPEC_RBW_KHZ   = 62.5f;   // resolution bandwidth used for each bin read
 static const float SPEC_SPAN_MHZ  = 24.0f;   // total swept span (center ±12 MHz)
-static const float SPEC_FMIN_MHZ  = 137.0f;  // SX126x physical tuning floor (region-agnostic)
-static const float SPEC_FMAX_MHZ  = 1020.0f; // SX126x physical tuning ceiling
+// 150-960 is what BOTH in-tree drivers actually accept: SX1262::setFrequency
+// and LR1110::setFrequency each range-check exactly that (the old 137/1020
+// pair was the SX126x SILICON range, which the driver refuses anyway — bins
+// outside 150-960 silently kept the previous bin's tune and mis-attributed
+// its RSSI).
+static const float SPEC_FMIN_MHZ  = 150.0f;  // driver-enforced tuning floor (SX126x + LR11x0)
+static const float SPEC_FMAX_MHZ  = 960.0f;  // driver-enforced tuning ceiling
 static const int   SPEC_DBM_MIN   = -130;    // chart Y floor (dBm)
 static const int   SPEC_DBM_MAX   = -50;     // chart Y ceiling (dBm)
 static const int   SPEC_DWELL       = 6;     // RSSI reads per bin (peak-hold over the settle window)
@@ -22688,7 +22701,7 @@ static lv_chart_series_t* s_spec_ser      = nullptr;
 static lv_obj_t*          s_spec_wf       = nullptr;    // waterfall canvas
 static lv_color_t*        s_spec_wf_buf   = nullptr;    // PSRAM RGB565 backing buffer (SPEC_BINS x SPEC_WF_ROWS)
 static lv_obj_t*          s_spec_axis_lbl = nullptr;    // start/center/end MHz row
-static lv_obj_t*          s_spec_info_lbl = nullptr;    // "RBW … span … center … gain" readout
+static lv_obj_t*          s_spec_info_lbl = nullptr;    // "RBW … span" readout
 static lv_obj_t*          s_spec_peak_lbl = nullptr;    // live "peak −87 dBm @ 869.7" readout
 static lv_obj_t*          s_spec_scale_lbl = nullptr;   // vertical colour-scale: floor dBm (bottom)
 static lv_obj_t*          s_spec_scale_hi_lbl = nullptr;// vertical colour-scale: ceiling dBm (top)
@@ -22699,7 +22712,6 @@ static float              s_spec_step     = 0.0f;       // per-bin step (MHz)
 static int                s_spec_pos      = 0;          // next bin to sweep this pass
 static uint8_t            s_spec_sf       = 7;          // mesh SF/CR reused for the reads
 static uint8_t            s_spec_cr       = 5;
-static bool               s_spec_gain     = false;      // mesh rx_boosted_gain (for the readout)
 static int                s_spec_floor    = -120;       // smoothed noise-floor estimate (dBm) -> waterfall colour auto-scales to it
 static int                s_spec_ylo      = -130;       // dynamic trace Y range (dBm), tracks live min/max
 static int                s_spec_yhi      = -80;
@@ -22742,8 +22754,9 @@ static void spectrumUpdateFloor() {
 // Sweep a chunk of bins. Spread across several ticks so a full sweep doesn't block
 // the UI. Returns true when a full sweep just completed (caller paints a row).
 //
-// On SX126x boards (RADIO_CLASS defined) we drive the modem DIRECTLY — retune to the
-// bin, startReceive() to ARM RX, settle, then peak-hold several GET_RSSI_INST reads.
+// On boards with a raw RadioLib handle (RADIO_CLASS defined — SX126x family and the
+// M9's LR1110) we drive the modem DIRECTLY — retune to the bin, startReceive() to
+// ARM RX, settle, then peak-hold several GET_RSSI_INST reads.
 // This is the fix for the "dead trace": the wrapper path (setParams + recvRaw) left a
 // stale STATE_RX in the wrapper after the first retune, so recvRaw() never re-armed and
 // every later bin read a meaningless standby RSSI. Going direct also lets us peak-hold
@@ -22759,19 +22772,25 @@ static bool spectrumSweepChunk() {
 #if defined(HAS_THINKNODE_M9)
     // LR1110: skipCalibration — LR1110::setFrequency(f) recalibrates image
     // rejection whenever the retune jumps >= 20 MHz, which the 24 MHz wrap
-    // from band end back to band start does EVERY sweep; a relative RSSI
-    // display doesn't need it (the mesh's own begin() calibration covers the
-    // ±12 MHz span) and it stalls the sweep for nothing.
-    radio.setFrequency(f, true);          // retune (chip -> standby on the new freq)
+    // from band end back to band start does EVERY sweep, stalling the sweep
+    // for nothing. openSpectrumPage already ran one CalibImage over the whole
+    // swept span (begin()'s own calibration only reaches mesh_freq ±4 MHz), so
+    // every bin is inside a calibrated band without per-bin work.
+    // If the retune itself fails, skip the bin's reads (keep its previous
+    // value) rather than attributing the OLD frequency's RSSI to this bin.
+    if (radio.setFrequency(f, true) != RADIOLIB_ERR_NONE) continue;   // retune (chip stays in standby on the new freq)
 #else
-    radio.setFrequency(f);                // retune (chip -> standby on the new freq)
+    // Same skip-on-failure as the LR1110 branch: a rejected retune must not
+    // attribute the old frequency's RSSI to this bin.
+    if (radio.setFrequency(f) != RADIOLIB_ERR_NONE) continue;   // retune (chip -> standby on the new freq)
 #endif
     radio.startReceive();                 // ARM RX — GET_RSSI_INST is only valid in RX
-    // The SX1262's instantaneous-RSSI register needs SEVERAL ms in RX to settle after
-    // arming: at ~1.5 ms it still reads the -127 dBm reset default, only by ~3-4 ms does
-    // it report the true channel power. So we settle, then peak-hold a handful of reads
-    // out to ~4 ms — the late (valid) reads dominate, the early -127s are discarded by
-    // the max(). A single short snapshot read here was the original "dead -127" bug.
+    // The modem's instantaneous-RSSI readout needs SEVERAL ms in RX to settle after
+    // arming (measured on the SX1262; the LR1110 behaves the same): at ~1.5 ms it
+    // still reads the reset default, only by ~3-4 ms does it report the true channel
+    // power. So we settle, then peak-hold a handful of reads out to ~4 ms — the late
+    // (valid) reads dominate, the early defaults are discarded by the max(). A single
+    // short snapshot read here was the original "dead -127" bug.
     delayMicroseconds(SPEC_SETTLE_US);
     int peak = -200;
     for (int k = 0; k < SPEC_DWELL; k++) {
@@ -22787,16 +22806,32 @@ static bool spectrumSweepChunk() {
 #else
       int r = (int)radio.getRSSI(false);  // instantaneous channel RSSI (dBm)
 #endif
-      if (r > peak) peak = r;
+      // Both driver families return 0 dBm when the underlying RSSI read fails
+      // (an SPI/BUSY hiccup on this shared bus) — and 0 would win the peak-hold,
+      // paint a full-scale spike, and blow the auto-scaled Y range out for tens
+      // of sweeps (it only contracts SPEC_Y_DECAY dB per sweep). Real channel
+      // power can never plausibly reach -5 dBm at this RBW, so discard anything
+      // outside (-180, -5) instead of letting one glitch squash the trace.
+      if (r <= -5 && r >= -180 && r > peak) peak = r;
       delayMicroseconds(SPEC_READ_GAP_US);
     }
 #if defined(HAS_THINKNODE_M9)
-    radio.standby();   // getRSSI(…, skipReceive) no longer drops RX for us — leave the bin cleanly
+    // Park in STDBY_XOSC (raw mode byte 0x01), NOT the default standby(): the
+    // plain call selects STDBY_RC, which stops the TCXO on this board (it is
+    // powered from the chip's DIO3 rail), so the next bin's startReceive would
+    // re-pay the ~5 ms TCXO startup RadioLib programmed — roughly doubling the
+    // per-bin cost. XOSC standby keeps the TCXO running between bins (~5.5 ms
+    // per bin expected; re-verify with a micros() log on hardware). The raw
+    // byte is deliberate: this RadioLib defines RADIOLIB_LR11X0_STANDBY_XOSC
+    // with the SAME value as STANDBY_RC (both 0x00), so the named constant
+    // would silently select RC again. closeSpectrumPage's restore drops the
+    // chip back to a true STDBY_RC before handing it to the mesh.
+    radio.standby(0x01);
 #endif
-    s_spec_rssi[i] = (int16_t)peak;
+    if (peak > -200) s_spec_rssi[i] = (int16_t)peak;   // every read discarded -> keep the old bin
   }
 #else
-  // Non-SX126x fallback (e.g. the Tanmatsu LoRa bridge): wrapper single read.
+  // No raw radio handle (e.g. the Tanmatsu LoRa bridge): wrapper single read.
   uint8_t scratch[8];
   for (int i = s_spec_pos; i < end; i++) {
     const float f = s_spec_start + (float)i * s_spec_step;
@@ -22916,6 +22951,20 @@ static void spectrumTimerCb(lv_timer_t* t) {
 static void spectrumRestoreRadio() {
   if (!s_spectrum_active) return;     // idempotent — never restore/clear twice
   NodePrefs* p = the_mesh.getNodePrefs();
+#if defined(HAS_THINKNODE_M9)
+  // The sweep left the chip parked in STDBY_XOSC; drop to a true STDBY_RC first
+  // so the mesh gets the chip back in the standby mode RadioLib's own flow uses
+  // (and because CalibImage is only legal in RC standby). Then re-run image
+  // calibration over the mesh channel ±4 MHz — the exact band begin() had
+  // calibrated — so the mesh RX returns to its begin()-time image rejection
+  // instead of the sweep's span-wide compromise cal. setParams below normally
+  // stays under the driver's 20 MHz auto-recal trigger, so nothing else would
+  // restore it (a mesh channel within ~8 MHz of the 150/960 band edge clamps
+  // the span asymmetrically and CAN leave the last bin >20 MHz out — the
+  // auto-recal then fires redundantly before this explicit one; harmless).
+  radio.standby();
+  if (p) radio.calibrateImageRejection(p->freq - 4.0f, p->freq + 4.0f);
+#endif
   if (p) {
     radio_driver.setParams(p->freq, p->bw, p->sf, p->cr);
     radio_driver.setTxPower(p->tx_power_dbm);
@@ -23347,6 +23396,39 @@ static void openRemotePage() {
 
 static void openSpectrumPage() {
   closeSpectrumPage();
+#if defined(HAS_THINKNODE_M9)
+  // A mesh transmit may be ON AIR right now: sends are asynchronous (startSendRaw
+  // arms the chip and returns while the packet is still transmitting), and this
+  // callback runs right after the_mesh.loop() in the same task. Seizing the radio
+  // immediately would cut that packet off mid-air — lost packet plus a partial
+  // burst splattered across the channel. The mesh and UI share one task, so at
+  // this boundary the wrapper is in RX whenever no send is pending; if it is NOT,
+  // wait (bounded) for the transmit to finish before taking over. isSendComplete()
+  // consumes the TX-done event, so the dispatcher will later expire this packet as
+  // a timed-out send — a stats/log blemish, versus truncating it on the air (the
+  // packet double-counts: n_sent++ from the consumed TX-done plus the timeout
+  // path's logTxFail; that timeout's finishTransmit also blips the restored RX
+  // for one mesh-loop pass — all transient). The cap means a stuck flag can only
+  // delay the sweep, never hang it. Two accepted costs: this wait runs on the
+  // shared UI/mesh task, so LVGL and the keys freeze for its duration (~2.3 s at
+  // the shipping SF8/BW62.5 config, 6 s absolute cap) — tolerable because it only
+  // triggers while a packet is genuinely on air; and in the rare one-loop-pass
+  // window where a radio-error path left the wrapper IDLE (not RX, nothing
+  // pending), the wait burns the full cap for nothing — telling IDLE apart from
+  // TX-in-flight needs a wrapper accessor that doesn't exist yet; bounded and
+  // self-recovering, so tolerated. (The same truncation exists on every board,
+  // but only this port's dispatcher-recovery path has been re-validated, so the
+  // wait stays M9-only for now.)
+  if (!radio_driver.isInRecvMode()) {
+    uint32_t cap = radio_driver.getEstAirtimeFor(MAX_TRANS_UNIT) * 3 / 2;   // dispatcher's own worst-case send budget
+    if (cap > 6000) cap = 6000;
+    const uint32_t t0 = millis();
+    while (millis() - t0 < cap) {
+      if (radio_driver.isSendComplete() || radio_driver.isInRecvMode()) break;
+      delay(5);
+    }
+  }
+#endif
   // Park the buffered-receive drain task while this page drives the raw radio.
   // The acquire/release pair guarantees no drain is mid-flight when we take over.
   radio_driver.radioAcquire();
@@ -23361,11 +23443,10 @@ static void openSpectrumPage() {
   float center = pr ? pr->freq : 915.0f;
   s_spec_sf   = pr ? pr->sf : 7;
   s_spec_cr   = pr ? pr->cr : 5;
-  s_spec_gain = pr ? (pr->rx_boosted_gain != 0) : false;
   float span = SPEC_SPAN_MHZ;
   // Centre the sweep on the node's HOME frequency for ANY region (US915 / EU868 / 433 /
   // AU915 …) — never pin it to a US-ISM window, or non-US users would sweep an empty band
-  // that never includes their channel. Clamp only to the SX126x's physical tuning range.
+  // that never includes their channel. Clamp only to the radio's physical tuning range.
   float start = center - span * 0.5f;
   float stop  = center + span * 0.5f;
   if (start < SPEC_FMIN_MHZ) start = SPEC_FMIN_MHZ;
@@ -23382,6 +23463,19 @@ static void openSpectrumPage() {
   // Configure the modem ONCE for the scan: a narrow resolution bandwidth so adjacent
   // bins resolve, and boosted RX gain for sensitivity. The per-bin sweep then only
   // changes frequency, which keeps each bin fast. (Restored to mesh config on close.)
+  // Drop to standby FIRST: the chip is still in mesh RX at this point, and the
+  // datasheets describe these config commands as standby-mode commands. Whether the
+  // silicon actually rejects them from RX is unverified — but one SPI command is
+  // cheap hardening against the first sweep running on stale modem config.
+  radio.standby();
+#if defined(HAS_THINKNODE_M9)
+  // LR1110: image rejection is only calibrated where the chip was told to
+  // calibrate it — begin() covered mesh_freq ±4 MHz, NOT this ±12 MHz span. One
+  // CalibImage over the whole span (legal from the RC standby above, a few ms,
+  // once per open) makes every bin's skipCalibration retune within spec; the
+  // close path re-runs the mesh's own ±4 MHz calibration on the way out.
+  radio.calibrateImageRejection(start, stop);
+#endif
   radio.setBandwidth(SPEC_RBW_KHZ);
   radio.setRxBoostedGainMode(true);
 #endif
@@ -23516,9 +23610,11 @@ static void openSpectrumPage() {
   lv_obj_set_style_text_color(s_spec_axis_lbl, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
   lv_obj_set_pos(s_spec_axis_lbl, chart_x, wf_y + wf_disp_h + 3);
 
-  // Each bin needs ~4 ms (the SX1262 RSSI settle), so SPEC_CHUNK=5 caps the per-tick
-  // radio work at ~20 ms (smooth UI blocks); a 28 ms tick keeps ~30% idle for LVGL.
-  // A full 160-bin sweep takes ~32 ticks (~0.9 s) -> a fresh waterfall row ~every 0.9 s.
+  // Each bin costs ~5.5 ms (1.5 ms settle + ~2.4 ms of peak-hold reads + retune/RX
+  // command overhead), so SPEC_CHUNK=8 blocks the UI ~44 ms per tick; the 8 ms timer
+  // makes the ticks run essentially back-to-back, so a full 160-bin sweep is 20
+  // ticks ≈ ~1 s and the quarter-sweep waterfall rows land ~every 250 ms. (Numbers
+  // assume the between-bin XOSC standby holds the TCXO up — re-time on hardware.)
   s_spec_timer = lv_timer_create(spectrumTimerCb, 8, nullptr);    // ticks back-to-back with the sweep chunks; waterfall + trace repaint every quarter sweep (~250 ms)
   lv_obj_move_foreground(s_spec_root);
   lv_obj_move_foreground(g_statusbar.root);   // keep the tall title bar above this page

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -62,6 +62,7 @@
 #endif
 #if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
   #include <SD.h>             // microSD — T-Deck/M9 on the LoRa SPI, V4-R8 on the TFT SPI
+  #include "SdFastClock.h"    // post-mount operating-clock raise (SD_SPI_FAST_HZ boards)
   #include "sd_diskio.h"      // internal Arduino-SD drive helpers (sdcard_init / sd_*_raw)
   extern SPIClass* tdeckSharedSPI();
   // FatFs mkfs (the prebuilt ESP-IDF compiles f_setlabel OUT — FF_USE_LABEL=0 —
@@ -2149,6 +2150,10 @@ static bool g_cap_touch_hw_started = false;
 // LVGL just calls flush_cb more often.
 static constexpr int LV_DRAW_BUF_LINES = 24;
 static lv_color_t* g_draw_buffer = nullptr;
+// Operating clock of the LAST successful SD.begin() on SPI-SD boards (0 = none). Recorded at
+// every mount/remount site (main.cpp boot adoption + the two UITask mounts) because SD.begin's
+// clock is the session clock; Settings -> About reports it on the R8 (no serial console there).
+uint32_t g_sd_operating_hz = 0;
 static uint32_t    g_draw_buf_px  = 240 * LV_DRAW_BUF_LINES;   // actual buffer size in px; shrinks if the full alloc fails at boot
 #if CAP_LARGE_SCREEN
 // UI resolution scaling (Tanmatsu, no touchscreen). LVGL renders at s_lv_pw x s_lv_ph (PHYSICAL
@@ -3230,7 +3235,16 @@ static void lvglFlush(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_color_t
     return;
   }
 #endif
+#if defined(HELTEC_LORA_V4_R8)
+  // Async DMA band flush: returns as soon as the swapped copy is handed to the SPI DMA, so
+  // LVGL renders the next band while this one drains; the last band of the refresh closes
+  // the frame transaction. The screenshot/web-mirror copies below read color_p, which the
+  // driver has already copied out — unaffected. (LGFXDisplay::flushBandRGB565)
+  display.flushBandRGB565(area->x1, area->y1, w, h, reinterpret_cast<uint16_t*>(color_p),
+                          lv_disp_flush_is_last(disp_drv));
+#else
   display.writePixelsRGB565(area->x1, area->y1, w, h, reinterpret_cast<uint16_t*>(color_p));
+#endif
   if (g_shot_buf) {                       // mirror this area into the screenshot buffer
     for (int32_t row = 0; row < h; ++row) {
       const int32_t dy = area->y1 + row;
@@ -3821,10 +3835,10 @@ static void navRefocusFirstVisible(lv_obj_t* p) {
 }
 // Small key hints over each menubar icon — shown only while keyboard nav is on.
 static void navMenubarKeysSync() {
-#if defined(HAS_TANMATSU) || defined(TLORA_PAGER)
+#if defined(HAS_TANMATSU) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
   // Tanmatsu menubar uses the coloured F-key shapes, not letter hotkeys. The
   // pager prints each fixed mnemonic beside its icon directly in the tab label,
-  // so neither target needs this optional overlay. A plain `return` isn't enough
+  // so neither target needs this optional overlay. The M9 has no tab bar at all. A plain `return` isn't enough
   // since the body below still needs s_kbd_nav to exist at compile time; exclude it.
 #else
   if (!g_lv.tabview) return;
@@ -10639,7 +10653,8 @@ static void buildRadioSettings() {
 
 #if defined(HELTEC_LORA_V4_TFT)
   // Heltec V4.3 only: the external FEM's high-gain receive amplifier (~17 dB). Bypassed by
-  // default; a big win in quiet/remote sites, but can desensitize in noisy areas. This is
+  // default on the plain V4 (ON by default on the V4-R8 since prefs v49); a big win in
+  // quiet/remote sites, but can desensitize in noisy areas. This is
   // SEPARATE from the SX1262's tiny internal "boosted gain". Hidden on V4.2 (no switchable LNA).
   if (board.femLnaControllable()) {
     int rh = settingsRowLabel(body, y, 4, TR("High-gain receiver (FEM LNA)"), COLOR_TEXT, &g_font_12, 56);
@@ -11434,6 +11449,7 @@ static void sdRestoreRun() {
   g_lv.task->persistHistoryNow();
   discoveredFlushNow();
   the_mesh.flushContactsIfDirty();
+  the_mesh.persistSyncHistoryNow();
   if (!touchPrefsFlush()) {
     g_sd_migration_blocked = true;
     g_lv.task->showAlert(TR("Copy blocked: internal data is busy"), 2600);
@@ -11449,7 +11465,6 @@ static void sdRestoreRun() {
 
 #if defined(TLORA_PAGER)
   if (!meshcomodSdProfileMatchesInternal()) {
-  the_mesh.persistSyncHistoryNow();
     g_lv.task->showAlert(TR("Copy blocked: SD card holds a different or unreadable profile"), 3600);
     return;
   }
@@ -13388,6 +13403,22 @@ static void buildDeviceSettings(int sec) {
 #else
     mk_info(TR("Model:"), "Heltec LoRa32 V4");
 #endif
+#if defined(HELTEC_LORA_V4_R8)
+    // Perf-pass readout (2026-08-20). This board has no reachable serial console, so the
+    // four runtime facts that pass needs verified live here: CPU clock, display bus clock +
+    // flush mode (DMA = async band flush active), micro-SD operating clock, FEM LNA state.
+    {
+      char sd[16];
+      if (g_sd_operating_hz >= 1000000)   snprintf(sd, sizeof sd, "%lu MHz", (unsigned long)(g_sd_operating_hz / 1000000));
+      else if (g_sd_operating_hz > 0)     snprintf(sd, sizeof sd, "%lu kHz", (unsigned long)(g_sd_operating_hz / 1000));
+      else                                snprintf(sd, sizeof sd, "none");
+      snprintf(buf, sizeof(buf), "CPU %u · TFT %u MHz %s · SD %s · LNA %s",
+               (unsigned)getCpuFrequencyMhz(), (unsigned)(LGFX_SPI_WRITE_HZ / 1000000),
+               display.asyncFlushActive() ? "DMA" : "sync", sd,
+               board.femLnaControllable() ? (touchPrefsGetFemLna() ? "on" : "off") : "n/a");
+      mk_info(TR("Perf:"), buf);
+    }
+#endif
     // Public key prefix (first 8 bytes = 16 hex)
     {
       const uint8_t* pk = the_mesh.getSelfPubKey();
@@ -14912,6 +14943,18 @@ static void buildMqttSettings() {
 #endif
 }
 
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+// Wi-Fi modem power save: persist + apply live. Only touches the driver once associated —
+// WiFi.setSleep() on an unassociated STA naps the radio through scan dwells (see main.cpp).
+// esp_wifi_set_ps is a plain setter (no disconnect/begin), so it is safe from the LVGL ctx.
+static void wifiPowerSaveToggleCb(lv_event_t* e) {
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+  const bool on = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
+  wifiConfigSetPowerSave(on);
+  if (WiFi.status() == WL_CONNECTED) WiFi.setSleep(on);
+}
+#endif
+
 static void buildWifiSettings() {
   lv_obj_t* body = createSettingsModal("", SettingsModalKind::Wifi);   // no group header — the top bar already says "Wi-Fi"
   int y = 0;
@@ -14931,6 +14974,18 @@ static void buildWifiSettings() {
   lv_obj_set_pos(g_set_modal.wifi_sta_status_l, 2, y + SC(7));
   lv_label_set_text(g_set_modal.wifi_sta_status_l, TR("Loading..."));
   y += SC(30);
+
+  // Modem power save (DTIM sleep) — see wifiPowerSaveToggleCb. Default ON; OFF on the V4-R8.
+  {
+    int rh = settingsRowLabel(body, y, 4, TR("Power save (modem sleep)"), COLOR_TEXT, &g_font_12, 56);
+    lv_obj_t* sw = lv_switch_create(body);
+    lv_obj_align(sw, LV_ALIGN_TOP_RIGHT, 0, y);
+    if (wifiConfigGetPowerSave()) lv_obj_add_state(sw, LV_STATE_CHECKED);
+    lv_obj_add_event_cb(sw, wifiPowerSaveToggleCb, LV_EVENT_VALUE_CHANGED, nullptr);
+    y += LV_MAX(34, rh + 10);
+    y += settingsRowLabel(body, y, 0, TR("Off: snappier app/TCP link, steadier on a weak signal. On: less power, kinder to Bluetooth."),
+                          COLOR_SUB, &g_font_12, 0) + 2;
+  }
 
   // Make sure the network we're currently using shows up as saved, and on first
   // run import any legacy 3-slot profiles into the new known-networks store.
@@ -19868,8 +19923,13 @@ static bool fmSdTryMount() {
         SD.end();
         delay(120);
         mounted = SD.begin(PIN_SD_CS, *spi, mounted_hz, "/sd", 6) && SD.cardType() != CARD_NONE;
+      } else {
+        mounted_hz = 4000000;
       }
     }
+    // Operating-clock raise with read-verify (SD_SPI_FAST_HZ boards only; no-op elsewhere).
+    if (mounted) { mounted_hz = sdTryFastClock(PIN_SD_CS, *spi, mounted_hz, "SD"); mounted = mounted_hz != 0; }
+    if (mounted) g_sd_operating_hz = mounted_hz;
   }
 #endif
   if (mounted) {
@@ -23489,6 +23549,12 @@ static void openSpectrumPage() {
   lv_obj_set_style_bg_opa(s_spec_root, LV_OPA_COVER, LV_PART_MAIN);
   lv_obj_clear_flag(s_spec_root, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_event_cb(s_spec_root, spectrumDismissCb, LV_EVENT_CLICKED, nullptr);
+  // Keyboard/d-pad nav (M9, T-Deck, Tanmatsu): nothing on this page is actionable — the
+  // chart and the waterfall's scale box are plain containers, so the nav collector was
+  // highlighting them for no reason. Skip the whole subtree (same as the lock screen):
+  // the focus group stays empty and the only way out is Back (hardware key / bar chevron /
+  // Esc — all routed through the page ladder, none of which needs focus).
+  lv_obj_add_flag(s_spec_root, NAV_SKIP_FLAG);
 
   // Settings-subpage chrome: the GLOBAL status bar goes tall and shows "‹ Spectrum"
   // (tap the bar = Back). Content insets below the bar's lower row — no second header.
@@ -27765,11 +27831,11 @@ static bool       s_map_show_links = true;
 static lv_obj_t*  s_map_link_objs[k_map_links_max] = {};
 static lv_point_t s_map_link_pts[k_map_links_max][2];
 
-// Per-element visibility of the map's on-screen text/markers (persisted; all
-// default shown). Coords = bottom-left read-out, TileXYZ = the zoom + tile path
-// line, Contacts = the contact markers.
+// Per-element visibility of the map's on-screen text/markers (persisted; coords +
+// contacts default shown, the tile line default hidden since prefs v50). Coords =
+// bottom-left read-out, TileXYZ = the zoom + tile path line, Contacts = the contact markers.
 static bool s_map_show_coords    = true;
-static bool s_map_show_tilexyz   = true;
+static bool s_map_show_tilexyz   = false;
 static bool s_map_show_contacts  = true;
 static bool s_map_tile_debug     = false;  // developer: tile-pipeline diagnostic overlay on the zoom line (off by default)
 static bool s_map_direct_only    = false;  // when true, only 0-hop (directly-heard) contacts appear
@@ -38413,6 +38479,7 @@ static void powerOffCb(lv_event_t* e) {
     g_lv.task->persistHistoryNow();        // flush chat before we go down
     discoveredFlushNow();                  // and the Discovered ring
     the_mesh.flushContactsIfDirty();       // and any coalesced contacts refresh
+    the_mesh.persistSyncHistoryNow();      // and the app-sync replay ring (RAM is lost in deep sleep)
     touchPrefsFlush();                     // and all queued A/B preference snapshots
 #if defined(HELTEC_LORA_V4_R8)
     g_lv.task->showAlert(TR("Powering off\xE2\x80\xA6 press BOOT to wake"), 1500);
@@ -38479,7 +38546,6 @@ static void rebootToDownloadMode() {
 #endif
 
 static void powerDownloadCb(lv_event_t* e) {
-    the_mesh.persistSyncHistoryNow();      // and the app-sync replay ring (RAM is lost in deep sleep)
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   closePowerMenu();
 #if defined(ESP32)
@@ -38488,6 +38554,7 @@ static void powerDownloadCb(lv_event_t* e) {
   if (g_lv.task) {
     g_lv.task->persistHistoryNow();   // flush chat before we go down
     discoveredFlushNow();             // and the Discovered ring
+    the_mesh.persistSyncHistoryNow(); // and the app-sync replay ring
     touchPrefsFlush();                 // and all queued A/B preference snapshots
     g_lv.task->showAlert(TR("Download mode\xE2\x80\xA6 reflash over USB"), 1500);
   }
@@ -38554,7 +38621,6 @@ static void openPowerMenu() {
     }
     lv_obj_add_event_cb(b, cb, LV_EVENT_CLICKED, nullptr);
     lv_obj_t* l = lv_label_create(b);
-    the_mesh.persistSyncHistoryNow(); // and the app-sync replay ring
     lv_label_set_text(l, TR(txt));
     lv_obj_set_style_text_font(l, &g_font_14, LV_PART_MAIN);
     lv_obj_set_style_text_color(l, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
@@ -44417,10 +44483,14 @@ static void buildUiTree() {
 
   lv_obj_t* tab_btns = lv_tabview_get_tab_btns(g_lv.tabview);
 #if defined(HAS_THINKNODE_M9)
-  // TABBAR_H is 0 on this board (see its definition) — hide the zero-height
-  // btnmatrix outright so it can never paint, hit-test, or take focus.
+  // No tab bar on this board (TABBAR_H == 0, see its definition): hide the zero-height
+  // btnmatrix outright so it can never paint, hit-test, or take focus — and build NONE of
+  // the bar chrome below (surface styling, Home re-tap / swipe-up gestures, key hints, the
+  // tab font, the accent "glow" indicator). The M9 switches screens with its dedicated
+  // HOME/MESSAGE/MAP keys and the app drawer; a bottom highlight over content was the only
+  // visible leftover of the bar once the icons went.
   lv_obj_add_flag(tab_btns, LV_OBJ_FLAG_HIDDEN);
-#endif
+#else
   // Tab bar bar itself sits on pure BG, not the panel — keeps the bottom
   // strip indistinguishable from the rest of the screen except for the
   // active-tab highlight.
@@ -44453,6 +44523,7 @@ static void buildUiTree() {
 #if CAP_TRACKBALL
   lv_obj_add_event_cb(tab_btns, navMenubarSizeCb, LV_EVENT_SIZE_CHANGED, nullptr);  // keep the keyboard-nav key hints positioned
 #endif
+#endif  // !HAS_THINKNODE_M9 — tab-bar chrome
 
   // Tab labels: icons-only on touch targets; the 480px-wide Pager prefixes each
   // icon with its physical-keyboard mnemonic so the shortcuts are discoverable.
@@ -44491,7 +44562,9 @@ static void buildUiTree() {
   lv_obj_t* tab_settings = lv_tabview_add_tab(g_lv.tabview, LV_SYMBOL_SETTINGS);
 #endif
   // Slightly larger font for icons so they're easy to tap.
-#if CAP_UI_SIZE
+#if defined(HAS_THINKNODE_M9)
+  // no tab bar on the M9 (see above) — nothing to size
+#elif CAP_UI_SIZE
   lv_obj_set_style_text_font(tab_btns, &g_font_tab, LV_PART_MAIN);
 #else
   lv_obj_set_style_text_font(tab_btns, &g_font_16, LV_PART_MAIN);
@@ -44566,11 +44639,14 @@ static void buildUiTree() {
 #endif
   lv_obj_add_flag(s_chat_unread_badge, LV_OBJ_FLAG_HIDDEN);
 
+#if !defined(HAS_THINKNODE_M9)
   // Thin rounded accent "glow" bar that marks the active tab. A child of the
   // screen (like s_update_badge) created BEFORE the chat overlays so those cover
   // it, and above the tabview so it shows over the bottom bar. A soft accent
   // shadow gives it the glow; updateTabIndicator() slides it under the active
-  // tab and hides it on the map.
+  // tab and hides it on the map. NOT built on the M9 (no tab bar): it sat on the
+  // screen, not in the bar, so hiding the bar left it glowing over the content's
+  // bottom edge — the "lingering tab highlight". updateTabIndicator() null-guards.
   s_tab_indicator = lv_obj_create(lv_scr_act());
   lv_obj_remove_style_all(s_tab_indicator);
   lv_obj_clear_flag(s_tab_indicator, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
@@ -44583,6 +44659,7 @@ static void buildUiTree() {
   lv_obj_set_style_shadow_opa(s_tab_indicator, LV_OPA_40, LV_PART_MAIN);
   lv_obj_set_style_shadow_spread(s_tab_indicator, 0, LV_PART_MAIN);
   updateTabIndicator();   // place it under the initial active tab
+#endif  // !HAS_THINKNODE_M9
 
   // Create full-screen detail overlays (hidden until a thread is tapped)
   makeChatDetail(g_lv.dm);
@@ -48502,7 +48579,9 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   // sluggishness. 160 MHz is the known-good 2x bump; 240 MHz showed RGB565
   // noise on the map's SJPG decode, so 160 is the ceiling. The T-Deck sets no
   // ESP32_CPU_FREQ so it already boots at the 240 MHz default — bumping only
-  // the V4 here avoids dragging the T-Deck *down* to 160.
+  // the V4 here avoids dragging the T-Deck *down* to 160. The V4-R8 env now
+  // sets ESP32_CPU_FREQ=240 itself (whole of setup() at full clock), so this
+  // is a no-op there.
 #if !defined(HAS_TDECK_GT911)
   setCpuFrequencyMhz(240);   // S3 max; watch the map tiles for SJPG decode noise (drop to 160 if it shows)
 #endif
@@ -49308,8 +49387,8 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     // mesh so it survives reboot. OFF by default — no effect unless the user enabled it.
     the_mesh.setScopeDirectFloods(touchPrefsGetScopeDirect());
 #if defined(HELTEC_LORA_V4_TFT)
-    // Heltec V4.3 high-gain FEM LNA: apply the saved state at boot (default OFF / bypassed,
-    // matching the hardware). No-op on a V4.2 board (femLnaControllable() == false).
+    // Heltec V4.3 high-gain FEM LNA: apply the saved state at boot (default OFF / bypassed on
+    // the plain V4; ON on the V4-R8 since prefs v49). No-op on a V4.2 board (femLnaControllable() == false).
     if (board.femLnaControllable()) board.setFemLnaEnable(touchPrefsGetFemLna());
 #endif
 #if defined(HAS_TDISPLAY_P4)
@@ -50488,6 +50567,7 @@ void UITask::rebootDevice() {
   }
   discoveredFlushNow();   // persist the Discovered ring before we go down
   the_mesh.flushContactsIfDirty();   // and any coalesced contacts refresh (card-less devices)
+  the_mesh.persistSyncHistoryNow();  // and the app-sync replay ring
   touchPrefsFlush();       // finish queued A/B snapshots before reset
   if (_board) _board->reboot();
 }
@@ -50567,7 +50647,6 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
   if (touchPrefsGetIgnoreTinyMsgs()) {
     const char* b = body ? body : "";
     while (*b == ' ' || *b == '\t' || *b == '\r' || *b == '\n') b++;   // whitespace is not content
-  the_mesh.persistSyncHistoryNow();  // and the app-sync replay ring
     size_t blen = strlen(b);
     while (blen > 0 && (b[blen-1] == ' ' || b[blen-1] == '\t' ||
                         b[blen-1] == '\r' || b[blen-1] == '\n')) blen--;
@@ -50931,8 +51010,13 @@ static void sdHealthTick() {
     const bool remounted = begin_ok && SD.cardType() != CARD_NONE;
 #else
     SD.end();
-    const bool remounted = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6) &&
-                           SD.cardType() != CARD_NONE;
+    bool remounted = SD.begin(PIN_SD_CS, *spi, 4000000, "/sd", 6) &&
+                     SD.cardType() != CARD_NONE;
+    if (remounted) {
+      const uint32_t hz = sdTryFastClock(PIN_SD_CS, *spi, 4000000, "SD");   // no-op unless SD_SPI_FAST_HZ
+      remounted = hz != 0;
+      if (remounted) g_sd_operating_hz = hz;
+    }
 #endif
     if (remounted) {
       s_sd_mounted        = true;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -226,6 +226,11 @@ constexpr uint16_t k_ui_history_min_version = 6;   // v4/v5 used 96-char records
 // the ring (larger, scales with MAX_UI_MESSAGES) flushes lazily every 2 s,
 // reducing flash write pressure when the ring is large.
 constexpr const char* k_ui_threads_path = "/ui_threads_v1.bin";
+// Threads-index writes go tmp+rename (same discipline as the segment compacts):
+// a truncate-in-place "w" rewrite interrupted by a hard power-cut left a short
+// file the next boot quarantine-DELETED — chat list, unread counts and DM
+// entries gone (M9 power slider = rail cut; any board on a brownout).
+constexpr const char* k_ui_threads_tmp_path = "/ui_threads_v1.bin.tmp";
 constexpr const char* k_ui_msgs_path    = "/ui_msgs_v1.bin";
 constexpr const char* k_ui_msgs_tmp_path = "/ui_msgs_v1.bin.tmp";
 // Separate temp for the SYNCHRONOUS (shutdown/reboot/no-PSRAM) writer. The
@@ -819,8 +824,8 @@ static inline void tileFetchPendingDec() {
 // below are shared; T-Deck and the pager each get their own I2S install/
 // tone/WAV functions, since the pager additionally drives an ES8311 codec
 // over I2C that the T-Deck's plain MAX98357A DAC doesn't have.
-#if defined(HELTEC_LORA_V4_R8)
-static bool fmSdTryMount();   // V4-R8 microSD — fwd decl (defined in the mount-helper block below)
+#if defined(HELTEC_LORA_V4_R8) || defined(HAS_THINKNODE_M9)
+static bool fmSdTryMount();   // V4-R8/M9 microSD — fwd decl (defined in the mount-helper block below; sdRestoreRun needs it)
 #endif
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
 static constexpr int kI2sSampleRate = 16000;
@@ -1590,6 +1595,12 @@ constexpr int CHAT_KB_H        = 130;  // on-screen keyboard (portrait)
 // 320×180 landscape).
 #if CAP_LARGE_SCREEN
 constexpr int TABBAR_H = 46;   // taller on the big 800×480 panel — room for the coloured F-key shapes
+#elif defined(HAS_THINKNODE_M9)
+// No tab bar on this board: it is tap-only chrome (navMaybeRebuild deliberately
+// never adds it to the focus group), and the M9 has no touch — the dedicated
+// HOME/MESSAGE/MAP keys and the app drawer's Chats/Contacts/Map/Settings tiles
+// cover every tab. Reclaims the row for content (user request).
+constexpr int TABBAR_H = 0;
 #else
 constexpr int TABBAR_H = 30;   // bottom nav bar (trimmed from 38; icons stay g_font_16)
 #endif
@@ -2699,6 +2710,7 @@ static lv_obj_t* s_cc_env_label = nullptr;   // Expansion-Kit local-env line in 
 static lv_obj_t* s_cc_sys_label = nullptr;   // CPU/RAM/PSRAM/IP line; refreshed live while CC open
 static void ccBuildSysInfo(char* buf, size_t n);   // fwd-decl; defined with the CC helpers below
 static void closeControlCenter();   // defined in the control-center section below
+static void openControlCenter();    // defined in the control-center section below (early decl for the M9 CTRL key)
 static lv_obj_t* s_power_menu   = nullptr;   // power off / reboot menu (control center)
 static void closePowerMenu();               // defined in the control-center section below
 static void openPowerMenu();                // hold the red ✕ (F1) on the Tanmatsu → power off / reboot
@@ -5344,7 +5356,7 @@ static void otaButtonRefreshState() {
   }
 }
 
-#if defined(HAS_TDECK_GT911) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
+#if (defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
 // ---- Save-update-to-SD (Launcher installs) ---------------------------------
 // Launcher-managed T-Decks have no spare A/B slot (touchHasOtaUpdateSlot() is
 // false), so Wi-Fi OTA can't work there — but the Launcher itself can flash an
@@ -8803,6 +8815,12 @@ static void kbBackspaceSelCb(lv_event_t* e) {
 
 static void closeSettingsModal() {
   hideKb();
+#if CAP_KEYPAD_NAV
+  // The synchronous lv_obj_del below can take down the group-focused object —
+  // detach first, exactly like the chat rebuilds do (navDetachBeforeTreeMutation
+  // has no !CAP_KEYPAD_NAV fallback, hence the gate; navMarkDirty below does).
+  navDetachBeforeTreeMutation();
+#endif
   if (g_set_modal.root) {
     lv_obj_del(g_set_modal.root);
   }
@@ -8816,6 +8834,7 @@ static void closeSettingsModal() {
   s_addct_name_ta    = nullptr;
   s_addct_error_l    = nullptr;
   resetSettingsModalState();
+  navMarkDirty();   // focus group re-roots to whatever the modal was covering
 }
 
 static void settingsCloseCb(lv_event_t* e) {
@@ -11363,7 +11382,7 @@ static void useSdStorageToggleCb(lv_event_t* e) {
                                          : TR("Data -> internal on reboot"), 1800);
 }
 
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
 // "Copy internal data to SD": recovery for the beta_36 upgrades where the live
 // profile was orphaned on internal flash while the honored SD toggle adopted an
 // empty card. Pager resumes only onto a card with no identity or the identical
@@ -11540,7 +11559,7 @@ static void uiScaleSelectCb(lv_event_t* e) {
 #endif
 
 // Hard-lock (not just dim) when the screen idles off, so the touchscreen is
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8)
 // Toggle idle light-sleep via the Settings row. Updates NVS, the live
 // touchSleep state, and the status-bar icon in one shot (mirrors lockOnScreenOffToggleCb).
 static void sleepIdleToggleCb(lv_event_t* e) {
@@ -12721,7 +12740,7 @@ static void buildDeviceSettings(int sec) {
     lv_obj_add_event_cb(sw, useSdStorageToggleCb, LV_EVENT_VALUE_CHANGED, nullptr);
     y += LV_MAX(40, h + 12);
   }
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
   /* Where contacts ACTUALLY live this boot. The toggle above is only an intent — if the
      card failed to mount at boot (cold/slow card), contacts silently stay on internal flash
      even with it ON. This line shows the truth and flags that mismatch. */
@@ -12761,7 +12780,7 @@ static void buildDeviceSettings(int sec) {
      fresh-identity) card. This copies EVERYTHING from internal flash over the
      card's copies and reboots into the restored profile. This is a SPIFFS->SD
      recovery on T-Deck, V4-R8 and Pager; Tanmatsu uses SD_MMC with no SPIFFS. */
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
   {
     lv_obj_t* b = lv_btn_create(body);
     lv_obj_set_size(b, lv_pct(96), SC(30));
@@ -12775,7 +12794,7 @@ static void buildDeviceSettings(int sec) {
     lv_obj_center(lbl);
     y += SC(40);
   }
-#endif  // HAS_TDECK_GT911 || HELTEC_LORA_V4_R8 || TLORA_PAGER (SPIFFS->SD recovery copy)
+#endif  // HAS_TDECK_GT911 || HELTEC_LORA_V4_R8 || TLORA_PAGER || HAS_THINKNODE_M9 (SPIFFS->SD recovery copy)
 #endif
 
   }
@@ -13267,11 +13286,12 @@ static void buildDeviceSettings(int sec) {
     lv_obj_center(l_bat);
     y += SC(42);
   }
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8)
   // Experimental battery saver (idle power-save) — throttles the CPU when the
   // device is parked (screen off, on battery, standalone). Moved here from
-  // Settings -> Lock so it lives with the battery. T-Deck only (the gate never
-  // passes on the V4).
+  // Settings -> Lock so it lives with the battery. T-Deck + V4-R8 (the old
+  // "gate never passes on the V4" note was stale for the R8: batteryIsCharging
+  // can't block it there, and the other gates are user state).
   {
     int h = settingsRowLabel(body, y, 6, TR("Battery saver (experimental)"), COLOR_TEXT, &g_font_12, 56);
     lv_obj_t* sw = lv_switch_create(body);
@@ -17888,7 +17908,10 @@ static uint16_t batteryFullMv() {
   return s_batt_full_mv ? s_batt_full_mv : 4200;
 }
 
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8)
+// (R8: the divider is permanently connected — PIN_ADC_CTRL=-1 — so the same
+// EMA + above-full voltage heuristic applies; threshold accuracy vs the
+// uncalibrated ADC_MULTIPLIER=5.07 conversion needs on-device confirmation.)
 static constexpr uint16_t kBattChargingMv = 4250;
 
 // Per-board battery sampler: EMA over the noisy ADC so the value doesn't jitter
@@ -18021,22 +18044,23 @@ static inline void sdNoteIoFailure() {
   s_sd_fail_note_ms = m ? m : 1;
 }
 
-// ----- Battery history: 5-minute log to SD + a 24h chart popup (T-Deck only) -----
+// ----- Battery history: 5-minute log + a 24h chart popup (every board) -----
 // Logging piggybacks the always-on UITask::loop (no extra wakeup): every
 // k_batt_log_period_ms a line is appended to /meshcomod/battery.log and the file
 // is trimmed to the last 24h. The rewrite streams line-by-line via a temp file,
 // so memory cost is one short String at a time. Tapping the battery in the status
 // bar opens a voltage chart built from that file.
-// Battery log prefers the SD card when present (T-Deck); on boards with no SD
-// slot — or a T-Deck with no card inserted — it falls back to internal SPIFFS so
-// the 24h chart still works. SD path lives under /meshcomod with the other files;
+// The log follows the RESOLVED ui-data backend (where chat history lives), not
+// bare card presence: telemetry/discover logging mkdirs /meshcomod on ANY
+// mounted card, which used to flip the battery log onto a card the profile
+// never opted into — the log and its chart then disagreed with where the rest
+// of the data lived. SD path lives under /meshcomod with the other files;
 // SPIFFS (flat) uses a top-level path.
 static fs::FS& battLogFs() {
 #if CAP_SD || defined(TLORA_PAGER)
-  if (SD.cardType() != CARD_NONE) {
+  if (uiDataFsIsSdCard()) {
     if (SD.exists("/meshcomod")) return SD;
-    // cardType() says present (cached) but real I/O failed — wedge/removal tell.
-    // (Or just a card without /meshcomod; sdHealthTick's probe arbitrates cheaply.)
+    // Backend resolved to SD but real I/O failed — wedge/removal tell.
     sdNoteIoFailure();
   }
 #endif
@@ -18044,7 +18068,7 @@ static fs::FS& battLogFs() {
 }
 static bool battLogOnSd() {
 #if CAP_SD || defined(TLORA_PAGER)
-  return SD.cardType() != CARD_NONE && SD.exists("/meshcomod");
+  return uiDataFsIsSdCard() && SD.exists("/meshcomod");
 #else
   return false;
 #endif
@@ -20634,8 +20658,13 @@ static void fmShowObj(lv_obj_t* o, bool show) {
 }
 
 // "Set as lock wallpaper" action shown in the windowed image viewer, plus the
-// open image's path / filesystem so the action can persist it.
+// open image's path / filesystem so the action can persist it. The button is
+// CAP_LOCK_SCREEN-gated: on the one filesystem board WITHOUT a lock screen
+// (V4-R8) nothing ever renders the wallpaper, so offering to set one — with a
+// "Lock wallpaper set" toast — was a dead control.
+#if CAP_LOCK_SCREEN
 static lv_obj_t* s_fm_img_wall = nullptr;
+#endif
 static char      s_fm_img_path[208] = {0};
 static bool      s_fm_img_on_sd     = false;
 
@@ -20654,7 +20683,9 @@ static void fmImageRelayout() {
   fmShowObj(s_fm_img_hdr,   !fs);
   fmShowObj(s_fm_img_close, !fs);
   fmShowObj(s_fm_img_full,  !fs);
+#if CAP_LOCK_SCREEN
   fmShowObj(s_fm_img_wall,  !fs);
+#endif
   fmShowObj(s_fm_img_hint,   fs);
   // The status bar lives on lv_layer_sys (above this overlay), so hide it
   // outright for a true full-screen image; restore it otherwise.
@@ -20700,6 +20731,7 @@ static void fmImageRootClickCb(lv_event_t* e) {
 // Persist the currently-viewed JPEG as the lock-screen wallpaper. By the time the
 // viewer is up the file is a confirmed JPEG (PNG is rejected earlier), so it's a
 // valid wallpaper. SD paths get the "sd:" prefix the decoder expects.
+#if CAP_LOCK_SCREEN
 static void fmSetWallpaperCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED || !s_fm_img_path[0]) return;
   char pref[TOUCH_LOCK_WALLPAPER_MAXLEN];
@@ -20715,6 +20747,7 @@ static void fmSetWallpaperCb(lv_event_t* e) {
   fmImageClose();
   if (g_lv.task) g_lv.task->showAlert(TR("Lock wallpaper set"), 1300);
 }
+#endif  // CAP_LOCK_SCREEN (fmSetWallpaperCb)
 
 #if CAP_SOUND_FILES
 // ---- .wav -> notification-sound chooser (opened from the File Manager) ------
@@ -20907,6 +20940,7 @@ static void fmOpenImage(const char* name) {
   lv_obj_t* fll = lv_label_create(full); lv_label_set_text(fll, TR("Full"));
   lv_obj_set_style_text_font(fll, &g_font_12, LV_PART_MAIN); lv_obj_center(fll);
 
+#if CAP_LOCK_SCREEN
   // "Set as lock wallpaper" — bottom-left, windowed chrome only.
   lv_obj_t* wall = lv_btn_create(s_fm_img_root);
   lv_obj_set_height(wall, 30);
@@ -20920,6 +20954,7 @@ static void fmOpenImage(const char* name) {
   lv_obj_set_style_text_color(wll, lv_color_black(), LV_PART_MAIN);
   lv_obj_center(wll);
   s_fm_img_wall = wall;
+#endif  // CAP_LOCK_SCREEN (wallpaper button)
 
   // "tap to exit" hint, shown only in full-screen mode.
   lv_obj_t* hint = lv_label_create(s_fm_img_root);
@@ -22702,7 +22737,16 @@ static bool spectrumSweepChunk() {
 #if defined(RADIO_CLASS)
   for (int i = s_spec_pos; i < end; i++) {
     const float f = s_spec_start + (float)i * s_spec_step;
+#if defined(HAS_THINKNODE_M9)
+    // LR1110: skipCalibration — LR1110::setFrequency(f) recalibrates image
+    // rejection whenever the retune jumps >= 20 MHz, which the 24 MHz wrap
+    // from band end back to band start does EVERY sweep; a relative RSSI
+    // display doesn't need it (the mesh's own begin() calibration covers the
+    // ±12 MHz span) and it stalls the sweep for nothing.
+    radio.setFrequency(f, true);          // retune (chip -> standby on the new freq)
+#else
     radio.setFrequency(f);                // retune (chip -> standby on the new freq)
+#endif
     radio.startReceive();                 // ARM RX — GET_RSSI_INST is only valid in RX
     // The SX1262's instantaneous-RSSI register needs SEVERAL ms in RX to settle after
     // arming: at ~1.5 ms it still reads the -127 dBm reset default, only by ~3-4 ms does
@@ -22712,10 +22756,24 @@ static bool spectrumSweepChunk() {
     delayMicroseconds(SPEC_SETTLE_US);
     int peak = -200;
     for (int k = 0; k < SPEC_DWELL; k++) {
+#if defined(HAS_THINKNODE_M9)
+      // LR11x0::getRSSI(false) is NOT the SX126x's cheap register read: it
+      // re-arms RX and drops to standby around EVERY call (startReceive +
+      // GetRssiInst + standby) — 6x per bin that both crawled the sweep
+      // (hundreds of extra chip commands + BUSY waits per chunk: the reported
+      // "spectrum refreshes poorly on M9") and, worse, sampled the unsettled
+      // post-arm default instead of live channel power, defeating the settle
+      // above. We hold RX ourselves through the dwell: skipReceive=true.
+      int r = (int)radio.getRSSI(false, true);
+#else
       int r = (int)radio.getRSSI(false);  // instantaneous channel RSSI (dBm)
+#endif
       if (r > peak) peak = r;
       delayMicroseconds(SPEC_READ_GAP_US);
     }
+#if defined(HAS_THINKNODE_M9)
+    radio.standby();   // getRSSI(…, skipReceive) no longer drops RX for us — leave the bin cleanly
+#endif
     s_spec_rssi[i] = (int16_t)peak;
   }
 #else
@@ -25426,6 +25484,16 @@ static uint8_t  s_map_zoom       = k_map_zoom_default;
 static bool     s_map_view_inited = false;  // first map open did the recenter+zoom-snap; after that, remember the user's view (issue #5)
 static bool       s_map_follow     = false; // auto-follow: recenter on self whenever the GPS coords change
 static lv_obj_t*  s_map_follow_btn = nullptr;
+#if defined(HAS_M9_KEYBOARD)
+// Map pan mode (M9): the Map key on the Map tab toggles it — arrows then pan
+// via mapNudge, Map/Back exits. Lives here with the map state because
+// mapAutoFollowTick must pause while it's active: auto-follow compares the GPS
+// fix against the MAP CENTER, so the pan itself creates the delta and follow
+// snapped the view back within one 250 ms tick of every nudge — no GPS
+// movement needed. Follow (if on) resumes, by design, the moment pan exits.
+static bool s_m9_map_pan = false;
+static bool s_m9_pan_gap_hinted = false;   // one "Wi-Fi off" hint per pan session
+#endif
 // Map zoom control style: false = slider (default, toggled by the on-map button),
 // true = a +/- button pair (issue #26). Loaded from prefs at boot; toggled in the
 // Map options popup. mapZoomControlsApply() positions/shows the right controls.
@@ -26046,7 +26114,7 @@ static void otaWorkerRun(WiFiClient& client, HTTPClient& http) {
   s_ota_state = 2;   // success -> the UI poll timer reboots into the new slot
 }
 
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
 // Stream the app-only bin for the active update channel onto the SD card
 // (/BINS/wadamesh-beta_<N>-<stable|beta>.bin) so the Launcher can flash it —
 // the no-A/B-slot counterpart to otaWorkerRun above. Same immutable versioned
@@ -26307,7 +26375,7 @@ static void tileFetchTaskFn(void* arg) {
       otaWorkerRun(client, http);
       continue;
     }
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
     // SD firmware download for Launcher installs (user-initiated from About).
     if (s_sdfw_request) {
       s_sdfw_request = false;
@@ -26412,6 +26480,14 @@ static void tileFetchTaskFn(void* arg) {
         vf.close();
         if (mr == 3 && m[0] == 0xFF && m[1] == 0xD8 && m[2] == 0xFF) {
           ++s_tile_fetch_ok;                         // already on disk + valid -> skip the re-download
+#if defined(HAS_THINKNODE_M9)
+          // A visible tile gets queued when its READ was transiently blocked
+          // (SD fail-note window, PSRAM pressure) even though it's on disk.
+          // Skipping WITHOUT arming the repaint left it blank until the next
+          // manual pan ("one pan behind"). Visible-zoom only, so draining a
+          // zoom-pack backlog doesn't fire spurious re-renders.
+          if (req.z == s_map_zoom) s_tile_fetch_dirty = true;
+#endif
           tileFetchPendingDec();
           continue;
         }
@@ -29179,13 +29255,14 @@ static void mapCanvasEventCb(lv_event_t* e) {
   refreshMapInfoLabel();
 }
 
-#if defined(HAS_TANMATSU) || defined(TLORA_PAGER)
-// Keyboard pan (Ctrl+Arrow on Tanmatsu / WAXD on the pager, both on the Map
-// tab). Mirrors the drag-release math in mapCanvasEventCb: synthesize a pixel
-// delta of ~1/4 the visible span in the arrow direction, convert it through
-// the same world-px ↔ lat/lon helpers (so the lon step automatically scales
-// with the current zoom's degrees-per-pixel) and re-render. dir: 0=up(north,
-// +lat) 1=down(south,−lat) 2=left(west,−lon) 3=right(east,+lon).
+#if defined(HAS_TANMATSU) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
+// Keyboard pan (Ctrl+Arrow on Tanmatsu / WAXD on the pager / the M9's Map-key
+// pan mode, all on the Map tab). Mirrors the drag-release math in
+// mapCanvasEventCb: synthesize a pixel delta of ~1/4 the visible span in the
+// arrow direction, convert it through the same world-px ↔ lat/lon helpers (so
+// the lon step automatically scales with the current zoom's degrees-per-pixel)
+// and re-render. dir: 0=up(north, +lat) 1=down(south,−lat) 2=left(west,−lon)
+// 3=right(east,+lon).
 static void mapNudge(int dir) {
   if (!s_map_canvas) return;
   // No center yet (no GPS / location) → nothing to pan around.
@@ -29202,13 +29279,16 @@ static void mapNudge(int dir) {
     default: return;
   }
   worldPxToLatLon(cwx, cwy, s_map_zoom, &s_map_center_lat, &s_map_center_lon);
-  // Match the touch-drag: it does NOT clear s_map_follow, so neither do we
-  // (mapAutoFollowTick re-centers on the next GPS move regardless).
+  // Match the touch-drag: it does NOT clear s_map_follow. NB auto-follow
+  // recenters on the CENTER-vs-fix delta — the pan itself trips it, no GPS
+  // movement needed — so mapAutoFollowTick pauses while the M9's pan mode is
+  // active (s_m9_map_pan); on touch boards a drag away simply snaps back on
+  // the next 250 ms tick while follow is on, which is that button's contract.
   renderMapTiles();
   renderMapMarkers();
   refreshMapInfoLabel();
 }
-#endif  // HAS_TANMATSU || TLORA_PAGER (mapNudge)
+#endif  // HAS_TANMATSU || TLORA_PAGER || HAS_THINKNODE_M9 (mapNudge)
 
 // ----- Zoom + recenter -----
 //
@@ -29361,6 +29441,9 @@ static void mapRecenterCb(lv_event_t* e) {
 // moves meaningfully (or the view was panned away). Called from the map tick.
 static void mapAutoFollowTick() {
   if (!s_map_follow || !g_lv.task) return;
+#if defined(HAS_M9_KEYBOARD)
+  if (s_m9_map_pan) return;   // Map-key pan mode owns the center; follow resumes when pan exits
+#endif
   const double lat = g_lv.task->getNodeLat();
   const double lon = g_lv.task->getNodeLon();
   if (lat == 0.0 && lon == 0.0) return;                 // no fix yet
@@ -30669,7 +30752,7 @@ static void settingsCatBuild(int cat) {
           lv_obj_set_style_text_color(beta_note, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
         }
 
-#if defined(HAS_TDECK_GT911) && CAP_OTA
+#if (defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)) && CAP_OTA
         // "Save update bin to SD" — the Launcher-install update path: downloads
         // the app-only bin for the active channel into /BINS/ on the SD card,
         // named wadamesh-beta_<N>-<stable|beta>.bin, ready for the Launcher to
@@ -30748,7 +30831,7 @@ static void closeSettingsCategory() {
   hideKb();
   if (s_settings_open_cat == CAT_ABOUT) {   // null the live-label ptrs (freed with the sheet)
     s_sysinfo_lbl = nullptr; s_sysinfo_rest_lbl = nullptr; s_update_about_lbl = nullptr; s_ota_status_lbl = nullptr;
-#if defined(HAS_TDECK_GT911) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
+#if (defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
     s_sdfw_status_lbl = nullptr;
 #endif
     s_ota_btn = nullptr; s_ota_btn_lbl = nullptr;
@@ -35640,7 +35723,7 @@ static void updatePagerEncoder(unsigned long now) {
 // Defined OUTSIDE HAS_TDECK_KEYBOARD so the ungated gesture handlers can use it.
 static bool drawerPopupOpen() {
   return s_siginfo_root || s_spec_root || s_mentions_root || s_power_menu || s_ct_sort_sheet || s_ctd_overlay || settingsModalIsOpen()
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)
          || s_fullscreen_view
 #endif
          ;
@@ -35675,6 +35758,18 @@ static bool isDismissKey(int key) {
     case 'p': case 'P':
     case 'q': case 'Q':
     case 'a': case 'A':
+      return true;
+    default: return false;
+  }
+#elif defined(HAS_M9_KEYBOARD)
+  // The dedicated Back/Home function keys must always stay with the firmware —
+  // a Lua app may never swallow its own exit (see the forward in handleHwKey),
+  // and this board has no touchscreen fallback to tap its way out with. They
+  // are sentinel bytes the keyboard controller reserves, never typed text, so
+  // there is no typing conflict.
+  switch (key) {
+    case M9_KEY_HW_BACK:
+    case M9_KEY_HOME:
       return true;
     default: return false;
   }
@@ -36949,6 +37044,9 @@ static void serviceLockingCountdown(unsigned long now) {
 // handled HERE, in their own function, called before that swallow — not
 // wedged into T-Deck's CAP_TRACKBALL chain as an #elif. Returns true if the
 // key was consumed.
+// (s_m9_map_pan — the Map-key pan-mode flag — is declared with the map state,
+// next to s_map_follow: mapAutoFollowTick pauses while it's set.)
+
 static bool m9HandleNavKey(int key) {
   if (!s_kbd_nav) return false;
   switch (key) {
@@ -36965,8 +37063,55 @@ static bool m9HandleNavKey(int key) {
       if (foc && lv_obj_is_valid(foc)) lv_event_send(foc, LV_EVENT_LONG_PRESSED, nullptr);
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     }
+    case M9_KEY_HW_BACK:
+      // Restored after 0ea242c accidentally replaced this case with ENTER_LONG
+      // (the board's only Back). Ladder mirrors pagerNavGoBack(): innermost
+      // thing open closes first. An open dropdown LIST must take ESC before the
+      // registry, or Back would close the enclosing modal instead of the list.
+      // s_ct_select_mode is a flags=0 registry row (a MODE, not "a popup is
+      // open"), so anyPopupOpen() alone would never let Back leave it.
+      if (s_setup_root) return true;   // wizard: nothing to back out of
+      if (s_m9_map_pan) {              // pan mode is the innermost "thing open" on the map
+        s_m9_map_pan = false;
+        if (g_lv.task) g_lv.task->showAlert(TR("Map pan off"), 900);
+      }
+      else if (navOpenDropdown())                    navPushTap(LV_KEY_ESC);
+      // An open app page covers everything EXCEPT the Control Center / power
+      // menu (the only popups a key can open OVER an app page here). The app
+      // drawer it was launched from stays open BENEATH it by design — the
+      // generic registry dismiss used to eat that invisible drawer first, so
+      // Back looked dead inside every app (reported bug). Close the page
+      // itself; the drawer is then the next, visible Back target.
+      else if (s_apppage_close && !s_cc_root && !s_power_menu) s_apppage_close();
+      else if (anyPopupOpen() || s_ct_select_mode)   hwKeyDismissTopPopup();
+      else if (LvChatPanel* cp = navOpenChatPanel()) closeChatPanel(cp);
+      else                                           navPushTap(LV_KEY_ESC);
+      s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
+    case M9_KEY_GPS_LONG:
+      // The controller's own long-press of SUB_MAP (0x84), labeled "GPS
+      // toggle" in Elecrow's keyboard firmware — mirror the CC GPS chip.
+      if (s_setup_root) return true;
+      if (g_lv.task) {
+        g_lv.task->toggleGPS();
+        g_lv.task->showAlert(g_lv.task->getGPSState() ? TR("GPS on") : TR("GPS off"), 800);
+      }
+      s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
+    case M9_KEY_CTRL:
+      // The controller latches ONE key and resolves layers itself, so CTRL can
+      // never chord — bind the standalone press to the Control Center, a
+      // one-press quick-settings key matching its label.
+      if (s_setup_root) return true;
+      openControlCenter();
+      s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_HOME:
       if (s_setup_root) return true;
+      if (s_apppage_close) {
+        // A full-screen app page (Lua app, Snake, Web…) isn't a popup-registry
+        // row — close it and stop: one action per press, so HOME on the Home
+        // tab doesn't also toggle the drawer underneath the closing page.
+        s_apppage_close();
+        s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
+      }
       if (getActiveTab() == HOME_TAB_INDEX) {
         const bool was_open = s_home_drawer_mode;          // read BEFORE dismissing anything
         for (int i = 0; i < 8 && anyPopupOpen(); i++) hwKeyDismissTopPopup();   // still closes anything else on top (registry untouched, Back/etc. keep working)
@@ -36977,6 +37122,7 @@ static bool m9HandleNavKey(int key) {
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_LEFT_MESSAGE:
       if (s_setup_root) return true;
+      if (s_apppage_close) s_apppage_close();   // close an open app page — else the jump lands invisibly beneath it
       navGoToMainTab(CHAT_INBOX_TAB_INDEX);
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_SUB_MESSAGE:
@@ -36985,7 +37131,17 @@ static bool m9HandleNavKey(int key) {
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_MAP:
       if (s_setup_root) return true;
-      navGoToMainTab(MAP_TAB_INDEX);
+      if (getActiveTab() == MAP_TAB_INDEX && !anyPopupOpen() && !s_apppage_close) {
+        // Already on the map: toggle pan mode (arrows pan, Map/Back exits).
+        s_m9_map_pan = !s_m9_map_pan;
+        s_m9_pan_gap_hinted = false;   // fresh session: the Wi-Fi-off gap hint may fire once
+        if (g_lv.task) g_lv.task->showAlert(s_m9_map_pan ? TR("Map pan: arrows pan, Back exits")
+                                                         : TR("Map pan off"), 1200);
+      } else {
+        s_m9_map_pan = false;   // fresh entry always starts in nav mode
+        if (s_apppage_close) s_apppage_close();   // close an open app page — else the jump lands invisibly beneath it
+        navGoToMainTab(MAP_TAB_INDEX);
+      }
       if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_SUB_MAP:
       if (s_setup_root) return true;
@@ -36999,23 +37155,91 @@ static bool m9HandleNavKey(int key) {
 #if defined(HAS_M9_KEYBOARD)
 static bool m9HandleArrowKey(int key, lv_obj_t* ta) {
   if (!s_kbd_nav) return false;
+  // An open dropdown LIST owns the arrows (mirrors Tanmatsu's navPump capture):
+  // navMoveDir would move group focus off the dropdown, which closes the list —
+  // the "UP/DOWN closes the dropdown instead of moving its highlight" bug. The
+  // FIFO'd LV_KEY_UP/DOWN reach the focused dropdown's own LV_EVENT_KEY handler,
+  // which moves the highlighted option.
+  if (navOpenDropdown()) {
+    switch (key) {
+      case M9_KEY_UP:   navPushTap(LV_KEY_UP);   break;
+      case M9_KEY_DOWN: navPushTap(LV_KEY_DOWN); break;
+      case M9_KEY_LEFT: case M9_KEY_RIGHT:       break;   // swallow — the list is vertical-only
+      default: return false;
+    }
+    s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput();
+    return true;
+  }
+  // Map pan mode (toggled by the Map key on the Map tab): arrows pan the map
+  // instead of moving focus. Self-clears if the user somehow left the tab.
+  if (s_m9_map_pan) {
+    if (getActiveTab() != MAP_TAB_INDEX || ta) {
+      s_m9_map_pan = false;
+    } else {
+      switch (key) {
+        case M9_KEY_UP:    mapNudge(0); break;
+        case M9_KEY_DOWN:  mapNudge(1); break;
+        case M9_KEY_LEFT:  mapNudge(2); break;
+        case M9_KEY_RIGHT: mapNudge(3); break;
+        default: return false;
+      }
+#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
+      // Panned into an area with no cached tiles while offline: the fetch
+      // queue silently no-ops without Wi-Fi, so the leading edge stays blank
+      // with only the small corner label saying why. Say it once per session.
+      if (!s_m9_pan_gap_hinted && s_map_last_missing > 0 && WiFi.status() != WL_CONNECTED) {
+        s_m9_pan_gap_hinted = true;
+        if (g_lv.task) g_lv.task->showAlert(TR("Wi-Fi off — new map areas can't download"), 1600);
+      }
+#endif
+      if (g_lv.task) g_lv.task->noteUserInput();
+      return true;
+    }
+  }
   switch (key) {
-    case M9_KEY_UP:
+    case M9_KEY_UP: {
+      lv_obj_t* const was = s_nav_group ? lv_group_get_focused(s_nav_group) : nullptr;
       navMoveDir(NAV_UP);
+      // Focus had nowhere to go: page-scroll instead. A display-only Lua app
+      // scrolls its own body (RF Monitor's feed); everything else falls to
+      // navScrollFocused — nearest scrollable ancestor, else the biggest
+      // scrollable on screen — which is what makes sparse pages with few or
+      // NO focusable rows (the Signal info popup's stats) scrollable at all
+      // on a board with no touch to drag them.
+      if (s_nav_group && lv_group_get_focused(s_nav_group) == was) {
+        if (!(luaAppIsOpen() && luaAppScroll(true))) navScrollFocused(true);
+      }
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput();
       return true;
-    case M9_KEY_DOWN:
+    }
+    case M9_KEY_DOWN: {
+      lv_obj_t* const was = s_nav_group ? lv_group_get_focused(s_nav_group) : nullptr;
       navMoveDir(NAV_DOWN);
+      if (s_nav_group && lv_group_get_focused(s_nav_group) == was) {
+        if (!(luaAppIsOpen() && luaAppScroll(false))) navScrollFocused(false);
+      }
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput();
       return true;
+    }
     case M9_KEY_LEFT:
-      if (ta)                 lv_textarea_cursor_left(ta);
+      if (ta) {
+        // Caret already at the start: fall through to focus-move so arrows
+        // always eventually LEAVE the field (a silent boundary no-op read as
+        // "textareas need 3-4 presses to move off").
+        const uint32_t p = lv_textarea_get_cursor_pos(ta);
+        lv_textarea_cursor_left(ta);
+        if (lv_textarea_get_cursor_pos(ta) == p) navMoveDir(NAV_LEFT);
+      }
       else if (navOnTabBar()) navSwitchTab(-1);
       else                    navMoveDir(NAV_LEFT);
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput();
       return true;
     case M9_KEY_RIGHT:
-      if (ta)                 lv_textarea_cursor_right(ta);
+      if (ta) {
+        const uint32_t p = lv_textarea_get_cursor_pos(ta);
+        lv_textarea_cursor_right(ta);
+        if (lv_textarea_get_cursor_pos(ta) == p) navMoveDir(NAV_RIGHT);   // caret at end — same as LEFT
+      }
       else if (navOnTabBar()) navSwitchTab(+1);
       else                    navMoveDir(NAV_RIGHT);
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput();
@@ -37036,7 +37260,34 @@ static void handleHwKey(int key) {
   //
   // The dismiss key is deliberately NOT forwarded: an app must never be able to
   // trap the user by swallowing its own exit, whether by bug or by design.
-  if (luaAppIsOpen() && !isDismissKey(key)) {
+  if (luaAppIsOpen() && !isDismissKey(key)
+#if defined(HAS_M9_KEYBOARD)
+      // Locked or dark: the lock/wake handlers below must see the key — else
+      // ENTER_LONG (this board's only unlock) is eaten by the app and the
+      // device can never be unlocked again without the power slider.
+      && !(g_lv.task && (g_lv.task->isManualLock() || g_lv.task->isScreenOff()))
+      // Display-only apps (no on_input — Airtime, RF Monitor): forward nothing;
+      // the d-pad keeps its native meaning so it can focus the page's own
+      // buttons (Airtime's Reset), click them with Enter, and page-scroll the
+      // body (m9HandleArrowKey's luaAppScroll fallback). luaAppKey would
+      // otherwise eat every key into a callback that doesn't exist.
+      && luaAppHasOnInput()
+#endif
+     ) {
+#if defined(HAS_M9_KEYBOARD)
+    // The M9 d-pad emits raw sentinel bytes no app understands (sendKey maps
+    // only LV_KEY_*/printables) — feed them through the same steer/press
+    // channel the T-Deck trackball uses, so store apps (Snake, 2048, …) are
+    // playable here: arrows -> swipe, d-pad centre -> also a synthetic tap
+    // (store apps' "tap to start / retry" listens for type=="down").
+    switch (key) {
+      case M9_KEY_UP:    luaAppSteer(0, -1); if (g_lv.task) g_lv.task->noteUserInput(); return;
+      case M9_KEY_DOWN:  luaAppSteer(0,  1); if (g_lv.task) g_lv.task->noteUserInput(); return;
+      case M9_KEY_LEFT:  luaAppSteer(-1, 0); if (g_lv.task) g_lv.task->noteUserInput(); return;
+      case M9_KEY_RIGHT: luaAppSteer(1,  0); if (g_lv.task) g_lv.task->noteUserInput(); return;
+      case M9_KEY_ENTER: luaAppPress(); break;   // then also delivered as ev.key=="enter" below
+    }
+#endif
     if (luaAppKey(key)) {
       if (g_lv.task) g_lv.task->noteUserInput();
       return;
@@ -37403,7 +37654,7 @@ if (g_lv.task && g_lv.task->isManualLock()) {
     // goes through hideKb(); this covers the physical-keyboard Enter.
     accentBoxHide();
     mentionBoxHide();
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_M9_KEYBOARD)
     if (s_editor_ta && ta == s_editor_ta) {
       lv_textarea_add_char(ta, '\n');   // multiline editor: Enter inserts a newline
     } else if (s_term_input_ta && s_kb_bind_ta == s_term_input_ta) {
@@ -37639,7 +37890,18 @@ static const char* wifiStaStatusBrief(int s) {
       return "off";
     case WL_NO_SSID_AVAIL: return "AP not found";
     case WL_SCAN_COMPLETED: return "scan done";
-    case WL_CONNECT_FAILED: return "auth failed";
+    case WL_CONNECT_FAILED: {
+      // Append the esp_wifi disconnect reason — "auth failed" alone covers
+      // wrong password (r15, 4-way handshake timeout), WPA3-only/H2E SAE
+      // failures (r2/r202), and AP-side rejection alike.
+      extern volatile uint8_t g_wifi_last_disc_reason;   // main.cpp
+      static char s_auth_fail[24];
+      if (g_wifi_last_disc_reason) {
+        snprintf(s_auth_fail, sizeof s_auth_fail, "auth failed (r%u)", (unsigned)g_wifi_last_disc_reason);
+        return s_auth_fail;
+      }
+      return "auth failed";
+    }
     case WL_CONNECTION_LOST: return "link lost";
     case WL_DISCONNECTED: return "disconnected";
     default: return "connecting…";
@@ -37968,6 +38230,7 @@ static void powerRebootCb(lv_event_t* e) {
   g_lv.task->showAlert(TR("Rebooting\xE2\x80\xA6"), 600);
   g_lv.task->rebootDevice();   // flushes chat history, then reboots
 }
+#if !defined(HAS_THINKNODE_M9)   // M9 has no Power-off row (no wake-capable button — see openPowerMenu)
 static void powerOffCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
   closePowerMenu();
@@ -37979,11 +38242,33 @@ static void powerOffCb(lv_event_t* e) {
     discoveredFlushNow();                  // and the Discovered ring
     the_mesh.flushContactsIfDirty();       // and any coalesced contacts refresh
     touchPrefsFlush();                     // and all queued A/B preference snapshots
+#if defined(HELTEC_LORA_V4_R8)
+    g_lv.task->showAlert(TR("Powering off\xE2\x80\xA6 press BOOT to wake"), 1500);
+#else
     g_lv.task->showAlert(TR("Powering off\xE2\x80\xA6 click trackball to wake"), 1500);
+#endif
   }
   // Let the toast paint, then enter deep sleep.
   lv_refr_now(NULL);
   delay(900);
+#if defined(HELTEC_LORA_V4_R8)
+  // Park everything before sleeping — without this the SX1262 stayed in RX
+  // with the FEM enabled (pure drain, no wake purpose: all wake sources are
+  // cleared below except the button) and the non-RTC rail pins (VEXT=40,
+  // GPS_EN=42, backlight=44) lost their driven levels and floated.
+  radio_driver.powerOff();
+  board.loRaFEMControl.setSleepModeEnable();
+  pinMode(PIN_TFT_LEDA_CTL, OUTPUT);              // re-route from LEDC ch6 back to plain GPIO
+  digitalWrite(PIN_TFT_LEDA_CTL, LOW);            // backlight off
+  pinMode(PIN_GPS_EN, OUTPUT);
+  digitalWrite(PIN_GPS_EN, HIGH);                 // inactive (PIN_GPS_EN_ACTIVE=LOW)
+  pinMode(PIN_VEXT_EN, OUTPUT);
+  digitalWrite(PIN_VEXT_EN, HIGH);                // inactive (active LOW) — VEXT rail off
+  gpio_hold_en((gpio_num_t)PIN_VEXT_EN);          // non-RTC pads: hold levels through deep sleep
+  gpio_hold_en((gpio_num_t)PIN_GPS_EN);
+  gpio_hold_en((gpio_num_t)PIN_TFT_LEDA_CTL);
+  gpio_deep_sleep_hold_en();                      // released in HeltecV4Board::begin on wake
+#endif
 #if defined(PIN_USER_BTN)
   const gpio_num_t wake = (gpio_num_t)PIN_USER_BTN;   // GPIO0, trackball click, active-low
   // CRITICAL: the trackball button is held HIGH by a pull-up while idle and
@@ -38002,6 +38287,7 @@ static void powerOffCb(lv_event_t* e) {
   esp_deep_sleep_start();   // never returns; a press wakes via full reboot
 #endif
 }
+#endif  // !HAS_THINKNODE_M9 (powerOffCb)
 
 #if defined(ESP32)
 #if !defined(HAS_TANMATSU) && !defined(HAS_TDISPLAY_P4)
@@ -38060,6 +38346,10 @@ static void openPowerMenu() {
   // ROM force-download leaves a COM that esptool cannot open on HW CDC — hide the entry.
   const int card_w = (sw - 40 > 240) ? 240 : (sw - 40);
   const int p_bh = 34, p_y0 = 28, p_step = 40, card_h = p_y0 + 3 * p_step + 8;
+#elif defined(HAS_THINKNODE_M9)
+  // Power-off row hidden (see below) — 3 rows: Reboot / Download / Cancel.
+  const int card_w = (sw - 40 > 240) ? 240 : (sw - 40);
+  const int p_bh = 34, p_y0 = 28, p_step = 40, card_h = p_y0 + 3 * p_step + 8;
 #else
   const int card_w = (sw - 40 > 240) ? 240 : (sw - 40);
   const int p_bh = 34, p_y0 = 28, p_step = 40, card_h = 206;
@@ -38097,13 +38387,22 @@ static void openPowerMenu() {
     lv_obj_center(l);
     return b;
   };
-  mk(TR(LV_SYMBOL_POWER "  Power off"),        powerOffCb,      0xC44B55, p_y0);
-  mk(TR(LV_SYMBOL_REFRESH "  Reboot"),         powerRebootCb,   0,        p_y0 + p_step);
-#if !defined(HAS_RAK_TAP_V2)
-  mk(TR(LV_SYMBOL_DOWNLOAD "  Download mode"), powerDownloadCb, 0,        p_y0 + 2 * p_step);
-  mk(TR("Cancel"), powerCancelCb, 0, p_y0 + 3 * p_step);
+#if defined(HAS_THINKNODE_M9)
+  // No "Power off" here: deep sleep would arm ext0 wake on a user button this
+  // board doesn't have (only a power-cut slider and reset, neither a wakeable
+  // GPIO) — an off state recoverable only by cycling the slider. The slider IS
+  // the power-off. Remaining rows shift up one slot.
+  const int p_y = p_y0;
 #else
-  mk(TR("Cancel"), powerCancelCb, 0, p_y0 + 2 * p_step);
+  mk(TR(LV_SYMBOL_POWER "  Power off"),        powerOffCb,      0xC44B55, p_y0);
+  const int p_y = p_y0 + p_step;
+#endif
+  mk(TR(LV_SYMBOL_REFRESH "  Reboot"),         powerRebootCb,   0,        p_y);
+#if !defined(HAS_RAK_TAP_V2)
+  mk(TR(LV_SYMBOL_DOWNLOAD "  Download mode"), powerDownloadCb, 0,        p_y + p_step);
+  mk(TR("Cancel"), powerCancelCb, 0, p_y + 2 * p_step);
+#else
+  mk(TR("Cancel"), powerCancelCb, 0, p_y + p_step);
 #endif
 }
 
@@ -43943,6 +44242,11 @@ static void buildUiTree() {
   }
 
   lv_obj_t* tab_btns = lv_tabview_get_tab_btns(g_lv.tabview);
+#if defined(HAS_THINKNODE_M9)
+  // TABBAR_H is 0 on this board (see its definition) — hide the zero-height
+  // btnmatrix outright so it can never paint, hit-test, or take focus.
+  lv_obj_add_flag(tab_btns, LV_OBJ_FLAG_HIDDEN);
+#endif
   // Tab bar bar itself sits on pure BG, not the panel — keeps the bottom
   // strip indistinguishable from the rest of the screen except for the
   // active-tab highlight.
@@ -44056,7 +44360,11 @@ static void buildUiTree() {
   lv_obj_set_style_text_font(s_update_badge, &lv_font_montserrat_12, LV_PART_MAIN);
   lv_obj_set_style_text_align(s_update_badge, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
   lv_obj_set_style_pad_all(s_update_badge, 0, LV_PART_MAIN);
+#if defined(HAS_THINKNODE_M9)
+  lv_obj_align(s_update_badge, LV_ALIGN_BOTTOM_RIGHT, -8, -4);   // no tab bar on this board
+#else
   lv_obj_align(s_update_badge, LV_ALIGN_BOTTOM_RIGHT, -8, -(TABBAR_H - 16));
+#endif
   lv_obj_add_flag(s_update_badge, LV_OBJ_FLAG_HIDDEN);
 
   // Unread-count badge over the Chats (envelope) tab — leftmost of 5. Same
@@ -44075,7 +44383,9 @@ static void buildUiTree() {
   lv_obj_set_style_pad_hor(s_chat_unread_badge, 3, LV_PART_MAIN);
   lv_obj_set_style_pad_ver(s_chat_unread_badge, 0, LV_PART_MAIN);
   lv_obj_align(s_chat_unread_badge, LV_ALIGN_BOTTOM_LEFT,
-#if defined(HAS_EXPANSION_KIT)
+#if defined(HAS_THINKNODE_M9)
+               8, -4);                                                     // no tab bar on this board — bottom-left corner
+#elif defined(HAS_EXPANSION_KIT)
                lv_disp_get_hor_res(nullptr) / 12 + 7, -(TABBAR_H - 16));   // 6 tabs: half-cell over Chats
 #else
                lv_disp_get_hor_res(nullptr) / 10 + 7, -(TABBAR_H - 16));   // 5 tabs: half-cell over Chats
@@ -45530,6 +45840,33 @@ static bool uiDataFsReady() {
     return true;
   }
   if (SPIFFS.begin(false)) { s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0'; return true; }
+#elif defined(HAS_THINKNODE_M9)
+  // ThinkNode M9: same Arduino-SD-on-shared-bus shape as the T-Deck (CAP_SD=1;
+  // used to fall into the V4 SPIFFS #else, losing the SD-backed deep message
+  // ring despite a mounted card).
+  if (sdAdoptLiveMount() || fmSdTryMount()) {
+    SD.mkdir("/meshcomod");
+    s_ui_data_fs = &SD;
+    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+    return true;
+  }
+  if (SPIFFS.begin(false)) { s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0'; return true; }
+#elif defined(HELTEC_LORA_V4_R8)
+  // R8 (Expansion Kit V2, REMOVABLE card): follow the boot adoption decision,
+  // never bare card presence — mirrors the pager's profile-keyed shape. When
+  // the boot store adopted the card (g_full_data_on_sd: identity/prefs/
+  // contacts live there), chat history + battery log + Lua app files follow;
+  // otherwise everything stays on internal SPIFFS as before. NB an R8 that
+  // adopted a card on an OLDER build carries a day-one /msgs snapshot on the
+  // card — Settings > Storage > "Copy internal data to SD" refreshes it.
+  if (g_full_data_on_sd) {
+    if (!(sdAdoptLiveMount() || fmSdTryMount())) return false;
+    SD.mkdir("/meshcomod");
+    s_ui_data_fs = &SD;
+    strncpy(s_ui_data_root, "/meshcomod", sizeof s_ui_data_root - 1);
+    return true;
+  }
+  if (SPIFFS.begin(false) || SPIFFS.begin(true)) { s_ui_data_fs = &SPIFFS; s_ui_data_root[0] = '\0'; return true; }
 #else
   // V4 (no SD): internal SPIFFS. Format-on-fail so a fresh / never-formatted
   // partition becomes usable — that's the V4 history-loss fix. Safe: only formats
@@ -45907,7 +46244,7 @@ static bool uiDataFsIsSdCard() {
   if (!uiDataFsReady()) return false;
 #if defined(HAS_TANMATSU) || defined(HAS_TDISPLAY_P4)
   return s_ui_data_fs == &SD_MMC;
-#elif defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#elif defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
   return s_ui_data_fs == &SD;
 #else
   return false;
@@ -45924,7 +46261,7 @@ static File uiDataOpen(const char* name, const char* mode) {
   if (!uiDataFsReady()) return File();
   char p[80]; snprintf(p, sizeof p, "%s%s", s_ui_data_root, name);
   File f = s_ui_data_fs->open(p, mode);
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
   // A failed WRITE open on the SD-backed history store is the wedge tell (reads
   // fail legitimately on first boot). Called from the loop task AND the core-0
   // history worker — sdNoteIoFailure is a volatile stamp, safe from both.
@@ -45963,6 +46300,7 @@ static bool readHistoryRec(File& f, void* dst, size_t cur_sz, size_t disk_sz) {
 
 bool UITask::loadThreadsFromStorage() {
 #if defined(ESP32)
+  uiDataRemove(k_ui_threads_tmp_path);   // sweep an orphaned tmp from an interrupted save (mirrors the msgs-tmp sweep)
   File f = uiDataOpen(k_ui_threads_path, "r");
   if (!f) return false;
 
@@ -46486,7 +46824,9 @@ bool UITask::saveThreadsToStorage() {
   }
 #endif
   WdtHeavyGuard _wg;
-  File f = uiDataOpen(k_ui_threads_path, "w");
+  // Write to the tmp, commit with rename: a power cut mid-write leaves the old
+  // index intact instead of a short file the next boot would quarantine.
+  File f = uiDataOpen(k_ui_threads_tmp_path, "w");
   if (!f) return false;
 
   UiHistoryHeader hdr{};
@@ -46499,7 +46839,7 @@ bool UITask::saveThreadsToStorage() {
   // this (frequently-rewritten, small) file does instead.
   hdr.msgcount              = static_cast<uint32_t>(_msgcount);
   if (f.write(reinterpret_cast<const uint8_t*>(&hdr), sizeof(hdr)) != sizeof(hdr)) {
-    f.close(); return false;
+    f.close(); uiDataRemove(k_ui_threads_tmp_path); return false;
   }
 
   UiHistoryThread t{};
@@ -46516,11 +46856,11 @@ bool UITask::saveThreadsToStorage() {
     strncpy(t.name, _ui_threads[i].name, MAX_THREAD_NAME);
     t.name[MAX_THREAD_NAME] = '\0';
     if (f.write(reinterpret_cast<const uint8_t*>(&t), sizeof(t)) != sizeof(t)) {
-      f.close(); return false;
+      f.close(); uiDataRemove(k_ui_threads_tmp_path); return false;
     }
   }
   f.close();
-  return true;
+  return uiDataReplaceFile(k_ui_threads_path, k_ui_threads_tmp_path);
 #else
   return false;
 #endif
@@ -46549,7 +46889,7 @@ static bool uiMsgsWriteResult(bool ok) {
     s_msgs_write_fail_ms = m ? m : 1;
     s_msgs_write_fail_epoch = ep;
     if (s_msgs_write_fails < 0xFFFFu) s_msgs_write_fails = s_msgs_write_fails + 1;
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
     if (s_ui_data_fs == &SD) sdNoteIoFailure();
 #endif
   }
@@ -48004,10 +48344,12 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     tzset();
   }
 
-#if defined(TLORA_PAGER)
+#if defined(TLORA_PAGER) || defined(HELTEC_LORA_V4_R8)
   // Boot storage setup may have mounted SD before UITask starts. Synchronize
   // the UI's lifecycle state before tile-backend selection and before the
-  // first loop tick can run health/remount logic.
+  // first loop tick can run health/remount logic. (R8: without this the
+  // reinsert watch SD.end()'d the LIVE DataStore volume ~30 s after boot —
+  // spurious "SD card remounted" toast, or a slow card stranded unmounted.)
   sdAdoptLiveMount();
 #endif
 
@@ -48157,6 +48499,30 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
       s_tile_root_default[0] = '\0';
     }
     WIRE_DBG("[TILE] microSD-tile mode -> caching Wi-Fi tiles on SD /tiles (merges with library)");
+  }
+#endif
+#if defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
+  // Prefer the SD card for the Wi-Fi tile cache even when "Tiles from SD card"
+  // is off. The 4.75 MB tiles partition fills after a few panned screens of
+  // downloads and has NO eviction, after which every further tile fetch fails
+  // forever ("panning doesn't reload tiles"). Cache to the card root /tiles
+  // (same layout the Launcher T-Deck uses; merges with any dropped-in pack).
+  // The partition stays registered as s_tile_fs_default, so
+  // mapNoteStorageChanged falls back to it if the card ever wedges or (R8) is
+  // pulled — maps stay online either way.
+#if defined(HAS_THINKNODE_M9)
+  // M9: the card is BUILT IN — always worth walking the full mount ladder.
+  if (s_tile_fs != &SD && (sdAdoptLiveMount() || fmSdTryMount())) {
+#else
+  // R8: the Expansion-Kit card is REMOVABLE — follow the boot mount only
+  // (adopting is a cached cardType() check; a card-less boot pays nothing and
+  // a late-inserted card is adopted by sdHealthTick + mapNoteStorageChanged).
+  if (s_tile_fs != &SD && sdAdoptLiveMount()) {
+#endif
+    s_tile_fs = &SD;
+    s_tile_root[0] = '\0';
+    s_tiles_fs_ready = true;
+    printf("[TILE] caching Wi-Fi tiles on SD /tiles\n");
   }
 #endif
 #endif
@@ -48449,6 +48815,13 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
     if (s_ui_rotation != LV_DISP_ROT_NONE) {
       s_ui_rotation = LV_DISP_ROT_NONE;
       touchPrefsSetUiRotation(LV_DISP_ROT_NONE);
+      // Heal the PANEL too: main.cpp's boot wordmark already applied the saved
+      // landscape rotation before this guard ran, so reverting only the pref
+      // left LVGL rendering portrait frames into a landscape-rotated panel —
+      // one fully garbled session per landscape attempt. (::display — the
+      // begin() parameter shadows the global, and the DisplayDriver base has
+      // no setDisplayRotation.)
+      ::display.setDisplayRotation(0);
     }
 #endif
 #if defined(HAS_TDECK_GT911)
@@ -49670,6 +50043,16 @@ static inline void touchScreenBacklight(bool on) {
   if (on) touchPanelSleep(false);   // wake the panel BEFORE lighting it (old frame intact)
   ledcWrite(kBlPwmChannel, on ? ((uint32_t)s_brightness_pct * 255u / 100u) : 0u);
   if (!on) touchPanelSleep(true);   // then stop the panel driving the crystals (anti burn-in)
+#if defined(HELTEC_LORA_V4_R8)
+  // Dark screen: throttle the CHSC6x poll task (8 ms -> 50 ms) — its blocking
+  // I2C read rides the SHARED sensor/RTC bus on this board, and full-rate
+  // polling with the screen off was pure idle drain. Wake-on-touch keeps
+  // working, at most ~42 ms later. (Local extern: the include path resolves
+  // the VENDORED MeshCore copy of HeltecV4CapTouch.h, which predates this
+  // function — the compiled driver is the repo copy in src/helpers/input.)
+  extern void heltecV4CapTouchSetSlowPoll(bool slow);
+  heltecV4CapTouchSetSlowPoll(!on);
+#endif
 #elif defined(TFT_BL)
   pinMode(TFT_BL, OUTPUT);
   #ifdef TFT_BACKLIGHT_ON
@@ -50216,8 +50599,8 @@ void UITask::notify(UIEventType t) {
   if (t == UIEventType::contactMessage || t == UIEventType::channelMessage || t == UIEventType::roomMessage)
     msgLedFlash();
 #endif
-#if defined(HAS_TDECK_KEYBOARD)
-  // Same idea on the T-Deck (no notification LED): wake the screen + briefly light the keyboard.
+#if defined(HAS_TDECK_KEYBOARD) || defined(HAS_M9_KEYBOARD)
+  // Same idea on the T-Deck and M9 (no notification LED): wake the screen + briefly light the keyboard.
   if (touchPrefsGetMsgFlash() &&
       (t == UIEventType::contactMessage || t == UIEventType::channelMessage || t == UIEventType::roomMessage)) {
     s_msgflash_until = millis() + 1600;
@@ -50383,7 +50766,7 @@ static void sdHealthTick() {
 #endif
       markSdIo();
       if (g_lv.task) g_lv.task->showAlert(TR("SD card remounted"), 1800);
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
       // Land the RAM ring on the card promptly, not up to 30+ s later: every
       // message received while the card was out is only in RAM. Armed as an
       // OFF-THREAD flush — a synchronous write here froze the UI for >30 s on
@@ -50465,7 +50848,7 @@ static void sdHealthTick() {
     return;
   }
 #endif
-#if defined(HAS_TDECK_GT911) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
+#if (defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)) && defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION) && CAP_OTA
   if (s_sdfw_request) return;     // worker streaming a firmware download to /BINS (T-Deck only)
 #endif
   // Probe when some SD user flagged a failure (rate-limited to 1/5 s), and
@@ -50496,6 +50879,11 @@ static void sdHealthTick() {
   if (sdProbeAlive()) {
     // Transient failure (card full, bad path, ...) — keep the mount and let the
     // preserved tile queue continue on it.
+#if defined(MULTI_TRANSPORT_COMPANION) && defined(HAS_THINKNODE_M9)
+    // The note window blanked every SD tile read (loadTileJpeg bails on it) —
+    // arm the rate-capped map repaint so pan gaps heal without a keypress.
+    if (s_map_last_missing > 0) s_tile_fetch_dirty = true;
+#endif
     tileBackendSwapFinish();
     return;
   }
@@ -50505,7 +50893,7 @@ static void sdHealthTick() {
     s_sd_data_warn_next_ms = 0;
 #endif
     if (g_lv.task) g_lv.task->showAlert(TR("SD card remounted"), 1800);
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
     if (!s_ui_data_fs) uiDataFsReady();
     if (s_ui_data_fs == &SD) {
       SD.mkdir("/meshcomod");                          // fresh replacement card: recreate the data root
@@ -50870,7 +51258,7 @@ void UITask::loop() {
     }
   }
 
-#if defined(HAS_TDECK_KEYBOARD)   // notify-flash (and so the notify wake) is a T-Deck feature
+#if defined(HAS_TDECK_KEYBOARD) || defined(HAS_M9_KEYBOARD)   // notify-flash (and so the notify wake): T-Deck + M9
   // Notify-wake re-dim: a screen lit by a MESSAGE (not user input) goes dark again after a
   // short bounded window. On a busy channel the per-message wakes otherwise keep a static
   // image lit for the full screen-timeout — or forever at "never" — which retains into the
@@ -50887,7 +51275,7 @@ void UITask::loop() {
       _screen_off = true;
     }
   }
-#endif  // HAS_TDECK_KEYBOARD (notify-wake re-dim)
+#endif  // HAS_TDECK_KEYBOARD || HAS_M9_KEYBOARD (notify-wake re-dim)
 
 #if defined(HAS_TOUCH_UI)
   if (!g_lv.ready) return;
@@ -50996,7 +51384,7 @@ void UITask::loop() {
         // unmountable card spikes current / churns the bus and can reset the board.
         if (!sdRuntimeLifecycleBusy() && now >= s_sd_retry_after_ms && fmSdTryMount()) {
           showAlert(TR("SD card inserted"), 1500);
-#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
           if (!s_ui_data_fs) uiDataFsReady();
           if (s_ui_data_fs == &SD) {
             SD.mkdir("/meshcomod"); // fresh replacement card: recreate the data root
@@ -51195,9 +51583,16 @@ void UITask::loop() {
 #elif defined(HAS_M9_KEYBOARD)
   // M9's keyboard controller is on its OWN bus (Wire1) — no touch task shares
   // it, so polling happens right here on the UI thread rather than from a
-  // separate core-0 task. No keyboard-backlight control exists on this
-  // controller (TODO — see M9_PORT.md if/when one is confirmed), so this is
-  // just poll + drain, no backlight tick.
+  // separate core-0 task (the poll itself rate-limits to ~15 ms inside
+  // m9KeyboardPoll so the free-running loop doesn't hammer the bus).
+  //
+  // Keys used to dispatch against a one-tick-stale nav mirror: Enter's tree
+  // mutations (open/close a modal) only land inside lv_timer_handler at the
+  // END of a tick, so the FIRST arrow of the next tick ran navMoveDir against
+  // s_nav_objs still mirroring the screen behind the modal — the intermittent
+  // "modal navigation breaks out to the screen behind" bug. Sync the group to
+  // the current tree before draining (cheap: sig-compare early-out).
+  if (s_kbd_nav || s_tb_nav) navMaybeRebuild();
   m9KeyboardPoll();
   for (int kbi = 0; kbi < 12; ++kbi) {
     int key = m9KeyboardReadKey();
@@ -51205,6 +51600,29 @@ void UITask::loop() {
     if (!_screen_off) s_kb_last_key_ms = now;
     if (s_remote_mode) { remotePhysicalKey(key); continue; }   // remote mode: physical keys are the exit
     handleHwKey(key);
+  }
+  // New-message notify flash — same contract as the T-Deck branch above:
+  // hard-locked reveals the lock screen (lights the wallpaper, keeps the
+  // lock), an unlocked idle-dim gets the full wake. Especially useful here:
+  // no notification LED and no touch to check the screen with.
+  if (s_msgflash_wake) {
+    s_msgflash_wake = false;
+    if (_manual_lock)     { lockscreenReveal(); s_notify_wake_ms = millis(); }
+    else if (_screen_off) { wakeScreen();       s_notify_wake_ms = millis(); }
+  }
+  // Keyboard backlight: the controller DOES expose duty control (reg 0x02;
+  // it also auto-lights on keypress and times out after 10 s on its own —
+  // this sets the level/mode our side wants). off / on / auto follow the same
+  // s_kb_bl_mode the Control Center "Keyboard" chip cycles; write-on-change
+  // only, so the tick costs zero I2C in steady state.
+  {
+    uint8_t kb_bl = 0;
+    if (s_kb_bl_mode == 1) kb_bl = 255;
+    else if (s_kb_bl_mode == 2 && (now - s_kb_last_key_ms) < kKbBacklightIdleMs) kb_bl = 255;
+    if (_screen_off || _manual_lock) kb_bl = 0;   // dark/locked screen -> keyboard dark too
+    else if (s_msgflash_until && (int32_t)(now - s_msgflash_until) < 0) kb_bl = 255;   // notify pulse
+    static uint8_t s_kb_bl_last = 0xFF;
+    if (kb_bl != s_kb_bl_last) { s_kb_bl_last = kb_bl; m9KeyboardSetBacklight(kb_bl); }
   }
   serviceLockscreen();
   serviceLockingCountdown(now);
@@ -51485,7 +51903,7 @@ void UITask::loop() {
   lv_timer_handler();
   uiCp("ui:tail");
 #if (CAP_SD || defined(TLORA_PAGER)) && \
-    (defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER))
+    (defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9))
   sdRestoreRun();   // intentionally outside the LVGL event/render call stack
 #endif
 #if !defined(HAS_TANMATSU)
@@ -51649,12 +52067,12 @@ static const PopupEnt k_popup_registry[] = {
   { P_OPEN(s_local_sensors_root),    []{ closeLocalSensorsPage(); },      PF_COUNT },   // was in no registry at all
 #endif
   { P_OPEN(s_siginfo_root),          []{ closeSigInfoPopup(); },          PF_COUNT },
-#if defined(HAS_TDECK_GT911) || defined(HAS_TANMATSU) || defined(TLORA_PAGER)
+#if defined(HAS_TDECK_GT911) || defined(HAS_TANMATSU) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9)
   { P_OPEN(s_fm_img_root),           []{ fmImageClose(); },               PF_COUNT },
   { P_OPEN(s_editor_root),           []{ fmEditorClose(); },              PF_COUNT },
   { P_OPEN(s_fm_prompt),             []{ fmPromptClose(); },              PF_COUNT },
   { P_OPEN(s_fm_actions),            []{ fmCloseActions(); },             PF_COUNT },
-#if CAP_SD || defined(TLORA_PAGER)
+#if CAP_SOUND_FILES   // s_fm_snd_root exists only under this gate (same set as the old CAP_SD||PAGER inside this block, minus the M9)
   { P_OPEN(s_fm_snd_root),           []{ fmSndClose(); },                 PF_COUNT },   // was in no registry at all
 #endif
   { P_OPEN(s_fm_fmt_overlay),        nullptr,                             PF_COUNT },   // format progress: block keys, not dismissable
@@ -51669,7 +52087,7 @@ static const PopupEnt k_popup_registry[] = {
   { P_OPEN(s_telem_config_root),     []{ telemetryConfigClose(); },       PF_COUNT },   // sits on the telemetry window
   { P_OPEN(s_telemetry_root),        []{ telemetryClose(); },             PF_COUNT },
 #endif
-#if defined(HAS_TDECK_GT911)
+#if defined(HAS_TDECK_GT911) || defined(HAS_THINKNODE_M9)
   { P_OPEN(s_lockwall_picker),       []{ lockwallPickerClose(); },        PF_COUNT },
 #endif
   { P_OPEN(s_accent_picker),         []{ accentPickerClose(); },          PF_COUNT | PF_SWIPE },

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -14943,18 +14943,6 @@ static void buildMqttSettings() {
 #endif
 }
 
-#if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
-// Wi-Fi modem power save: persist + apply live. Only touches the driver once associated —
-// WiFi.setSleep() on an unassociated STA naps the radio through scan dwells (see main.cpp).
-// esp_wifi_set_ps is a plain setter (no disconnect/begin), so it is safe from the LVGL ctx.
-static void wifiPowerSaveToggleCb(lv_event_t* e) {
-  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
-  const bool on = lv_obj_has_state(lv_event_get_target(e), LV_STATE_CHECKED);
-  wifiConfigSetPowerSave(on);
-  if (WiFi.status() == WL_CONNECTED) WiFi.setSleep(on);
-}
-#endif
-
 static void buildWifiSettings() {
   lv_obj_t* body = createSettingsModal("", SettingsModalKind::Wifi);   // no group header — the top bar already says "Wi-Fi"
   int y = 0;
@@ -14974,18 +14962,6 @@ static void buildWifiSettings() {
   lv_obj_set_pos(g_set_modal.wifi_sta_status_l, 2, y + SC(7));
   lv_label_set_text(g_set_modal.wifi_sta_status_l, TR("Loading..."));
   y += SC(30);
-
-  // Modem power save (DTIM sleep) — see wifiPowerSaveToggleCb. Default ON; OFF on the V4-R8.
-  {
-    int rh = settingsRowLabel(body, y, 4, TR("Power save (modem sleep)"), COLOR_TEXT, &g_font_12, 56);
-    lv_obj_t* sw = lv_switch_create(body);
-    lv_obj_align(sw, LV_ALIGN_TOP_RIGHT, 0, y);
-    if (wifiConfigGetPowerSave()) lv_obj_add_state(sw, LV_STATE_CHECKED);
-    lv_obj_add_event_cb(sw, wifiPowerSaveToggleCb, LV_EVENT_VALUE_CHANGED, nullptr);
-    y += LV_MAX(34, rh + 10);
-    y += settingsRowLabel(body, y, 0, TR("Off: snappier app/TCP link, steadier on a weak signal. On: less power, kinder to Bluetooth."),
-                          COLOR_SUB, &g_font_12, 0) + 2;
-  }
 
   // Make sure the network we're currently using shows up as saved, and on first
   // run import any legacy 3-slot profiles into the new known-networks store.

--- a/src/ui-touch/device_caps.h
+++ b/src/ui-touch/device_caps.h
@@ -85,12 +85,23 @@
   // HELTEC_LORA_V4_TFT to reuse all its UI code); the deltas are 8 MB octal
   // PSRAM (→ web browser) and a micro-SD slot on the Expansion Kit V2.
   #define CAP_TOUCH        1   // CHSC6x capacitive touch (Expansion Kit V2)
-  #define CAP_ROTATABLE    1   // user can flip portrait/landscape
+  // Rotation is OFF until a tester verifies the R8-specific landscape touch
+  // maps (HeltecV4CapTouch.cpp, TESTER-VERIFY): the boot guard at UITask.cpp
+  // ("V4-R8: force PORTRAIT at every boot") reverts any landscape pref anyway,
+  // so with 1 the Orientation control was a reboot trap that always landed
+  // back on Portrait (plus one garbled session, since the boot wordmark had
+  // already rotated the panel). Flip back to 1 together with removing that
+  // guard once landscape touch is confirmed on hardware.
+  #define CAP_ROTATABLE    0
   #define CAP_LARGE_SCREEN 0   // 240x320
   #define CAP_SD           1   // micro-SD on Expansion Kit V2 (shared TFT SPI bus, CS=3)
   #define CAP_FILESYSTEM   1   // browsable filesystem (the SD card)
   #define CAP_GPS          1
   #define CAP_OTA          1   // native dual-OTA slot
+  // 0: no unlock gesture exists yet — touch is deliberately inert while
+  // hard-locked and BOOT already wake-unlocks in the generic branch. Enabling
+  // needs a reveal+hold-to-unlock input path plus the DSEC_LOCK row gates
+  // (see UITask.cpp lockScreen()/noteUserInput) — a feature, not a cap flip.
   #define CAP_LOCK_SCREEN  0
 
 #elif defined(HAS_TDISPLAY_P4)        // ===== LilyGo T-Display P4 (ESP32-P4 + C6) =====

--- a/variants/heltec_v4/HeltecV4Board.cpp
+++ b/variants/heltec_v4/HeltecV4Board.cpp
@@ -11,6 +11,20 @@ void HeltecV4Board::begin() {
 
     loRaFEMControl.init();
 
+#if defined(HELTEC_LORA_V4_R8) && defined(PIN_SD_CS)
+    // Park the shared-FSPI micro-SD's chip-select HIGH before LGFX starts
+    // driving the bus (display.begin + logo blit run before the first
+    // SD.begin): GPIO3 is a strapping pin with no firmware pull, and a card
+    // that samples CS low during that window can latch a confused state the
+    // mount ladder then has to rescue. Same discipline as M9Board/the pager.
+    pinMode(PIN_SD_CS, OUTPUT);
+    digitalWrite(PIN_SD_CS, HIGH);
+    // The R8 boot FEM-type line makes the auto-detect visible (the About page
+    // reports the board name only) — needed to verify GPIO46 really is the
+    // FEM TX-enable on this board rather than a plain LED (see r8 audit).
+    Serial.printf("[R8] FEM type=%d (0=GC1109 1=KCT8103L 2=other)\n", (int)loRaFEMControl.getFEMType());
+#endif
+
     periph_power.begin();
     esp_reset_reason_t reason = esp_reset_reason();
     if (reason == ESP_RST_DEEPSLEEP) {
@@ -21,6 +35,15 @@ void HeltecV4Board::begin() {
 
       rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
       rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
+#if defined(HELTEC_LORA_V4_R8)
+      // Release the digital-pad holds powerOffCb armed before deep sleep
+      // (VEXT / GPS_EN / backlight) — held pads would otherwise block this
+      // boot's own rail and backlight drives.
+      gpio_deep_sleep_hold_dis();
+      gpio_hold_dis((gpio_num_t)PIN_VEXT_EN);
+      gpio_hold_dis((gpio_num_t)PIN_GPS_EN);
+      gpio_hold_dis((gpio_num_t)PIN_TFT_LEDA_CTL);
+#endif
     }
   }
 
@@ -64,6 +87,21 @@ void HeltecV4Board::begin() {
   }
 
   uint16_t HeltecV4Board::getBattMilliVolts()  {
+#if defined(HELTEC_LORA_V4_R8)
+    // R8: match Meshtastic's heltec_v4_r8 variant — the always-connected
+    // high-resistance divider wants LOW attenuation (2.5 dB, full-scale
+    // ~1.05 V; the node sits at VBAT/5.07 ≈ 0.65-0.85 V) and a CALIBRATED
+    // millivolt read. The generic uncalibrated raw*(3.3/1024) at the default
+    // 11 dB under-read this divider by ~5-10%: a full 4.2 V pack displayed
+    // ~3.9 V, so the charging-bolt threshold (batteryFullMv()+50) was
+    // unreachable by construction and one ADC count quantized to ~16 mV of
+    // display (the "frozen at 3839 mV" report).
+    static bool s_atten_set = false;
+    if (!s_atten_set) { analogSetPinAttenuation(PIN_VBAT_READ, ADC_2_5db); s_atten_set = true; }
+    uint32_t mv = 0;
+    for (int i = 0; i < 8; i++) mv += analogReadMilliVolts(PIN_VBAT_READ);
+    return (uint16_t)((mv / 8) * adc_mult);
+#else
     analogReadResolution(10);
 #if defined(PIN_ADC_CTRL) && PIN_ADC_CTRL >= 0
     digitalWrite(PIN_ADC_CTRL, HIGH);   // enable the battery divider
@@ -78,6 +116,7 @@ void HeltecV4Board::begin() {
     digitalWrite(PIN_ADC_CTRL, LOW);
 #endif
     return (adc_mult * (3.3 / 1024.0) * raw) * 1000;
+#endif
   }
 
   const char* HeltecV4Board::getManufacturerName() const {

--- a/variants/heltec_v4/LGFXDisplay.cpp
+++ b/variants/heltec_v4/LGFXDisplay.cpp
@@ -3,14 +3,24 @@
 
 #include "LGFXDisplay.h"
 #include <Arduino.h>
+#include <esp_heap_caps.h>
 
 #ifndef LGFX_INVERT_COLOR
   #define LGFX_INVERT_COLOR true  // default: black bg (ST7789 INVON)
 #endif
+// Largest LVGL band this driver ever sees: the R8's draw buffer is 240 x LV_DRAW_BUF_LINES
+// (24) px = 5760 px, in either orientation (LVGL re-splits to the buffer size). Rounded up.
+#ifndef LGFX_SWAP_BUF_PX
+  #define LGFX_SWAP_BUF_PX 6144
+#endif
 
 LGFXDisplay::LGFXDisplay(RefCountedDigitalPin* peripher_power)
   : DisplayDriver(240, 320),
-    _periph_power(peripher_power)
+    _periph_power(peripher_power),
+    _swap_buf(nullptr),
+    _swap_px(0),
+    _swap_alloc_failed(false),
+    _frame_open(false)
 {
   _isOn  = false;
   _color = 0xFFFF;
@@ -22,11 +32,13 @@ LGFXDisplay::LGFXDisplay(RefCountedDigitalPin* peripher_power)
     auto cfg = _bus.config();
     cfg.spi_host    = SPI2_HOST;
     cfg.spi_mode    = 0;
-    cfg.freq_write  = 40000000;      // 40 MHz — the old 20 MHz made a full-screen flush
-                                     // ~61 ms of pure bus time (~4x the plain V4's 80 MHz
-                                     // driver); ST7789 typically takes 62.5-80 MHz, so 40
-                                     // is still the conservative choice. If hardware shows
-                                     // tearing/garbled bands, fall back to 26.6 MHz.
+    // 80 MHz (perf pass 2026-08-20) — parity with the plain V4's TFT_eSPI driver on the
+    // same ST7789 panel family. History: 20 MHz made a full-screen flush ~61 ms of pure
+    // bus time, 40 MHz ~31 ms, 80 MHz ~15 ms. The S3's SPI clock is 80 MHz / n, so the
+    // only rungs are 80 / 40 / 26.7 / 20; build with -D LGFX_SPI_WRITE_HZ=40000000 to
+    // step back down if a unit shows tearing or garbled bands (the micro-SD shares
+    // SCLK/MOSI, so the trace load is higher than the plain V4's).
+    cfg.freq_write  = LGFX_SPI_WRITE_HZ;
     cfg.freq_read   = 16000000;
     cfg.spi_3wire   = false;
     cfg.use_lock    = true;
@@ -107,13 +119,14 @@ void LGFXDisplay::turnOn() {
 }
 void LGFXDisplay::turnOff() {
   if (!_isOn) return;
+  finishFrame();
   pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
   digitalWrite(PIN_TFT_LEDA_CTL, LOW);
   _isOn = false;
   if (_periph_power) _periph_power->release();
 }
-void LGFXDisplay::clear()                     { _lcd.fillScreen(0x0000); }
-void LGFXDisplay::startFrame(ColorVal)        { _lcd.fillScreen(0x0000); }
+void LGFXDisplay::clear()                     { finishFrame(); _lcd.fillScreen(0x0000); }
+void LGFXDisplay::startFrame(ColorVal)        { finishFrame(); _lcd.fillScreen(0x0000); }
 void LGFXDisplay::setTextSize(int sz)         { _lcd.setTextSize(sz); }
 
 void LGFXDisplay::setColor(ColorVal c) {
@@ -136,9 +149,61 @@ void LGFXDisplay::writePixelsRGB565(int x, int y, int w, int h, const uint16_t* 
   _lcd.endWrite();
 }
 
+// Async LVGL flush (perf pass 2026-08-20).
+//
+// LVGL renders little-endian RGB565 into ONE draw buffer; the ST7789 wants big-endian.
+// The sync path above hands that buffer to LovyanGFX with setSwapBytes(true), which is
+// LGFX's *convert* path: a per-pixel byte swap into 32..256 px chunks, each chunk its own
+// DMA kick, and the call only returns once the whole band is on the wire — so LVGL's
+// render of band N+1 never overlapped the transfer of band N (13 bands per full frame).
+//
+// Here the swap is one 16-bit rotate per pixel into our own internal DMA buffer, the band
+// goes out as ONE no-convert DMA (swap=false -> src depth == panel depth -> no_convert ->
+// Bus_SPI::writeBytes DMA), and we return at once: LVGL renders the next band while the
+// SPI drains this one. Ordering is LGFX's: the next writeBytes waits on SPI_USR before it
+// starts, and we waitDMA() before overwriting the buffer. One startWrite()/endWrite()
+// transaction spans the frame and is closed on the last band, so the micro-SD (bus_shared)
+// gets the bus back between frames exactly as before — just with ~13 fewer transaction
+// setups per frame. Total bus time is unchanged; what changes is that the CPU is free
+// during it.
+void LGFXDisplay::flushBandRGB565(int x, int y, int w, int h, const uint16_t* pixels, bool last) {
+  if (!_isOn || !pixels || w <= 0 || h <= 0) { if (last) finishFrame(); return; }
+  const size_t px = (size_t)w * (size_t)h;
+  if (!_swap_buf && !_swap_alloc_failed) {
+    _swap_px  = LGFX_SWAP_BUF_PX;
+    _swap_buf = (uint16_t*)heap_caps_malloc(_swap_px * sizeof(uint16_t),
+                                            MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT);
+    if (!_swap_buf) {
+      _swap_alloc_failed = true;   // internal DRAM exhausted: stay on the sync path for good
+      Serial.println("[TFT] async flush: no internal DMA RAM for the swap buffer; sync flush");
+    }
+  }
+  if (!_swap_buf || px > _swap_px) {          // fallback: synchronous convert path
+    writePixelsRGB565(x, y, w, h, pixels);
+    if (last) finishFrame();
+    return;
+  }
+  if (!_frame_open) { _lcd.startWrite(); _frame_open = true; }
+  _lcd.waitDMA();                             // the previous band may still be reading _swap_buf
+  const uint16_t* s = pixels;
+  uint16_t*       d = _swap_buf;
+  for (size_t i = 0; i < px; ++i) d[i] = __builtin_bswap16(s[i]);
+  _lcd.setAddrWindow(x, y, w, h);
+  _lcd.writePixelsDMA(_swap_buf, (int32_t)px, /*swap=*/false);   // already panel byte order
+  if (last) finishFrame();
+}
+
+void LGFXDisplay::finishFrame() {
+  if (!_frame_open) return;
+  _lcd.waitDMA();
+  _lcd.endWrite();
+  _frame_open = false;
+}
+
 // UI contract (see UITask applyRotation): called with 1 for ROT_90, 3 for ROT_270; portrait
 // stays as-inited (rotation 0). Honor the argument — the old hardcoded 1 ignored it.
 void LGFXDisplay::setDisplayRotation(uint8_t r) {
+  finishFrame();
   _lcd.setRotation(r & 3);
   setLogicalSize(_lcd.width(), _lcd.height());
 }
@@ -152,6 +217,7 @@ void LGFXDisplay::panelSleep(bool sleep) {
   // setSleep writes the bare command with no delay: t_SLPIN wants 5 ms of bus
   // quiet after SLPIN, and >=5 ms must pass after SLPOUT before the next
   // command (the wake path fires backlight + LVGL flushes immediately after).
+  finishFrame();
   if (sleep) { _lcd.sleep();  delay(5); }   // SLPIN
   else       { _lcd.wakeup(); delay(6); }   // SLPOUT
 }

--- a/variants/heltec_v4/LGFXDisplay.cpp
+++ b/variants/heltec_v4/LGFXDisplay.cpp
@@ -22,7 +22,11 @@ LGFXDisplay::LGFXDisplay(RefCountedDigitalPin* peripher_power)
     auto cfg = _bus.config();
     cfg.spi_host    = SPI2_HOST;
     cfg.spi_mode    = 0;
-    cfg.freq_write  = 20000000;      // 20 MHz — conservative for this PCB
+    cfg.freq_write  = 40000000;      // 40 MHz — the old 20 MHz made a full-screen flush
+                                     // ~61 ms of pure bus time (~4x the plain V4's 80 MHz
+                                     // driver); ST7789 typically takes 62.5-80 MHz, so 40
+                                     // is still the conservative choice. If hardware shows
+                                     // tearing/garbled bands, fall back to 26.6 MHz.
     cfg.freq_read   = 16000000;
     cfg.spi_3wire   = false;
     cfg.use_lock    = true;
@@ -63,15 +67,12 @@ LGFXDisplay::LGFXDisplay(RefCountedDigitalPin* peripher_power)
   }
 
   // ---- Backlight ----
-  {
-    auto cfg = _light.config();
-    cfg.pin_bl = PIN_TFT_LEDA_CTL; // 44
-    cfg.invert = false;
-    cfg.freq   = 44000;
-    cfg.pwm_channel = 7;
-    _light.config(cfg);
-    _panel.setLight(&_light);
-  }
+  // Deliberately NOT routed through LGFX's Light_PWM: UITask's applyBrightness()
+  // owns GPIO44 on LEDC channel 6 (20 kHz / 8-bit), and a second owner
+  // (Light_PWM ch7, 44 kHz / 9-bit, sharing LEDC timer 3) was a latent
+  // conflict — any future _lcd.setBrightness() would write 9-bit duty onto a
+  // channel that no longer owns the pin. begin()/turnOn()/turnOff() drive the
+  // pad directly for the boot-logo window; UITask takes over once the UI is up.
 
   _lcd.setPanel(&_panel);
 }
@@ -87,7 +88,8 @@ bool LGFXDisplay::begin() {
   // The old hardcoded setRotation(1) here put the panel in landscape under portrait frames —
   // the tester's "boot logo in the wrong orientation".
   _lcd.setRotation(0);
-  _lcd.setBrightness(255);
+  pinMode(PIN_TFT_LEDA_CTL, OUTPUT);       // boot-logo backlight (UITask's LEDC takes over later)
+  digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
   _lcd.fillScreen(0x0000);
   setLogicalSize(_lcd.width(), _lcd.height());
 
@@ -99,12 +101,14 @@ bool LGFXDisplay::begin() {
 void LGFXDisplay::turnOn() {
   if (_isOn) return;
   if (_periph_power) _periph_power->claim();
-  _lcd.setBrightness(255);
+  pinMode(PIN_TFT_LEDA_CTL, OUTPUT);       // re-route from any LEDC attach back to plain GPIO
+  digitalWrite(PIN_TFT_LEDA_CTL, HIGH);
   _isOn = true;
 }
 void LGFXDisplay::turnOff() {
   if (!_isOn) return;
-  _lcd.setBrightness(0);
+  pinMode(PIN_TFT_LEDA_CTL, OUTPUT);
+  digitalWrite(PIN_TFT_LEDA_CTL, LOW);
   _isOn = false;
   if (_periph_power) _periph_power->release();
 }
@@ -144,8 +148,12 @@ void LGFXDisplay::setDisplayRotation(uint8_t r) {
 // back with no redraw). Using LGFX's bus — not a second HSPI SPIClass on the same
 // pins — is what keeps the shared FSPI display bus intact across a wake.
 void LGFXDisplay::panelSleep(bool sleep) {
-  if (sleep) _lcd.sleep();    // SLPIN
-  else       _lcd.wakeup();   // SLPOUT
+  // Mirror the hardware-proven V4/T-Deck shim's datasheet timing — LovyanGFX's
+  // setSleep writes the bare command with no delay: t_SLPIN wants 5 ms of bus
+  // quiet after SLPIN, and >=5 ms must pass after SLPOUT before the next
+  // command (the wake path fires backlight + LVGL flushes immediately after).
+  if (sleep) { _lcd.sleep();  delay(5); }   // SLPIN
+  else       { _lcd.wakeup(); delay(6); }   // SLPOUT
 }
 
 #endif  // HELTEC_LORA_V4_R8

--- a/variants/heltec_v4/LGFXDisplay.h
+++ b/variants/heltec_v4/LGFXDisplay.h
@@ -16,6 +16,14 @@
 #define LGFX_USE_V1
 #include <LovyanGFX.hpp>
 
+// Display SPI write clock. 80 MHz (perf pass 2026-08-20) = parity with the plain V4's
+// TFT_eSPI driver; the S3's rungs are 80 / 40 / 26.7 / 20 MHz. Override with
+// -D LGFX_SPI_WRITE_HZ=40000000 if a unit shows tearing / garbled bands. Exposed here
+// (not just in the .cpp) so Settings -> About can report it.
+#ifndef LGFX_SPI_WRITE_HZ
+  #define LGFX_SPI_WRITE_HZ 80000000
+#endif
+
 class LGFXDisplay : public DisplayDriver {
 private:
   lgfx::Panel_ST7789  _panel;
@@ -26,6 +34,14 @@ private:
   bool _isOn;
   uint16_t _color;
   RefCountedDigitalPin* _periph_power;
+
+  // Async LVGL flush state (see flushBandRGB565): one internal DMA-capable band buffer
+  // holding the byte-swapped copy of the LVGL band currently on the wire, and whether a
+  // frame-spanning startWrite() transaction is open on the (micro-SD-shared) bus.
+  uint16_t* _swap_buf;
+  size_t    _swap_px;
+  bool      _swap_alloc_failed;
+  bool      _frame_open;
 
 public:
   LGFXDisplay(RefCountedDigitalPin* peripher_power = nullptr);
@@ -47,8 +63,22 @@ public:
   uint16_t getTextWidth(const char* str) override;
   void endFrame() override;
 
-  // ---- LVGL flush entry point ----
+  // ---- LVGL flush entry points ----
+  // Synchronous: byte-swap + write, returns once the band is on the wire (LovyanGFX's
+  // convert path). Kept for non-LVGL callers and as the fallback of the async path.
   void writePixelsRGB565(int x, int y, int w, int h, const uint16_t* pixels);
+  // Asynchronous (lvglFlush on the R8): swaps the band into an internal DMA buffer, kicks a
+  // single DMA and returns immediately so LVGL renders band N+1 while band N drains. `last`
+  // = lv_disp_flush_is_last(): waits for the DMA and closes the frame transaction so the
+  // shared micro-SD gets the bus back between frames. Falls back to the sync path if the
+  // DMA buffer could not be allocated.
+  void flushBandRGB565(int x, int y, int w, int h, const uint16_t* pixels, bool last);
+  // Wait for any in-flight band DMA and end the frame transaction (no-op if none is open).
+  // Every non-LVGL bus user below (sleep, rotation, clear) calls this first.
+  void finishFrame();
+  // True once the async path has its internal DMA buffer (i.e. LVGL flushes are async);
+  // false before the first flush or if internal DRAM was exhausted (sync fallback).
+  bool asyncFlushActive() const { return _swap_buf != nullptr; }
 
   // ---- Hardware panel rotation ----
   void setDisplayRotation(uint8_t r);

--- a/variants/heltec_v4/R8_AUDIT.md
+++ b/variants/heltec_v4/R8_AUDIT.md
@@ -1,0 +1,143 @@
+# Heltec V4-R8 (Expansion Kit V2) — audit pass, 2026-08-19
+
+Multi-agent audit (4 dimensions, each adversarially verified) of the R8 build,
+which compiles the whole plain-V4 TFT codebase with `HELTEC_LORA_V4_R8` gating
+only the deltas. 26 findings: 23 confirmed, 1 refuted, 2 hardware-uncertain.
+Everything below is compile-verified; items marked **[HW]** still want a check
+on the physical device.
+
+## Fixed in this pass (all R8-gated unless noted)
+
+### Storage
+- **Chat history / battery log / Lua app files now follow the SD adoption.**
+  `uiDataFsReady()` had no R8 arm, so even when the boot store adopted the card
+  (identity/prefs/contacts on SD), history stayed on SPIFFS with the small
+  500-message ring — a split store with none of the SD hardening. New R8 arm is
+  keyed on `g_full_data_on_sd` (the card is REMOVABLE — pager-shaped decision,
+  unlike the M9's always-adopt), plus `uiDataFsIsSdCard()` and the write-failure
+  wedge stamps / remount flush blocks. **[HW]** Upgrade caveat: an R8 that
+  adopted a card on an older build carries a day-one `/msgs` snapshot on it —
+  run Settings → Storage → "Copy internal data to SD" once to refresh.
+- **The reinsert watch no longer unmounts the live data store.** UITask never
+  adopted the boot SD mount on the R8 (`s_sd_mounted` stayed false), so
+  `sdHealthTick` SD.end()'d the volume DataStore was using ~30 s after boot —
+  spurious "SD card remounted" toast on warm cards; slow cards (the ones the
+  boot ladder's 400 kHz–1 MHz rungs exist for) could be stranded unmounted all
+  session with contacts silently unsaveable. `sdAdoptLiveMount()` now runs at
+  UITask::begin like the pager.
+- **Map tile cache prefers the SD card** (boot-mount-follow only — no mount
+  ladder on card-less boots), same rationale as the M9: the 4.75 MB tiles
+  partition fills and has no eviction, after which every tile download fails
+  forever. Partition remains the fallback when the card is out.
+- **SD chip-select (GPIO3, strapping pin) parked HIGH in board init** before
+  LGFX floods the shared FSPI bus with the boot logo.
+
+### Display / touch
+- **Rotation trap defused.** `CAP_ROTATABLE` → 0: the Orientation control was a
+  reboot trap (the boot guard force-reverts landscape because the R8 landscape
+  touch maps are TESTER-VERIFY), and worse, the boot wordmark had already
+  rotated the panel before the guard ran — the pref got reverted but the panel
+  stayed landscape → one fully garbled session per attempt. The guard now also
+  heals the panel (`::display.setDisplayRotation(0)`). Re-enable rotation +
+  remove the guard together once a tester confirms landscape touch. **[HW]**
+- **Display SPI raised 20 → 40 MHz** (full-screen flush was ~61 ms of pure bus
+  time, ~4× the plain V4's 80 MHz driver). **[HW]** Watch for tearing/garbled
+  bands; fall back to 26.6 MHz if seen.
+- **Panel sleep got its datasheet delays** (SLPIN +5 ms, SLPOUT +6 ms — the
+  LGFX call writes the bare command; the wake path fires backlight + flushes
+  immediately after). **[HW]**
+- **Backlight single-owner.** GPIO44 had three owners (LGFX Light_PWM ch7
+  44 kHz/9-bit, target.cpp digitalWrite, UITask LEDC ch6 20 kHz/8-bit — ch6/ch7
+  share LEDC timer 3). LGFX no longer configures a Light; begin/turnOn/turnOff
+  drive the pad directly and UITask's LEDC owns brightness after boot.
+- **Touch poll throttled while the screen is off** (8 → 50 ms): the CHSC6x poll
+  is a blocking ~2 ms I2C read on the SHARED sensor/RTC bus, formerly 24/7.
+  Wake-on-touch worst case +42 ms. (INT-pin gating would be better still but
+  needs the INT level/pulse behavior characterized on hardware first.)
+- **Swipe map corrected for the transient keyboard landscape** (LVGL
+  sw-rotate, panel NOT rotated): the R8's panel-baseline-swapped map applied
+  there too, inverting left/right swipes — a swipe could read backwards and
+  e.g. close a chat via the swipe-back gesture. The hardware-verified V4
+  formulas now apply whenever the panel isn't hardware-rotated. **[HW]**
+- **Touch probe address honored** (shared fix): a CHSC6x variant ACKing at
+  0x15/0x14 used to pass the probe and then read hardcoded 0x2E forever
+  ("touch init ok", dead touch). The driver now reads the address that ACKed.
+
+### Power
+- **"Power off" actually powers things off**: it used to leave the SX1262 in
+  RX with the FEM enabled (pure drain — every wake source except the button is
+  cleared) and the non-RTC rail pins (VEXT=40, GPS_EN=42, backlight=44)
+  floating. Now: radio off, FEM sleep, rails parked + `gpio_hold` through deep
+  sleep (released on wake in HeltecV4Board::begin). Toast says "press BOOT to
+  wake". **[HW]** measure off-current before/after.
+- **Battery saver unlocked** (Settings → Battery): the toggle was T-Deck-only
+  on a stale "gate never passes on the V4" rationale that doesn't hold for the
+  R8; a parked R8 busy-spun the main loop all night. **[HW]**
+- **Charging detection enabled** (T-Deck voltage heuristic): the R8's divider
+  is permanently connected (PIN_ADC_CTRL=-1), so the EMA + above-full check
+  applies; previously compile-time false — no bolt, no charge-flip publish.
+  **[HW]** confirm the charger lifts the divider node above full+50 mV, and
+  sanity-check ADC_MULTIPLIER=5.07 absolute accuracy.
+
+### UX
+- **"Save update bin to SD"** now offered on the R8 (About page) — it
+  qualified on every axis and its OTA bin name (`wadamesh-heltec-v4-r8-tft`)
+  already existed.
+- **"Set as wallpaper" hidden where no lock screen exists** (`CAP_LOCK_SCREEN`
+  gate — the R8 is the only filesystem board without one; the button toasted
+  "Lock wallpaper set" into the void).
+- `CAP_LOCK_SCREEN=0` documented: enabling it is a feature (needs a
+  reveal + hold-to-unlock input path), not a cap flip.
+
+## Resolved on hardware (2026-08-19 evening, edge-probe + NMEA passthrough)
+
+- **GPS: fully working — CLOSED.** Probed on the device: EN (GPIO42) is
+  active-LOW as inherited (module streams only with EN low); the module (CASIC
+  AT6558R GNSS) transmits on GPIO39 at 9600 baud; 67 clean NMEA sentences
+  captured. A "no GPS signal" report is the module honestly having no
+  satellite FIX (GGA quality 0 indoors) — needs sky view. Two traps recorded
+  for posterity: (1) `Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX)` passes the TX
+  macro as OUR RX pin (Arduino's first arg is RX) — the macros look swapped
+  but are correct; documented at the env pins. (2) The R8's `Serial` goes to
+  UART0, NOT the USB port — for a USB console build diagnostics with
+  `-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1`. The USB port is the
+  S3's USB-Serial-JTAG; pyserial DTR/RTS games can strap it into ROM download
+  mode (device "dead" until esptool's USBJTAGSerialReset sequence or the
+  reset button) — that bit us repeatedly.
+- **Battery reading + charging bolt: fixed and hardware-confirmed.** The
+  generic V4 read (uncalibrated `raw*(3.3/1024)` at the default 11 dB
+  attenuation) under-read the R8's always-connected HIGH-RESISTANCE divider:
+  the value pinned at 3839 mV (one 10-bit count ≈ 16 mV of display) through
+  charger plug/unplug, and a genuinely full 4.2 V pack displayed ~3.9 V — so
+  the charging-bolt threshold (batteryFullMv()+50 ≈ 4250 mV) was unreachable
+  by construction. Fix (R8 arm in `HeltecV4Board::getBattMilliVolts`): match
+  Meshtastic's `heltec_v4_r8` variant — `ADC_2_5db` attenuation ("lower dB
+  for high resistance voltage divider"; the node sits at VBAT/5.07 ≈
+  0.65-0.85 V) + IDF-calibrated `analogReadMilliVolts` × ADC_MULTIPLIER.
+  User-confirmed working on the device (value live, charging visible).
+  Diag hook `-DR8_DIAG_BATT` (Serial print + on-screen toast) kept flag-gated
+  in main.cpp for future battery debugging.
+
+## Open / hardware-uncertain (documented, not coded)
+- **FEM TX-enable vs the TX LED**: the R8 env moved the LED to GPIO46, which is
+  also the inherited GC1109 FEM TX-enable. If the real FEM enable moved
+  elsewhere, TX runs through the FEM bypass (several dB down, presents as
+  "poor range"). The new boot line `[R8] FEM type=…` plus a TX-current/RSSI
+  comparison against a plain V4 settles it. **[HW]** — NB related observation
+  below: this unit's 2.4 GHz Wi-Fi is measurably weak, so judge LoRa range
+  with possible RF-path/assembly variance in mind.
+- **Wi-Fi "auth failed" root-caused on hardware: weak signal.** The UI's Wi-Fi
+  status now appends the esp_wifi disconnect reason ("auth failed (rNN)" —
+  permanent diagnostic, all Wi-Fi boards; recorder in main.cpp, string in
+  wifiStaStatusBrief). This unit failed with r2 (AUTH_EXPIRE) at a distance
+  where the M9 connects fine, and connected normally next to the router —
+  i.e. the AP timed out the handshake on a marginal link; not WPA3, not the
+  password. Practical: keep the R8 nearer the AP for tile/OTA downloads, and
+  treat the weak 2.4 GHz path as a data point for the FEM/LoRa-range check
+  above. Reason-code decode for future reports: r15 = wrong password (WPA2
+  4-way timeout), r2 = auth expired (weak signal, or a wrong password on a
+  WPA3-SAE association), r201 = AP not found (band steering / 5 GHz-only),
+  r23 = 802.1X (enterprise, unsupported).
+- Refuted during verification: the About "Model:" mislabel (code is inside
+  `#if 0`); slot-pool/cull, drain-order, tab-bar-geometry concerns (M9-pass
+  parity checks) — all verified non-issues on the R8.

--- a/variants/heltec_v4/R8_AUDIT.md
+++ b/variants/heltec_v4/R8_AUDIT.md
@@ -141,3 +141,53 @@ on the physical device.
 - Refuted during verification: the About "Model:" mislabel (code is inside
   `#if 0`); slot-pool/cull, drain-order, tab-bar-geometry concerns (M9-pass
   parity checks) — all verified non-issues on the R8.
+
+---
+
+# Perf pass (2026-08-20)
+
+Question asked: "are we achieving full performance out of the R8 build?" Audit of
+CPU / memory / flash / display / SD / Wi-Fi / RF paths. Compute side was already at
+spec (240 MHz runtime clock, octal PSRAM @ 80 MHz, QIO flash @ 80 MHz, LVGL heap in
+PSRAM, draw buffer in internal DMA RAM, 16 ms refresh). Six gaps found and fixed,
+all flashed to the user's unit the same day:
+
+1. **FEM LNA defaulted OFF.** The R8 is a V4.3.1-generation board (KCT8103L FEM with
+   the software-switchable ~17 dB RX LNA); `fem_lna` defaulted to 0 = bypassed.
+   Prefs schema v49: default ON on `HELTEC_LORA_V4_R8`, one-time flip of existing
+   installs (no new field). Toggle stays in Radio & Mesh. **[HW]** confirm the boot
+   line `[R8] FEM type=1` / About "LNA on"; expect better RX in quiet sites, possibly
+   worse in RF-noisy ones (then turn it off).
+2. **Display bus 40 → 80 MHz** (`LGFX_SPI_WRITE_HZ`, LGFXDisplay.h): parity with
+   the plain V4's TFT_eSPI driver. Full-frame bus time ~31 → ~15 ms. **[HW]** watch
+   for tearing / garbled bands; `-D LGFX_SPI_WRITE_HZ=40000000` steps back.
+3. **Async DMA band flush** (`LGFXDisplay::flushBandRGB565`, used by `lvglFlush` on
+   the R8 only). Before: LVGL's LE pixels went through LovyanGFX's convert path
+   (per-pixel swap into 32..256 px chunks, each its own DMA kick) and the flush
+   returned only when the band was on the wire — render and transfer never
+   overlapped. Now: one 16-bit rotate per pixel into an internal DMA buffer (12 KB),
+   ONE no-convert DMA per band, `lv_disp_flush_ready` immediately; the last band
+   (`lv_disp_flush_is_last`) waits and closes the frame transaction so the shared
+   micro-SD gets the bus between frames exactly as before. Sync fallback if the
+   buffer can't be allocated. `finishFrame()` guards panel sleep / rotation / clear.
+4. **Wi-Fi modem power save is now a pref** (`wifi_ps` in the NVS Wi-Fi store;
+   toggle in Wi-Fi settings, applies live once associated). Default ON everywhere
+   (unchanged behaviour), OFF on the R8 (USB-powered kit; lower-latency TCP/app
+   link and steadier association on this unit's weak 2.4 GHz path).
+5. **micro-SD operating clock 4 → 20 MHz** (`SD_SPI_FAST_HZ`, include/SdFastClock.h):
+   after the proven 4 MHz mount, re-begin at 20 MHz and READ-VERIFY (a probe file's
+   first 512 B captured at 4 MHz and byte-compared after the raise; SPI-mode SD has
+   no data CRC so a bare mount success would not catch a marginal clock). Falls
+   back to 4 MHz. Wired at all three mount sites (boot adoption in main.cpp, the
+   UITask mount ladder, the reinsert remount). No-op on boards without the flag.
+6. **Boot at 240 MHz**: the R8 env now sets `ESP32_CPU_FREQ=240`; previously all of
+   setup() (radio init, SD ladder, store load, mesh begin) ran at the base env's
+   80 MHz until UITask bumped it. Screen-off DFS to 80 MHz unchanged.
+
+Verification aid: Settings → About on the R8 gained a `Perf:` row —
+`CPU 240 · TFT 80 MHz DMA · SD 20 MHz · LNA on` is the all-green reading.
+("sync" = DMA buffer alloc failed; "SD 4 MHz" = the 20 MHz verify failed and it
+fell back; both are safe degradations, not faults.)
+
+Deliberately NOT done: `-O2` (image is 3.70 MB in a 3.875 MB OTA slot), bigger data
+cache (baked into Arduino's prebuilt IDF libs), radio BW/SF/CR (network parameters).

--- a/variants/thinknode_m9/M9Board.cpp
+++ b/variants/thinknode_m9/M9Board.cpp
@@ -39,12 +39,18 @@ void ThinkNodeM9Board::begin() {
   // wedged the PSRAM bus and hung boot right after prefs init, bring-up #3).
   // SCHEMATIC TRUTH (read from the V1.0 sheet, bring-up #9): the microSD *is*
   // on this shared SPI bus with CS = GPIO48 — the patch's "SD CS = 36" misread
-  // the S3's PACKAGE pin 36 (SPICLK_N = GPIO48) as GPIO36. SD support returns
-  // with PIN_SD_CS=48 once the keyboard/radio bring-up settles (M9_PORT.md).
+  // the S3's PACKAGE pin 36 (SPICLK_N = GPIO48) as GPIO36.
   pinMode(PIN_TFT_CS, OUTPUT);
   digitalWrite(PIN_TFT_CS, HIGH);
   pinMode(P_LORA_NSS, OUTPUT);
   digitalWrite(P_LORA_NSS, HIGH);
+  // Park the SD's CS HIGH too: the card mounts lazily from the UI, so from
+  // reset until then it would otherwise watch 80 MHz display + radio traffic
+  // with its CS floating (no pull at reset on GPIO48) — a card that samples CS
+  // low can drive MISO into the LR1110's reads. SD.begin later re-runs the
+  // same pinMode, so this is purely the boot-window fix.
+  pinMode(PIN_SD_CS, OUTPUT);
+  digitalWrite(PIN_SD_CS, HIGH);
 
   // Bring up both rails at boot and leave them claimed for now. Display
   // power-down (turnOff()) releases periph_power via the pointer passed into
@@ -56,55 +62,62 @@ void ThinkNodeM9Board::begin() {
   periph_power.claim();
   backlight.claim();
 
-  pinMode(PIN_USER_BTN, INPUT_PULLUP); // BOOT button, GPIO0, active LOW
-
-  esp_reset_reason_t reason = esp_reset_reason();
-  if (reason == ESP_RST_DEEPSLEEP) {
-    uint64_t wakeup_source = esp_sleep_get_ext1_wakeup_status();
-    if (wakeup_source & (1ULL << P_LORA_DIO_1)) {
-      startup_reason =
-          BD_STARTUP_RX_PACKET; // woke from an incoming LoRa packet
-    }
-    rtc_gpio_hold_dis((gpio_num_t)P_LORA_NSS);
-    rtc_gpio_deinit((gpio_num_t)P_LORA_DIO_1);
-  }
+  // NB: no user/BOOT button pinMode here — this board has NO user button at
+  // all (schematic-confirmed: only a power-cut slider and a reset button,
+  // neither a GPIO). PIN_USER_BTN is deliberately not defined for this env;
+  // the old GPIO0 pull-up + UITask's screen-lock poll on it risked phantom
+  // locks from a floating strapping pin.
 }
 
 void ThinkNodeM9Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
-  esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-
-  // Hold DIO1 / NSS at their required levels through sleep (LR1110 IRQ wake).
-  rtc_gpio_set_direction((gpio_num_t)P_LORA_DIO_1, RTC_GPIO_MODE_INPUT_ONLY);
-  rtc_gpio_pulldown_en((gpio_num_t)P_LORA_DIO_1);
-  rtc_gpio_hold_en((gpio_num_t)P_LORA_NSS);
-
-  if (pin_wake_btn < 0) {
-    esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1),
-                                 ESP_EXT1_WAKEUP_ANY_HIGH);
-  } else {
-    esp_sleep_enable_ext1_wakeup((1ULL << P_LORA_DIO_1) |
-                                     (1ULL << pin_wake_btn),
-                                 ESP_EXT1_WAKEUP_ANY_HIGH);
-  }
-
+  // Deep-sleep wake on this board is TIMER-ONLY. The earlier "LR1110 DIO1
+  // (GPIO42) wake" was electrically impossible: ESP32-S3 RTC pads are GPIO0-21,
+  // so every rtc_gpio_* call on GPIO42/39 returned ESP_ERR_INVALID_ARG
+  // (unchecked) and esp_sleep_enable_ext1_wakeup rejected the mask — sleep was
+  // entered with NO wake source at all when secs==0. The only RTC-capable wake
+  // candidate is ESP_WAKEUP (GPIO12, pulsed by the keyboard MCU), whose
+  // edge/polarity/pulse width are undocumented — wire ext0/ext1 to it only
+  // after characterizing it on hardware (M9_PORT.md Deferred #6).
+  (void)pin_wake_btn;   // no wakeable button exists on this board
   if (secs > 0) {
     esp_sleep_enable_timer_wakeup(secs * 1000000ULL);
   }
+  // Release the active-LOW rails before sleeping: without an explicit hold
+  // their driven levels are lost in deep sleep anyway, and releasing them
+  // turns the LCD/GPS/sensor rail and backlight off deliberately.
+  backlight.release();
+  periph_power.release();
 
   esp_deep_sleep_start(); // CPU halts here and never returns
 }
 
+// secs=0 -> no timer, and no GPIO wake exists on this board: deep sleep with
+// no wake source, i.e. genuinely off until the physical power slider cycles.
+// (The touch UI's Power menu hides its Power-off row on M9 for this reason;
+// nothing in the companion build calls this — it exists as the board API.)
 void ThinkNodeM9Board::powerOff() { enterDeepSleep(0); }
 
 uint16_t ThinkNodeM9Board::getBattMilliVolts() {
 #if defined(PIN_VBAT_READ)
   analogReadResolution(12);
+  // GPIO13 is ADC2_CH2 on the S3 (not ADC1 — the port doc's table was wrong),
+  // and ADC2 is arbitrated against Wi-Fi: a sample taken while Wi-Fi owns the
+  // unit times out and the HAL returns raw 0, which the calibration converts
+  // to a small offset-mV value. Unfiltered, those samples dragged the average
+  // toward 0 whenever Wi-Fi was busy (status bar snapping to 0%, garbage in
+  // the battery log). Filter per-sample — half of 8 good samples still
+  // averages fine — and hold the last good reading when every sample failed.
+  static uint16_t s_last_good_mv = 0;
   uint32_t sum = 0;
+  int n = 0;
   const int kSamples = 8;
   for (int i = 0; i < kSamples; i++) {
-    sum += analogReadMilliVolts(PIN_VBAT_READ);
+    const uint32_t mv = analogReadMilliVolts(PIN_VBAT_READ);
+    if (mv >= 1250) { sum += mv; n++; }   // < 2.5 V at the pack through the 2:1 divider is impossible — ADC2-blocked read
   }
-  return (uint16_t)(2 * (sum / kSamples));
+  if (n == 0) return s_last_good_mv;
+  s_last_good_mv = (uint16_t)(2 * (sum / n));
+  return s_last_good_mv;
 #else
   return 0;
 #endif

--- a/variants/thinknode_m9/M9Board.cpp
+++ b/variants/thinknode_m9/M9Board.cpp
@@ -1,5 +1,7 @@
 #include "M9Board.h"
 #include "soc/usb_serial_jtag_reg.h"
+#include "target.h" // radio_driver / sensors / display externs for enterDeepSleep
+                    // (same source the base ESP32Board.cpp pulls them from)
 #include <Arduino.h>
 #include <SPI.h>
 
@@ -15,6 +17,18 @@ void ThinkNodeM9Board::begin() {
 
   ESP32Board::begin(); // attaches PIN_VBAT_READ, brings up Wire on
                        // PIN_BOARD_SDA/SCL (7/6)
+
+  // Undo the pad holds enterDeepSleep() arms (backlight/rail/NSS): a held pad
+  // silently ignores every pinMode/digitalWrite below, so a timer wake would
+  // otherwise come up with both rails latched OFF and the radio's NSS stuck.
+  // The holds live in the RTC domain and survive ANY reset short of the power
+  // slider actually cutting VBAT — the RST button included — so release them
+  // on every boot rather than gating on ESP_RST_DEEPSLEEP like HeltecV4Board
+  // does (harmless no-ops on a cold boot).
+  rtc_gpio_hold_dis((gpio_num_t)PIN_TFT_BL_EN);
+  rtc_gpio_hold_dis((gpio_num_t)PIN_PERIPH_POWER);
+  gpio_deep_sleep_hold_dis();
+  gpio_hold_dis((gpio_num_t)P_LORA_NSS); // digital pad (39 > RTC range), own API
 
   // The one place this board's init genuinely has to differ from T-Deck/
   // Heltec V4's pattern: their displays use ST7789LCDDisplay's dedicated-
@@ -79,14 +93,62 @@ void ThinkNodeM9Board::enterDeepSleep(uint32_t secs, int pin_wake_btn) {
   // edge/polarity/pulse width are undocumented — wire ext0/ext1 to it only
   // after characterizing it on hardware (M9_PORT.md Deferred #6).
   (void)pin_wake_btn;   // no wakeable button exists on this board
+
+  // Everything below mirrors the base ESP32Board::enterDeepSleep sequence this
+  // override hides — the rewrite exists only to drop the base's impossible
+  // rtc_gpio/ext1 wake calls (see above), not its power-downs.
+  //
+  // Display first: ST7789LCDDisplay::begin() holds its own claim on
+  // periph_power (via the pointer passed in target.cpp), so without turnOff()
+  // the release below would only drop the refcount 2->1 and GPIO18 would
+  // still be driven LOW (rail ON) when the CPU halts.
+#ifdef DISPLAY_CLASS
+  display.turnOff();
+#endif
+
+  // The LR1110 hangs off the always-on 3V3 rail, NOT the GPIO18-gated one,
+  // and with no wake source that could ever answer a packet, RX through deep
+  // sleep is pure drain (the exact failure V4-R8's power-off path fixed) —
+  // put the radio to sleep and park NSS high. GPIO39 is beyond the S3's RTC
+  // pads (GPIO0-21), so the base class's rtc_gpio_hold_en would return
+  // ESP_ERR_INVALID_ARG here; the digital-pad hold (latched through the sleep
+  // by gpio_deep_sleep_hold_en below) is the S3 equivalent.
+  radio_driver.powerOff();
+  digitalWrite(P_LORA_NSS, HIGH);
+  gpio_hold_en((gpio_num_t)P_LORA_NSS);
+
+  // Tell the GPS to stop while its rail is still up (the rail cut below kills
+  // it regardless, but stop() parks the provider's state cleanly).
+  if (sensors.getLocationProvider() != NULL) {
+    sensors.getLocationProvider()->stop();
+  }
+
+  Serial.flush();
+
+  // Clear stale wake sources before arming the timer, so a leftover from
+  // PM/auto-light-sleep can't ghost-wake us — same guard as the base class.
+  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
   if (secs > 0) {
     esp_sleep_enable_timer_wakeup(secs * 1000000ULL);
   }
-  // Release the active-LOW rails before sleeping: without an explicit hold
-  // their driven levels are lost in deep sleep anyway, and releasing them
-  // turns the LCD/GPS/sensor rail and backlight off deliberately.
-  backlight.release();
-  periph_power.release();
+
+  // Turn both active-LOW rails off. The backlight pad needs a re-route first:
+  // UITask's applyBrightness attached LEDC ch7 to GPIO17, and a bare
+  // digitalWrite doesn't take the pad back from the LEDC matrix signal (which
+  // is why RefCountedDigitalPin's release() alone can't darken it) — same
+  // pinMode dance as the V4-R8 power-off path.
+  pinMode(PIN_TFT_BL_EN, OUTPUT); // re-route from LEDC ch7 back to plain GPIO
+  backlight.release();            // refcount 1->0: drives HIGH = backlight off
+  periph_power.release();         // 1->0 now the display let go: rail off
+
+  // Latch the OFF levels through the sleep — the pads tristate the moment
+  // esp_deep_sleep_start() runs and both active-LOW gates would drift back
+  // on. GPIO17/18 ARE RTC pads, so their hold lives in the RTC domain and
+  // survives deep sleep on its own; NSS (held above) additionally needs the
+  // global digital-pad latch. All three are released again in begin().
+  rtc_gpio_hold_en((gpio_num_t)PIN_TFT_BL_EN);
+  rtc_gpio_hold_en((gpio_num_t)PIN_PERIPH_POWER);
+  gpio_deep_sleep_hold_en();
 
   esp_deep_sleep_start(); // CPU halts here and never returns
 }

--- a/variants/thinknode_m9/M9Keyboard.cpp
+++ b/variants/thinknode_m9/M9Keyboard.cpp
@@ -64,6 +64,17 @@ void m9KeyboardBegin() {
 
 void m9KeyboardPoll() {
   if (!s_inited) return;
+  // Rate-limit: the UI loop free-runs, and unthrottled this was a blocking
+  // ~0.5 ms write+read on the 100 kHz bus EVERY iteration (hundreds/s) — pure
+  // waste on the UI thread. The controller latches one key, so the poll only
+  // has to outpace keystrokes: 15 ms (~66/s) is ample for burst typing and
+  // removes ~97% of the bus traffic. Wraparound-safe; first call passes.
+  {
+    static uint32_t s_next_poll_ms = 0;
+    const uint32_t now_ms = millis();
+    if ((int32_t)(now_ms - s_next_poll_ms) < 0) return;
+    s_next_poll_ms = now_ms + 15;
+  }
   if (!s_bus) {
     uint32_t now = millis();
     if (now - s_last_probe_ms < 1000) return;
@@ -71,13 +82,18 @@ void m9KeyboardPoll() {
     kbTryFindBus();
     if (!s_bus) return;
   }
-  uint8_t key = 0;
-  if (!kbReadReg(*s_bus, M9_KB_REG_KEY, &key)) return;
-  if (key == 0x00 || key == 0xFF) return;   // no key / undefined-register reply
-  const uint8_t nh = (uint8_t)((s_head + 1) & 15);
-  if (nh != s_tail) {     // drop if the ring is full
-    s_ring[s_head] = key;
-    s_head = nh;
+  // Read the latched key; when one IS pending, drain a couple more reads in
+  // the same poll (bounded) — the controller holds a single slot, so a second
+  // key struck inside the 15 ms window would otherwise be lost.
+  for (int i = 0; i < 3; i++) {
+    uint8_t key = 0;
+    if (!kbReadReg(*s_bus, M9_KB_REG_KEY, &key)) return;
+    if (key == 0x00 || key == 0xFF) return;   // no key / undefined-register reply
+    const uint8_t nh = (uint8_t)((s_head + 1) & 15);
+    if (nh != s_tail) {     // drop if the ring is full
+      s_ring[s_head] = key;
+      s_head = nh;
+    }
   }
 }
 

--- a/variants/thinknode_m9/M9Keyboard.cpp
+++ b/variants/thinknode_m9/M9Keyboard.cpp
@@ -104,12 +104,12 @@ int m9KeyboardReadKey() {
   return key;
 }
 
-void m9KeyboardSetBacklight(uint8_t duty) {
-  if (!s_inited || !s_bus) return;
+bool m9KeyboardSetBacklight(uint8_t duty) {
+  if (!s_inited || !s_bus) return false;   // controller not found yet (see the probe note above)
   s_bus->beginTransmission((uint8_t)PIN_KB_ADDR);
   s_bus->write(M9_KB_REG_BACKLIGHT);
   s_bus->write(duty);
-  s_bus->endTransmission();
+  return s_bus->endTransmission() == 0;    // NACK/bus error -> the duty was NOT taken
 }
 
 #endif

--- a/variants/thinknode_m9/M9Keyboard.h
+++ b/variants/thinknode_m9/M9Keyboard.h
@@ -64,7 +64,10 @@ int m9KeyboardReadKey();
 
 /** Set the keyboard backlight PWM duty (0..255) on the controller. The
  *  controller lights up on keypress by itself and times out after 10 s;
- *  this just sets HOW bright. No-op until the controller has been found. */
-void m9KeyboardSetBacklight(uint8_t duty);
+ *  this just sets HOW bright. Returns false — writing nothing — until the
+ *  controller has been found, or when the I2C write NACKs, so a caller that
+ *  caches "last written" can retry instead of latching a duty the
+ *  controller never took. */
+bool m9KeyboardSetBacklight(uint8_t duty);
 
 #endif

--- a/variants/thinknode_m9/M9Keyboard.h
+++ b/variants/thinknode_m9/M9Keyboard.h
@@ -39,11 +39,14 @@
 #define M9_KEY_SUB_MAP       0x84
 #define M9_KEY_MAP           0x85
 #define M9_KEY_HW_BACK       0x86
-#define M9_KEY_CTRL          0x90
-// From the controller firmware's key tables (not yet bound in the UI):
-// 0x84 long-press emits 0x87 (labeled "GPS toggle"), Enter long-press emits
-// 0xA3, and matrix position col3/row4 emits 0x89 (unlabeled). Shift/Sym/Alt
-// never reach the wire — the controller consumes them as layer modifiers.
+#define M9_KEY_CTRL          0x90   // bound: opens the Control Center (single latched key — can never chord)
+// From the controller firmware's key tables: 0x84 long-press emits 0x87
+// (labeled "GPS toggle" — bound to toggleGPS()), Enter long-press emits 0xA3
+// (bound: LV_EVENT_LONG_PRESSED on the focused widget / lock-screen unlock).
+// Shift/Sym/Alt never reach the wire — the controller consumes them as layer
+// modifiers. DELIBERATELY UNBOUND: MIC 0x88 (no audio-capture feature exists)
+// and 0x89 (matrix col3/row4, physical key cap unidentified — binding an
+// unknown cap invites accidental triggers).
 #define M9_KEY_GPS_LONG      0x87
 #define M9_KEY_ENTER_LONG    0xA3
 

--- a/variants/thinknode_m9/M9_PORT.md
+++ b/variants/thinknode_m9/M9_PORT.md
@@ -656,6 +656,34 @@ These are left intentionally unset/unwired rather than guessed:
     config commands now issued from standby on open, and the stale SX126x-era
     comments/readout. Bin pitch (150 kHz) vs RBW (62.5 kHz) = ~42% span
     coverage is documented at the constants, deliberately unchanged.
+13. **App sync after a power cycle — fixed (2026-08-20), bench verification
+    wanted.** User report: the V4-R8 "remembers the chats and syncs them when
+    connecting to an app (MeshCore / MeshCore One)" but the M9 does not. Two
+    separate stores are involved. (a) The on-device chat store (UITask
+    threads/segments) — its power-cut loss was Deferred #9 above, fixed on
+    this branch but NOT in any released build up to beta_66. (b) The
+    companion sync ring (`MyMesh::history_ring` + per-client cursors, what
+    `CMD_SYNC_NEXT_MESSAGE` / `SyncSince` replay to an app that connects
+    later) was RAM-only on EVERY board, so any power cycle emptied it. On the
+    V4 that mostly goes unnoticed (USB-powered / left on; its menu power-off
+    deep-sleeps and also loses RAM), but the M9's only "off" is the slider —
+    a hard VBAT cut — so every M9 session started with an empty ring and the
+    app got `NO_MORE_MESSAGES` for everything received while it was away.
+    Now persisted on all boards (shared code, `MyMesh.cpp`
+    "Companion sync-history persistence"): `/synchist` append-only log of the
+    message frames (~180 B per message, coalesced 3 s / 10 s max, compacted
+    tmp+swap once it holds > 2x the ring) and `/synccur` per-client
+    `last_delivered_seq` + `next_seq` (tiny tmp+swap, coalesced 5 s / 30 s
+    max, flushed immediately on app disconnect). Both live on
+    `DataStore::getHotDataFS()` — the SD card under /meshcomod when the store
+    adopted it, else SPIFFS — and are restored in `MyMesh::begin()`. All
+    reboot / power-off / download-mode / SD-copy paths flush them next to
+    `persistHistoryNow()`. VERIFY on hardware: receive a few DMs + channel
+    messages with the phone app disconnected, slide the M9 off, slide it on,
+    connect the app — the messages should arrive. Residuals by design:
+    messages inside the 3 s coalesce before a hard cut are not replayed
+    (the on-device store has its own 2-5 s window), and a cut inside the
+    cursor window can make the app re-receive a few already-seen messages.
 
 
 ## Keyboard: register-addressed I2C slave (protocol build #8, USB-pad release build #9)

--- a/variants/thinknode_m9/M9_PORT.md
+++ b/variants/thinknode_m9/M9_PORT.md
@@ -269,7 +269,9 @@ compile-verified; on-device validation still wanted for the UX items):
 - **Keyboard backlight wired**: `m9KeyboardSetBacklight()` (controller reg
   0x02) is now driven from the drain-loop tick — off/on/auto via the CC
   "Keyboard" chip, write-on-change only. The old drain comment claiming "no
-  backlight control exists" was wrong.
+  backlight control exists" was wrong. (Audit pass 2 hardened this: the setter
+  reports success and the cache only latches written-and-ACKed duties — see
+  below.)
 - **Message flash/wake wired**: "Flash on new message" was a dead switch on M9
   (producer/consumer were T-Deck-only). M9 now wakes (or lock-reveals) on
   message and pulses the keyboard light; the 10 s notify re-dim applies.
@@ -372,6 +374,118 @@ ruled out the tile-slot pool, the tab-bar removal, and the key-drain timing:
   (`getRSSI(false, /*skipReceive=*/true)` + one explicit `standby()` per bin)
   and skips the pointless image recalibration the 24 MHz wrap-around jump
   triggered every sweep (`setFrequency(f, /*skipCalibration=*/true)`).
+
+## Audit pass 2 (2026-08-20) — second full sweep after the 08-19 fixes
+
+A second 7-dimension multi-agent audit (each dimension adversarially verified:
+30 findings, 29 confirmed, 1 refuted) over the tree WITH the 08-19 pass
+applied. All 29 fixed, compile-verified. On-device retest list at the end.
+
+**Key-trap / soft-lock class (all in UITask.cpp's M9 handlers):**
+
+- **SUB_MAP over a display-only Lua app orphaned the app** (the worst find):
+  0x84 opened the Advert page without closing the app page, the Advert page's
+  close stole the single `s_apppage_close` slot, and closing it nulled the
+  hook — the Lua app underneath became unreachable by ANY key (reboot/slider
+  only). SUB_MAP and SUB_MESSAGE now close an open app page first, like the
+  LEFT_MESSAGE/MAP jump keys always did.
+- **Back-ladder z-order redesign.** The old ladder's app-page rung assumed
+  "CC and power menu are the only popups that can stack over an app page" —
+  false for the Lua send-permission confirm (which the app itself raises) and
+  the registry walk closed the FIRST open row in declaration order, so Back
+  with the CC open over e.g. a Files rename prompt silently discarded the
+  prompt UNDERNEATH. New invariant: power menu and CC are always-frontmost
+  rungs (power before CC — CTRL peels an open power menu before opening the
+  CC so it holds in both stacking directions), the app-page rung defers to an
+  open confirm modal, and SUB_MESSAGE/SUB_MAP run HOME's bounded
+  dismiss-everything loop before opening their own overlay (refusing to
+  stack over a null-close progress blocker) so nothing is ever left open
+  beneath. HOME peels power/CC/confirm the same
+  way. Arrows/Enter are also no longer forwarded to an `on_input` Lua app
+  while a confirm modal is up — the send-permission dialog used to be
+  UNANSWERABLE on M9 (keys went to the app; Back/Home killed the app under
+  the dialog).
+- **Map pan-mode flag could go stale**: no popup guard (arrows panned the map
+  hidden under the CC) and no tab-jump clear (HOME with pan on left the flag
+  armed — the next Back anywhere was eaten by "Map pan off", and re-entering
+  the map via the drawer tile arrived still panning). Pan now self-clears on
+  any popup or tab leave; a stale flag is cleared silently, the toast only
+  fires for a genuine pan exit.
+- **Null-closer "blocker" popup rows now actually block**:
+  `popupRegistryDismissTop()` used to SKIP rows without a closer and dismiss
+  whatever sat beneath the progress overlay (Back during bulk-delete exited
+  select mode mid-operation; Back during SD format tore down the fullscreen
+  Files view the format returns to). The walker now stops at the first open
+  row; null-close rows refuse the dismiss. Shared fix (T-Deck had the same
+  hole). Behavior note: a tab jump during a progress overlay now leaves the
+  overlay up — intended blocker semantics.
+
+**Gate parity (compiled on M9 but wired only for the T-Deck):**
+
+- Terminal RX mirror — incoming mesh traffic never appeared in the M9's
+  terminal chat mode (TX echo only). Gate widened. (TLORA_PAGER also compiles
+  the terminal and still lacks the mirror — upstream follow-up, not M9's.)
+- Accent + @-mention pickers popped up while typing but were UNPICKABLE
+  (touch-only cells; the key-nav selection machinery is pager-only) — pure
+  dead chrome on a touchless board, and the mention box could linger after
+  leaving edit mode. Deliberate call: SUPPRESSED on M9 (auto-popups gated
+  off, dead settings row compiled out, `mentionBoxHide()` added to Back's
+  edit-mode branch). Porting the pager's key-nav selection is possible future
+  work if accents are ever wanted on this keyboard.
+- Fullscreen Terminal/Files title (status-bar borrow), wallpaper-set caption
+  refresh in the Device modal, and the map storage-error message (M9 now gets
+  the SD guidance, not "reflash the tiles partition") — all widened.
+- Dead `HAS_M9_KEYBOARD` alternative removed from a CAP_TRACKBALL-only
+  settings block (M9 nav is force-on at boot and must never grow an
+  off-switch).
+
+**Keyboard backlight cache**: `static uint8_t s_kb_bl_last = 0xFF` was meant
+as a never-written sentinel — but M9 duties are only 0/255 and 255 == 0xFF,
+so mode "On" restored from prefs skipped the first write EVERY BOOT (stuck on
+the controller's keypress-auto default until the first dim/wake cycle). The
+cache also latched duties whose I2C writes were dropped (controller still
+booting, NACK). `m9KeyboardSetBacklight()` now returns success (false on no
+bus / NACK), the cache is an int(-1) updated only on success — dropped writes
+retry until ACKed, at a 250 ms cadence so a found-then-wedged bus never pays
+an I2C transaction per free-running loop pass.
+
+**Board API (latent — nothing calls powerOff/enterDeepSleep on M9 today, but
+it shipped broken):** `enterDeepSleep()`'s single rail release left GPIO18
+driven ON (refcount was 2: board + display — `display.turnOff()` now drops
+the display's claim first), its backlight `digitalWrite` was inert (LEDC ch7
+owned the pad since UI boot — `pinMode()` re-route first, V4-R8 idiom), and
+no hold meant even correct levels were lost when pads tristate in sleep
+(`rtc_gpio_hold_en` on 17/18, `gpio_hold_en` + `gpio_deep_sleep_hold_en` for
+non-RTC NSS GPIO39; unconditional hold release at the top of `begin()` —
+RTC-domain holds survive the RST button). It also now mirrors the base-class
+sequence it was hiding: radio `powerOff()` + NSS parked HIGH, GPS provider
+stop, `Serial.flush()`, stale wake sources cleared — previously a "powered
+off" M9 kept the LR1110 in RX (mA-scale drain with no wake source that could
+ever use it) until the slider cut the battery.
+
+**Radio/build hardening:** the TCXO fallback in `radio_init()` still encoded
+the DISPROVEN tcxo=0 theory with a comment saying it "must stay 0" (a trap:
+the build only worked because platformio.ini defines the macro) — fallback is
+now 3.3f with the disproof recorded. `patch_radiolib_lr11x0.py` fail-closes:
+pattern drift with RadioLib present is a hard build error, and a pre-link
+check verifies the patch marker after libdeps exist (a fresh checkout's first
+`pio run` fails at link with a "patched — re-run" message rather than
+shipping an unpatched -706 binary; the second run builds clean). M9 env
+gained `ENV_SKIP_GPS_DETECT=1` (the cold-booting CC1167Q could miss the 1 s
+NMEA probe → `gps_detected` false all session → GPS toggle + GPS_LONG key
+dead; every sibling soldered-GPS env already set it) and `CORE_DEBUG_LEVEL=0`
+(ARDUHAL [E] spam on UART0, which doubles as the companion frame stream).
+Partition-CSV headroom prose refreshed (~2.99 MB firmware, ~0.88 MB headroom
+per slot). Refuted by the verifier, deliberately NOT applied:
+`RADIOLIB_EXCLUDE_SX126X`.
+
+**On-device retest list for this pass:** Airtime/RF-Monitor + SUB_MAP then
+Back (no orphan); CTRL over a Files rename prompt then Back (CC closes,
+prompt survives); send-permission dialog from a store app (arrows/Enter
+answer it); map pan → HOME → Back elsewhere (no eaten press); "Keyboard
+light: On" applied immediately at boot; GPS working from a cold boot without
+toggling; terminal chat shows the peer's replies; Back during an SD format
+does nothing.
 
 Still open / needs hardware (designed but deliberately NOT coded blind):
 ST7789 SLPIN/DISPOFF panel sleep on screen-off (shared-bus variant of the

--- a/variants/thinknode_m9/M9_PORT.md
+++ b/variants/thinknode_m9/M9_PORT.md
@@ -55,13 +55,13 @@ this table as schematic-verified, not Meshtastic-derived, going forward.)
 | microSD                      | 48 (CS)         | Shared LoRa SPI bus (Arduino SD, same as T-Deck) — CS is GPIO48, schematic net `SPICLK_N`. NOT one of the GPIO33-37 octal-PSRAM lines; SPICLK_N/GPIO48 (and SPICLK_P/GPIO47) are only reserved on the R8V/R16V 1.8V-differential-clock variants — this board is a plain R8 (see Hardware summary), which uses the ordinary single-ended SPICLK instead, so GPIO48 is genuinely free. The earlier "CS=36 is octal-PSRAM-reserved" claim conflated physical package pin 36 with GPIO36 — they are not the same pin. Confirmed working on hardware. |
 | Peripheral I2C SDA/SCL       | 7 / 6           | RTC 0x51, IMU 0x6b, compass 0x7c                                                                                                                                                                                                                              |
 | Keyboard I2C SDA/SCL         | 20 / 21         | controller @ 0x6c, **own bus** (Wire1)                                                                                                                                                                                                                        |
-| Battery ADC                  | 13              | ADC1_CH2, **2:1 divider** (manufacturer-confirmed)                                                                                                                                                                                                            |
+| Battery ADC                  | 13              | **ADC2**_CH2 (S3: ADC1=GPIO1-10, ADC2=GPIO11-20 — earlier "ADC1_CH2" label was wrong; ADC2 is Wi-Fi-arbitrated, see getBattMilliVolts's per-sample filter), **2:1 divider** (manufacturer-confirmed)                                                                                                                                                                                                            |
 | GPS RX/TX                    | 2 / 3           | CC1167Q, UART1                                                                                                                                                                                                                                                |
 | GPS EN / ON_OFF / RST / 1PPS | 11 / 10 / 5 / 4 | EN+RST wired, **both active-LOW** (confirmed on schematic: same P-MOS circuit as the peripheral power rail for EN; GPS_RST1 -> R46 -> NPN Q16 base, GPIO HIGH turns Q16 on and pulls the module's reset line to GND, so HIGH asserts reset / LOW releases it — inverted vs. the library defaults, both now overridden in platformio.ini). ON_OFF + 1PPS unused |
 | Buzzer                       | 9               | wired — simple GPIO piezo (`THINKNODE_M9_BUZZER_PIN`), Arduino `tone()`/`noTone()`, shares the Heltec V4 buzzer code path |
 | ESP_WAKEUP (from KB MCU)     | 12              | not wired; behaviour undocumented                                                                                                                                                                                                                             |
 | KEY_LED                      | 46              | not wired                                                                                                                                                                                                                                                     |
-| User button (BOOT)           | 0               | only direct button besides the keyboard                                                                                                                                                                                                                       |
+| User button (BOOT)           | —               | **does not exist** (Deferred #6, schematic-confirmed): only a power-cut slider and a reset button, neither a GPIO. PIN_USER_BTN removed from the env — the old GPIO0 entry here contradicted Deferred #6 |                                                                                                                                                                                                                       |
 
 This turn's corrections vs. the earlier (incorrect) attempt:
 
@@ -90,7 +90,10 @@ This turn's corrections vs. the earlier (incorrect) attempt:
 
 ## Keyboard (confirmed on hardware — `M9Keyboard.h`)
 
-One raw byte per read, controller resolves shift/symbol layers itself:
+Write reg 0x01 then read one byte (single latched key — see the
+register-addressed-slave section below; the old "one raw byte per read" note
+here was the exact protocol misunderstanding that made builds 1-7 see no
+keys). The controller resolves shift/symbol layers itself:
 
 | Key                  | Raw  | Key          | Raw  |
 | -------------------- | ---- | ------------ | ---- |
@@ -112,8 +115,13 @@ focused — see "Deferred" below.
 
 - `boards/thinknode_m9.json` — ESP32-S3R8, 16 MB flash, 8 MB PSRAM.
 - `variants/thinknode_m9/M9Board.{h,cpp}` — board class: both active-low power
-  rails (periph rail + backlight) via `RefCountedDigitalPin`, 1:1 battery
-  divider, deep-sleep/wake on LR1110 IRQ.
+  rails (periph rail + backlight) via `RefCountedDigitalPin`, 2:1 battery
+  divider. Deep sleep is TIMER-ONLY: the original "wake on LR1110 IRQ
+  (GPIO42)" was electrically impossible (S3 RTC pads are GPIO0-21 — every
+  rtc_gpio_*/ext1 call on 42/39 failed with ESP_ERR_INVALID_ARG, unchecked),
+  so those calls were removed. The only RTC-capable wake candidate is
+  ESP_WAKEUP GPIO12 from the keyboard MCU — needs hardware characterization
+  (Deferred #6).
 - `variants/thinknode_m9/target.{h,cpp}` — manual LR1110 `radio_init()`,
   GPS/RTC/sensor wiring, ST7789 display instantiation, `m9SharedSPI()` (mirrors
   the T-Deck's `tdeckSharedSPI()` — used by the SD mount code below).
@@ -215,6 +223,164 @@ focused — see "Deferred" below.
   the dropdown still closes and focus moves to the next page element. Root
   cause not yet found; see Deferred list.
 
+## Audit pass (2026-08-19) — Back key restored + feature/perf/data fixes
+
+A full audit traced every M9 input path and closed the following (all
+compile-verified; on-device validation still wanted for the UX items):
+
+- **HW Back (0x86) restored in nav mode.** Commit `0ea242c` accidentally
+  REPLACED `case M9_KEY_HW_BACK:` in `m9HandleNavKey` with the new
+  `case M9_KEY_ENTER_LONG:` — since then Back only worked inside text-edit
+  mode. Restored with a fuller ladder than the ad98f66 original: open
+  dropdown list (ESC) → popup registry (incl. contacts select-mode) →
+  full-screen app page (`s_apppage_close`: Lua apps, Snake, Web) → open chat →
+  LV_KEY_ESC. This plus the registry-gate fixes below fully explains the old
+  "some modals close via Back, some don't".
+- **Lua-app hard trap fixed.** `isDismissKey()` had no M9 arm (returned false
+  for everything), so any Lua app consumed Back/Home with no touch fallback —
+  the only escape was the power slider. M9 arm added (Back + Home are always
+  firmware keys); HOME also closes app pages now. Keys are additionally kept
+  from apps while the screen is locked/dark, so `ENTER_LONG` (the board's only
+  unlock) can't be eaten by an app after auto-lock.
+- **Popup-registry gates widened to M9**: Files-manager overlays (image
+  viewer, editor, prompts, actions, format overlay), Terminal command picker,
+  fullscreen Files/Terminal view, wallpaper picker, and `drawerPopupOpen`'s
+  fullscreen-view term. These compiled and ran on M9 but were invisible to
+  Back/Home and `anyPopupOpen()`.
+- **Dropdown keypad nav fixed**: no `navOpenDropdown()` capture existed in any
+  M9 key path (the doc's earlier claim it was added never matched a commit) —
+  arrows now FIFO LV_KEY_UP/DOWN into the open list instead of navMoveDir
+  defocusing (and thereby closing) it; Back sends ESC to the list first.
+- **Textarea 3-4-press focus escape**: edit-mode LEFT/RIGHT now fall through
+  to navMoveDir when the caret is already at the text boundary.
+- **Modal "breaks out" mitigation**: the M9 drain now runs `navMaybeRebuild()`
+  BEFORE dispatching keys (they used to dispatch against a one-tick-stale
+  focus mirror), and `closeSettingsModal()` gained the idiomatic
+  `navDetachBeforeTreeMutation()`/`navMarkDirty()` pair.
+- **Lua apps get the d-pad**: arrows → `luaAppSteer` (swipe events, T-Deck
+  trackball parity), d-pad centre → synthetic centre tap (`luaAppPress`, new)
+  + `ev.key=="enter"` (sendKey now maps `'\r'`). Snake and other store apps
+  are playable, including "tap to retry".
+- **New key bindings**: GPS_LONG 0x87 → `toggleGPS()` + alert (matches the CC
+  chip; NB if hardware shows the latched slot also emitting the 0x84 tap
+  first, the Advert page will open too — needs on-device check); CTRL 0x90 →
+  Control Center. MIC 0x88 and 0x89 deliberately left unbound (documented in
+  M9Keyboard.h).
+- **Keyboard backlight wired**: `m9KeyboardSetBacklight()` (controller reg
+  0x02) is now driven from the drain-loop tick — off/on/auto via the CC
+  "Keyboard" chip, write-on-change only. The old drain comment claiming "no
+  backlight control exists" was wrong.
+- **Message flash/wake wired**: "Flash on new message" was a dead switch on M9
+  (producer/consumer were T-Deck-only). M9 now wakes (or lock-reveals) on
+  message and pulses the keyboard light; the 10 s notify re-dim applies.
+- **Terminal/editor Enter**: the Enter-submit/newline gate excluded M9 —
+  widened, so Enter runs the terminal command / inserts editor newlines.
+- **"Store data on SD" honored**: the boot data-store path in main.cpp
+  excluded M9, so the (shown, persisted) toggle silently did nothing —
+  extended, with `m9SharedSPI()` arms in both selector chains, plus the truth
+  label, recovery-copy button and migration machinery in Settings.
+- **SD-backed chat history**: `uiDataFsReady()` had no M9 arm (fell into the
+  V4 no-SD SPIFFS branch) — added the T-Deck-shaped SD arm plus the SD-history
+  hardening gates (write-failure tell, remount re-flush).
+- **Threads-index write made atomic (shared fix)**: `saveThreadsToStorage()`
+  rewrote in place ("w"); a power-cut mid-write got the file quarantine-deleted
+  at boot (chat list/unread/DM entries lost — the bulk of Deferred #9's
+  symptom). Now tmp+rename via `uiDataReplaceFile`, orphan tmp swept at load.
+- **Power menu**: the "Power off" row is hidden on M9 — it armed ext0 wake on
+  a user button this board doesn't have, leaving the device unrecoverable
+  until a slider cycle. The slider IS the power-off. Reboot/Download/Cancel
+  remain. `PIN_USER_BTN` removed from the env (no button exists; GPIO0 was a
+  floating strapping pin being polled by the screen-lock branch).
+- **"Save update bin to SD"** (About) widened to M9 (OTA_BIN_NAME arm already
+  existed).
+- **Battery reads**: GPIO13 is ADC2 (Wi-Fi-arbitrated) — `getBattMilliVolts()`
+  now discards ADC2-blocked samples (< 1250 mV at the pin) per-sample and
+  holds the last good reading. The battery log now follows the resolved
+  ui-data backend instead of bare card presence (Deferred #8's battLogOnSd fix
+  landed earlier in 4846d4f; this closes the "any card with /meshcomod hijacks
+  the log" residue).
+- **Perf**: keyboard I2C poll throttled to 15 ms (was a blocking ~0.5 ms
+  100 kHz transaction EVERY free-running loop iteration — hundreds/s), with a
+  bounded 3-read drain per poll so a second key struck inside the window isn't
+  lost; SD CS (GPIO48) parked HIGH at boot (was floating across 80 MHz shared-
+  bus traffic until the first lazy mount); `RADIOLIB_DEBUG_BASIC` bring-up
+  flag dropped per its own note.
+
+**Follow-up fixes from the third on-device test round (same day) — "panning
+doesn't reload tiles":** a multi-agent trace confirmed four contributors and
+ruled out the tile-slot pool, the tab-bar removal, and the key-drain timing:
+
+- **Tile cache now prefers the BUILT-IN 16 GB microSD** (every M9 has one).
+  It used to cache into the 4.75 MB "tiles" partition, which fills after a few
+  panned screens and has NO eviction — every later download then failed
+  forever. Cache goes to SD /tiles (Launcher-T-Deck layout, merges with packs);
+  the partition remains the fallback if the card wedges.
+- **Auto-follow paused during pan mode**: mapAutoFollowTick recenters on the
+  CENTER-vs-fix delta, so the pan itself tripped it (the old mapNudge comment
+  claiming "recenters on the next GPS move" was wrong) — with follow on, every
+  nudge snapped back within one 250 ms tick. Follow resumes when pan exits.
+- **Two self-heal repaints (M9-gated)**: (1) the fetch worker's
+  already-on-disk skip now arms the rate-capped repaint for visible-zoom tiles
+  (a tile whose read was transiently blocked stayed blank "one pan behind");
+  (2) clearing an SD fail-note (which blanks ALL tile reads for up to ~5 s per
+  stamp) now arms the repaint too when the last render had gaps.
+- **Offline UX**: entering pan mode and hitting uncached areas with Wi-Fi off
+  shows a one-per-session alert — the fetch queue silently no-ops offline and
+  only a small corner label said why.
+- Still-relevant user guidance: a PNG tile pack on the card (/maps/osm or
+  /tiles) is only read when Map options → "Tiles from SD card" is ON and the
+  style is OSM; the toggle re-points and re-renders immediately.
+
+**Follow-up fixes from the second on-device test round (same day):**
+
+- **Back inside apps looked dead**: apps launch from the app DRAWER, which
+  stays open BENEATH the full-screen app page by design (closing the app
+  returns you to it) — and the drawer is a PF_COUNT popup-registry row, so the
+  restored Back ladder's `anyPopupOpen()` rung dismissed the invisible drawer
+  under the app instead of the app itself (Home worked because its handler
+  closes the app page first). The Back ladder now closes an open app page
+  before the registry dismiss, EXCEPT when the Control Center or power menu is
+  open (the only popups a key can open OVER an app page on this board — CTRL
+  falls through to openControlCenter() in display-only apps).
+- **Map pan mode added** (see the resolved keypad-nav item above): Map key on
+  the Map tab toggles arrows between focus-nav and mapNudge() panning.
+- The Chats/Map jump keys now close an open app page before switching tabs —
+  the jump used to land invisibly beneath the still-covering page.
+
+**Follow-up fixes from the first on-device test round (same day):**
+
+- **D-pad in display-only Lua apps (Airtime, RF Monitor)**: these apps declare
+  no `on_input`, but `luaAppKey()` consumed every key anyway — the d-pad was
+  dead inside them. Keys are now forwarded to a Lua app only when it actually
+  declares `on_input` (new `luaAppHasOnInput()`); otherwise the d-pad keeps its
+  native meaning: arrows move focus between the app page's own LVGL widgets
+  (Airtime's Reset button), Enter clicks them, and when focus has nowhere to go
+  UP/DOWN page-scroll the app body (new `luaAppScroll()` — RF Monitor's feed).
+- **Bottom tab bar removed on M9** (user request): it was tap-only chrome —
+  navMaybeRebuild deliberately never adds it to the focus group, so on a
+  touchless board it was uncontrollable dead space. `TABBAR_H` is now 0 for
+  M9 and the btnmatrix is hidden; every tab remains reachable via the dedicated
+  HOME/MESSAGE/MAP keys and the app drawer's Chats/Contacts/Map/Settings tiles.
+  Content gains the 30 px row; the update / chat-unread badges anchor to the
+  bottom corners instead of the (gone) bar.
+- **Spectrum sweep crawl fixed (LR1110-specific)**: `LR11x0::getRSSI(false)` is
+  not the SX126x's cheap register read — it internally re-arms RX and drops to
+  standby around EVERY call, so the 6-read peak-hold per bin paid ~960 extra
+  arm/disarm cycles per 160-bin sweep (each a multi-command SPI exchange with
+  BUSY waits) and sampled the unsettled post-arm RSSI default rather than live
+  channel power. The M9 sweep now holds RX through the dwell
+  (`getRSSI(false, /*skipReceive=*/true)` + one explicit `standby()` per bin)
+  and skips the pointless image recalibration the 24 MHz wrap-around jump
+  triggered every sweep (`setFrequency(f, /*skipCalibration=*/true)`).
+
+Still open / needs hardware (designed but deliberately NOT coded blind):
+ST7789 SLPIN/DISPOFF panel sleep on screen-off (shared-bus variant of the
+T-Deck's anti-burn-in path — a wrong sequence would look like a dead display);
+raising the SD operating clock above 4 MHz; deferring hist-flush during active
+input; Wire1 at 400 kHz; charging-detection (`batteryIsCharging` is
+compile-time false on M9); GPIO12 ESP_WAKEUP characterization for a real
+Power-off wake.
+
 ## Deferred — hardware-verify list
 
 These are left intentionally unset/unwired rather than guessed:
@@ -242,84 +408,91 @@ These are left intentionally unset/unwired rather than guessed:
    declarations, implementation block all extended to M9, separated cleanly
    from the genuinely-T-Deck-only I2S notification-sound chooser). Confirmed
    working on hardware, including the dedicated Settings > Lock browsing UI.
-6. **Deep-sleep wake source has NO real GPIO on M9 — confirmed broken, not
-   just unverified.** The "Power off" menu's `esp_sleep_enable_ext0_wakeup()`
-   call is written against `PIN_USER_BTN`, which does not correspond to any
-   real button on this board — M9 has no BOOT/user button at all (only a
-   physical power-cut slider and a reset button, neither of which are GPIOs
-   the firmware can wake from). Confirmed on schematic: M9 has no such button.
-   Practical effect: using "Power off" currently leaves the device requiring
-   a full manual power cycle (slider) to wake — not a graceful wake at all.
-   **Fix path, not yet implemented:** `ESP_WAKEUP` (GPIO12, from the keyboard
-   MCU) is a strong candidate — it's specifically documented as an unwired
-   wake-pulse line separate from the normal I2C keyboard bus, exactly the
-   kind of signal meant to wake the host chip while the main bus is powered
-   down. Its actual trigger behavior (edge vs. level, polarity, pulse width)
-   is undocumented and needs characterizing on real hardware before wiring
-   `esp_sleep_enable_ext0_wakeup()`/`ext1_wakeup()` to it. Separately,
-   `M9Board::enterDeepSleep()` (a different, scheduled/automatic sleep path
-   used by the mesh stack, not the user-facing Power-off menu) also has no
-   button/GPIO wake source — only LR1110 `DIO1` (radio activity) and a timer
-   — same open question applies there once GPIO12 is characterized.
-7. **KEY_LED (GPIO46), MIC/CTRL keys.** Pins/keycodes exist; no driver/action
-   references them yet.
-8. **Battery reading appears stuck at "charging" voltage after charger
-   disconnect, and battery-history logging shows no entries over hours of
-   runtime.** Traced the entire software chain (`getBattMilliVolts()` ->
-   `batteryMvSampled()` -> `batteryMvSmoothed()` -> status bar) — every layer
-   either re-samples fresh from the ADC or holds a value for at most 20
-   seconds; nothing in the code caches indefinitely. No software bug found in
-   this specific path via static reading. Two real possibilities, not yet
-   distinguished: (a) genuine hardware/battery-chemistry behavior (Li-ion
-   charge-termination voltage recovery can legitimately take longer than
-   expected to settle), or (b) a real bug not yet found. Needs a raw
-   millivolt diagnostic print directly in `getBattMilliVolts()` to tell which.
-   Separately, but likely related: `battLogAppend()`'s SD-vs-SPIFFS selection
-   (`battLogOnSd()`) should check `SD.exists("/meshcomod")` and return false
-   if it doesn't exist (respecting DataStore's opt-in "store on SD" setting
-   rather than assuming SD whenever a card happens to be mounted) — identified
-   but not yet applied.
-9. **Message data loss on power cycle (not on a clean reboot).** Confirmed
-   with channel messages specifically — points at something not being
-   flushed to persistent storage before a hard power-off that a clean reboot
-   flushes correctly. Not yet investigated.
+6. **Deep-sleep wake source has NO real GPIO on M9 — MITIGATED in the 2026-08-19
+   audit pass, GPIO12 characterization still open.** M9 has no BOOT/user button
+   at all (only a physical power-cut slider and a reset button, neither a GPIO
+   — schematic-confirmed). The Power menu's "Power off" row is now HIDDEN on M9
+   (it deep-slept with ext0 armed on the nonexistent button — device
+   unrecoverable until a slider cycle; the slider IS the power-off), and
+   `PIN_USER_BTN` was removed from the env. `M9Board::enterDeepSleep()` was
+   cleaned to timer-only wake — its old "LR1110 DIO1 (GPIO42) wake" was
+   electrically impossible (S3 RTC pads are GPIO0-21; every rtc_gpio_*/ext1
+   call failed unchecked). **Still open, hardware-required:** characterize
+   `ESP_WAKEUP` (GPIO12, from the keyboard MCU — RTC-capable): edge vs. level,
+   polarity, pulse width. Once known, a real graceful Power-off can return via
+   ext0/ext1 on GPIO12.
+7. **KEY_LED (GPIO46) unwired; MIC deliberately unbound; CTRL now bound.**
+   CTRL (0x90) opens the Control Center (2026-08-19 pass; the controller
+   latches a single key so CTRL can never chord). GPS_LONG (0x87) toggles GPS.
+   MIC (0x88) and 0x89 are deliberately unbound — see M9Keyboard.h. KEY_LED
+   still has no driver.
+8. **Battery reading — largely addressed (2026-08-19 pass), one hardware
+   question left.** Three separate things were tangled here: (a) the
+   battLogOnSd `/meshcomod` check landed back in 4846d4f (2026-07-08) — the
+   "identified but not yet applied" note that used to sit here was stale; the
+   empty-history symptom was that pre-fix bug. The log selection is now keyed
+   off the RESOLVED ui-data backend (`uiDataFsIsSdCard()`), so a card that
+   merely has a /meshcomod dir (telemetry/discover logs mkdir it on any card)
+   can no longer hijack the log. (b) GPIO13 is **ADC2** (not ADC1 as the pin
+   table used to claim) and ADC2 is Wi-Fi-arbitrated: blocked samples return
+   ~offset-mV garbage — `getBattMilliVolts()` now filters per-sample and holds
+   the last good reading. (c) Still open, hardware: whether "stuck at charging
+   voltage after unplug" beyond that is pack/charger chemistry at the divider
+   node — needs the raw-mV serial print on a real unit. Related:
+   `batteryIsCharging()` is compile-time FALSE on M9 (no charge detection at
+   all); widening the T-Deck's voltage-threshold detection to M9 needs
+   hardware confirmation that the charger raises the divider node the same way.
+9. **Message data loss on power cycle — root cause found and fixed
+   (2026-08-19 pass), bench verification wanted.** `saveThreadsToStorage()`
+   rewrote the threads index in place (mode "w"): a hard power-cut mid-write
+   left a short file the next boot quarantine-DELETED — chat list, unread
+   counts and DM entries gone (threads rebuild by name for channels, so the
+   worst visible loss was exactly "channel messages disappeared" plus list
+   state). Now tmp+rename (`uiDataReplaceFile`), orphan tmp swept at load.
+   Residual, by design: messages inside the ~5 s SPIFFS coalesce window before
+   a cut are lost. Verify with a bench power-cut loop while a channel floods.
 10. **Commander (Home tab) landscape layout** — fixed (chart width, 5-button
     column height math). **Control-center overflow (6+ toggles not fitting)**
     — also fixed (row/chip sizing extended to M9, matching T-Deck's existing
     2-row wrap grid). Both confirmed working.
-11. **Keypad-nav quirks still open, all UI/UX not hardware:**
-    - Dropdown-list navigation doesn't work (dropdown closes and focus moves
-      to the next page element instead of moving the highlighted option).
-      Traced the entire mechanism — `navOpenDropdown()` detection, FIFO
-      push/pop, indev group assignment, LVGL's own dropdown `LV_EVENT_KEY`
-      handler, main-loop ordering relative to `lv_timer_handler()` — and
-      confirmed the M9 dispatch code is correct up to and including the
-      `navPushTap(LV_KEY_DOWN)` call itself (verified via an in-code Serial
-      print that the correct branch is taken). Root cause not found; likely
-      downstream in LVGL's own delivery/processing at runtime.
-    - Textarea fields specifically need 3-4 presses to move focus off them
-      (confirmed: buttons/toggles/icons/apps all traverse in one press, only
-      textareas affected). Ruled out the keyboard drain-loop/`lv_timer_handler()`
-      ordering as the cause (reducing the drain to one key per `loop()`
-      iteration didn't help). Root cause not found.
-    - Modal navigation occasionally "breaks out" to the screen behind and back
-      while navigating up through a modal's items. Likely candidate:
-      `createSettingsModal()`'s standalone-modal path (used for Device/About/
-      etc.) has no `navMarkDirty()` call after `closeSettingsModal()`, same
-      class of stale-focus-group bug the wizard and home-drawer fixes above
-      addressed — diagnosed, not yet applied/confirmed.
-    - Some apps/overlays don't close via the dedicated Home key — only some do
-      (inconsistent per-screen, not a HOME-key dispatch bug given other
-      overlays close correctly).
-    - Some modals close via Back, some don't — also inconsistent per-modal.
-    - The Snake game does not respond to d-pad input at all (confirmed the
-      hardware keys themselves work correctly elsewhere) — likely reads input
-      through its own loop rather than the shared `handleHwKey()`/nav-group
-      system; not yet traced.
-    - Map panning: currently no way to pan the map at all with the d-pad
-      (arrows only drive UI nav). Idea, not started: use `M9_KEY_ENTER_LONG`
-      (now wired and proven via the lock-screen/context-menu work below) to
-      toggle between UI-nav mode and map-pan mode.
+11. **Keypad-nav quirks — all but map panning addressed in the 2026-08-19
+    audit pass (fixes compile-verified; retest each on hardware):**
+    - Dropdown-list navigation: FIXED. The real root cause was simpler than
+      the old note here claimed — NO `navOpenDropdown()` dispatch existed in
+      any committed M9 key path (`git log -S navOpenDropdown` shows only the
+      pager and Tanmatsu commits; the "Serial-verified dispatch" described
+      below was never committed). `m9HandleArrowKey` now captures an open
+      dropdown and FIFOs LV_KEY_UP/DOWN into it (Tanmatsu's navPump pattern),
+      and the restored Back sends LV_KEY_ESC to the list before the popup
+      ladder.
+    - Textarea 3-4-press focus escape: FIXED (probable cause). Edit-mode
+      LEFT/RIGHT consumed arrows as silent caret moves that no-op forever at
+      the text boundary; they now fall through to `navMoveDir` when the caret
+      doesn't move. If a pure-UP/DOWN reproduction survives on hardware, the
+      cause is elsewhere (controller-side latching?) — retest.
+    - Modal "breaks out": FIXED (two-part). Keys were dispatched against a
+      one-tick-stale focus mirror (Enter's tree mutations land inside
+      `lv_timer_handler` at the END of a tick) — the M9 drain now runs
+      `navMaybeRebuild()` first; and `closeSettingsModal()` gained
+      `navDetachBeforeTreeMutation()` + `navMarkDirty()` (the diagnosis below
+      was necessary but not sufficient — the stale-mirror window was the part
+      that survived the automatic sig-rebuild).
+    - Home key not closing some overlays / Back inconsistent per-modal:
+      FIXED. Fully explained by (a) the 0ea242c HW_BACK regression (nav-mode
+      Back did NOTHING at all in the shipped tree) and (b) popup-registry rows
+      compiled out on M9 (Files overlays, Terminal picker, fullscreen view,
+      wallpaper picker) plus app pages (Lua/Snake/Web) not being registry rows
+      — HOME and Back now close app pages via `s_apppage_close`.
+    - Snake d-pad: FIXED. On M9 Snake is the store Lua app (native SnakeGame
+      is compiled out under CAP_LUA_APPS) and it only listens for swipe/tap
+      events no M9 path generated; the d-pad now feeds `luaAppSteer` (swipes)
+      and the d-pad centre sends a synthetic tap + `ev.key=="enter"`, so
+      start/steer/retry all work — for every store app, not just Snake.
+    - Map panning: FIXED (second on-device round). Pressing the dedicated Map
+      key while ALREADY on the Map tab toggles pan mode — arrows pan via
+      mapNudge(), Map or Back exits (with toasts). A fresh entry to the tab
+      always starts in nav mode. (Chosen over the old ENTER_LONG idea: the
+      Map key re-press is discoverable and was a no-op before.)
 
     **Resolved this pass:**
     - Lock-screen unlock: fixed via `M9_KEY_ENTER_LONG` (the keyboard

--- a/variants/thinknode_m9/M9_PORT.md
+++ b/variants/thinknode_m9/M9_PORT.md
@@ -631,6 +631,31 @@ These are left intentionally unset/unwired rather than guessed:
       popup), then immediately reading the now-mutated `s_home_drawer_mode`
       flag and reopening it in the same keypress. Fixed by snapshotting the
       flag before the dismiss loop runs.
+12. **Spectrum app LR1110 pass (2026-08-20) — fixes compile-verified, three
+    on-device checks wanted:**
+    - Between-bin standby now sends the raw LR1110 `SetStandby(0x01)`
+      (STDBY_XOSC) so the DIO3-powered TCXO stays up across bins — the
+      vendored RadioLib's `RADIOLIB_LR11X0_STANDBY_XOSC` define equals
+      `STANDBY_RC` (both 0x00, upstream define bug), so the named constant
+      would silently re-select RC and re-pay the ~5 ms TCXO startup per bin.
+      VERIFY: a `micros()` log around `spectrumSweepChunk()` should show
+      ~5.5 ms/bin (~1 s full sweep), roughly half the pre-fix time.
+    - Open now runs one span-wide `calibrateImageRejection(start, stop)`
+      (begin() only calibrated mesh ±4 MHz); restore re-runs the mesh's own
+      ±4 MHz cal from a true STDBY_RC. VERIFY: mesh RX sensitivity unchanged
+      after a Spectrum session (image cal is back to the begin()-time band).
+    - Opening Spectrum during an in-flight mesh TX now waits (bounded by the
+      dispatcher's own 1.5x-airtime budget, capped 6 s) instead of truncating
+      the packet mid-air; the consumed TX-done means the dispatcher logs that
+      packet as a timed-out send — stats/log blemish only. VERIFY: open the
+      app while a long send is on air; the send should complete (watch for
+      the dispatcher's timeout warning, and no partial burst on a monitor).
+    Also fixed in the same pass: sweep clamps now 150-960 MHz (LR1110 range;
+    setFrequency failures skip the bin instead of mis-attributing RSSI), a
+    0-dBm failed-read sentinel guard in the peak-hold (shared with SX126x),
+    config commands now issued from standby on open, and the stale SX126x-era
+    comments/readout. Bin pitch (150 kHz) vs RBW (62.5 kHz) = ~42% span
+    coverage is documented at the constants, deliberately unchanged.
 
 
 ## Keyboard: register-addressed I2C slave (protocol build #8, USB-pad release build #9)

--- a/variants/thinknode_m9/partitions_m9_touch.csv
+++ b/variants/thinknode_m9/partitions_m9_touch.csv
@@ -2,11 +2,13 @@
 #
 # 16 MB layout with TWO EQUAL OTA app slots so the firmware can self-update
 # (HTTP OTA via the meshcomod proxy). The app region (app0+app1) is split
-# evenly at 3.875 MB each — the firmware is ~2.55 MB, leaving ~1.3 MB of growth
-# headroom per slot. The tiles + spiffs offsets are UNCHANGED from the previous
-# (single-big-app0) layout, so an OTA — or a one-time USB re-flash to install
-# this table — keeps the map tile cache and all user data (prefs / contacts /
-# channels / chat history) intact.
+# evenly at 3.875 MB each — the firmware is ~2.99 MB (2026-08 builds), leaving
+# ~0.88 MB of growth headroom per slot. Re-check that number at release time:
+# the slots CANNOT grow later without moving the tiles/spiffs offsets, which
+# the next paragraph forbids. The tiles + spiffs offsets are UNCHANGED from the
+# previous (single-big-app0) layout, so an OTA — or a one-time USB re-flash to
+# install this table — keeps the map tile cache and all user data (prefs /
+# contacts / channels / chat history) intact.
 #   - app0 3.875 MB (ota_0)   ┐ equal A/B slots; OTA ping-pongs between them
 #   - app1 3.875 MB (ota_1)   ┘
 #   - "tiles" 4.75 MB LittleFS partition (subtype 0x83) for the map tab's

--- a/variants/thinknode_m9/target.cpp
+++ b/variants/thinknode_m9/target.cpp
@@ -36,7 +36,9 @@ EnvironmentSensorManager sensors(gps);
 // (GPIO17, PNP) is handled separately by ThinkNodeM9Board — see M9Board.h
 // for why it's NOT routed through PIN_TFT_LEDA_CTL.
 DISPLAY_CLASS display(&board.periph_power);
-MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+// (No MomentaryButton here: the M9 has NO user/BOOT button — schematic-
+// confirmed, only a power-cut slider and reset. PIN_USER_BTN is undefined for
+// this env so UITask's button poll compiles out too.)
 #endif
 
 #ifndef LORA_CR

--- a/variants/thinknode_m9/target.cpp
+++ b/variants/thinknode_m9/target.cpp
@@ -8,7 +8,7 @@ ThinkNodeM9Board board;
 // minewsemi_me25ls01). Module() takes the same (NSS, IRQ/DIO1, RESET, BUSY,
 // spi) signature either way. M9: NSS=39, DIO1=42, RESET=45, BUSY=41,
 // SCLK=40, MISO=38, MOSI=47 — all on the SAME physical SPI bus as the LCD
-// (CS=16) and the microSD slot (CS=36), so radio and display share the
+// (CS=16) and the microSD slot (CS=48), so radio and display share the
 // literal global `SPI` object — matching how T-Deck/Heltec V4's radio (a
 // plain default-constructed `static SPIClass spi;`, not an explicit-host
 // instance) and the LR1110 reference boards (thinknode_m3, me25ls01, which
@@ -56,12 +56,15 @@ bool radio_init() {
 #ifdef LR11X0_DIO3_TCXO_VOLTAGE
   float tcxo = LR11X0_DIO3_TCXO_VOLTAGE;
 #else
-  // 0 = disable RadioLib's internal TCXO-bias feature. M9's LR1110 clock
-  // comes from Y1, a self-powered active oscillator (schematic-confirmed:
-  // VCC/GND/GND/OUT, output -> XTA directly) — not a passive crystal the
-  // chip needs to bias itself, so this must stay 0. See the build-flag
-  // comment in platformio.ini for the full explanation.
-  float tcxo = 0.0f;
+  // Fallback = the hardware-confirmed value, NOT 0. An earlier theory (Y1 =
+  // self-powered active oscillator, so disable RadioLib's TCXO bias) was
+  // disproven on the real unit: with tcxo=0 the chip boots on its internal
+  // RC (SPI alive) but the first command needing the true 32 MHz clock is
+  // rejected — radio init fails -707. The schematic's "VTCXO" rail feeding
+  // Y1 is the LR1110's own TCXO-supply output, so DIO3 must drive it at
+  // 3.3 V — see the LR11X0_DIO3_TCXO_VOLTAGE comment in platformio.ini for
+  // the empirical confirmation.
+  float tcxo = 3.3f;
 #endif
 
   // SPI bus itself was already begun once in ThinkNodeM9Board::begin() (the
@@ -150,11 +153,4 @@ mesh::LocalIdentity radio_new_identity() {
 SPIClass *m9SharedSPI() {
   return &SPI; // global instance, shared by radio + display + SD; begun once in
                // M9Board::begin()
-}
-
-void m9SetBacklight(bool on) {
-  if (on)
-    board.backlight.claim();
-  else
-    board.backlight.release();
 }

--- a/variants/thinknode_m9/target.h
+++ b/variants/thinknode_m9/target.h
@@ -36,5 +36,3 @@ mesh::LocalIdentity radio_new_identity();
 // directly (no dedicated local SPIClass — see target.cpp), so this just
 // hands that same instance to SD.begin().
 SPIClass *m9SharedSPI();
-
-void m9SetBacklight(bool on);

--- a/variants/thinknode_m9/target.h
+++ b/variants/thinknode_m9/target.h
@@ -25,7 +25,7 @@ extern EnvironmentSensorManager sensors;
 
 #ifdef DISPLAY_CLASS
 extern DISPLAY_CLASS display;
-extern MomentaryButton user_btn;
+// (no user_btn: the M9 has no user/BOOT button — see target.cpp)
 #endif
 
 bool radio_init();


### PR DESCRIPTION
## ThinkNode M9 (`68e3b45`, `1b7d793`)

- **Nav soft-locks fixed**: the 0ea242c regression that killed the hardware Back key in nav mode; SUB_MAP over a display-only Lua app stranding the app unreachable; the Back/HOME ladder redesigned so the Control Center, power menu, and confirm modals close in visual order (the Lua send-permission dialog used to be unanswerable on this touchless board); map pan mode can no longer leak across tab jumps or capture arrows under popups.
- **Storage**: "Store data on SD" honored (boot data-store path had no M9 arm), SD-backed chat history, map tile cache prefers the built-in card, atomic threads-index writes (shared fix — a power-cut mid-write used to wipe the chat list).
- **Gate parity**: terminal RX mirror, fullscreen view titles, wallpaper caption refresh, Enter-submit, "Save update bin to SD" and friends widened from their T-Deck-only gates; accent/@-mention pickers suppressed (touch-only chrome with no key path here).
- **Board API**: deep sleep actually drops the power rails now (display refcount + LEDC pin re-route + RTC/digital pad holds) and powers off the LR1110/GPS; battery reads filter Wi-Fi-blocked ADC2 samples; keyboard backlight cache only latches ACKed I2C writes.
- **Build hardening**: the RadioLib old-LR1110-FW patch fail-closes at link time (no unpatched -706 binary can ship), `ENV_SKIP_GPS_DETECT` + `CORE_DEBUG_LEVEL=0` added to the env.

## Spectrum brought to LR1110 spec (`e56ac11`)

Per-bin standby parked in STDBY_RC and re-paid the ~5 ms DIO3-TCXO startup every bin (~2x sweep time) — bins now park in STDBY_XOSC (raw 0x01; RadioLib's `RADIOLIB_LR11X0_STANDBY_XOSC` define is bugged identical to `STANDBY_RC`). One span-wide CalibImage per open with the mesh ±4 MHz calibration restored on close; sweep clamps corrected to the driver-enforced 150–960 MHz on both driver families with failed retunes skipping the bin; the 0 dBm failed-read sentinel no longer wins the peak-hold; opening Spectrum mid-TX now waits (bounded by the dispatcher's own airtime budget) instead of truncating the packet on the air.

## Heltec V4-R8 (`68e3b45`)

Chat history/battery log follow SD adoption, the reinsert watch no longer unmounts the live data store, tile cache prefers SD, `CAP_ROTATABLE` reboot trap defused, SD CS parked at boot. Full record in `variants/heltec_v4/R8_AUDIT.md`.

## Verification

All four touch envs (M9, T-Deck, V4-R8, pager LR1121) compile clean; both fix rounds passed an independent adversarial code review; M9 and V4-R8 validated on hardware. Remaining hardware-verify items are tracked in `variants/thinknode_m9/M9_PORT.md` ("Audit pass 2" + the Deferred list) and `R8_AUDIT.md`.