### PR TITLE
Add SD home page to web reader

### DIFF
--- a/src/ui-touch/ReaderContent.cpp
+++ b/src/ui-touch/ReaderContent.cpp
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ReaderContent.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace ReaderContent {
+namespace {
+
+bool ciPrefix(const char* text, size_t text_len, const char* prefix) {
+  const size_t prefix_len = strlen(prefix);
+  if (text_len < prefix_len) return false;
+  for (size_t i = 0; i < prefix_len; ++i) {
+    char actual = text[i];
+    char expected = prefix[i];
+    if (actual >= 'A' && actual <= 'Z') actual += 32;
+    if (expected >= 'A' && expected <= 'Z') expected += 32;
+    if (actual != expected) return false;
+  }
+  return true;
+}
+
+size_t decodeEntity(const char* text, size_t text_len, char* out, int* wrote) {
+  static const struct { const char* name; const char* utf8; } named[] = {
+    {"amp;","&"},{"lt;","<"},{"gt;",">"},{"quot;","\""},{"apos;","'"},{"nbsp;"," "},
+    {"mdash;","\xe2\x80\x94"},{"ndash;","\xe2\x80\x93"},{"hellip;","\xe2\x80\xa6"},
+    {"lsquo;","\xe2\x80\x98"},{"rsquo;","\xe2\x80\x99"},{"ldquo;","\xe2\x80\x9c"},
+    {"rdquo;","\xe2\x80\x9d"},{"copy;","\xc2\xa9"},{"reg;","\xc2\xae"},{"euro;","\xe2\x82\xac"},
+    {"deg;","\xc2\xb0"},{"middot;","\xc2\xb7"},{"bull;","\xe2\x80\xa2"},{"trade;","\xe2\x84\xa2"},
+  };
+  for (const auto& entity : named) {
+    const size_t name_len = strlen(entity.name);
+    if (text_len > name_len && strncmp(text + 1, entity.name, name_len) == 0) {
+      const int width = strlen(entity.utf8);
+      memcpy(out, entity.utf8, width);
+      *wrote = width;
+      return name_len + 1;
+    }
+  }
+  if (text_len > 3 && text[1] == '#') {
+    long codepoint = 0;
+    const bool hex = text[2] == 'x' || text[2] == 'X';
+    size_t i = hex ? 3 : 2;
+    const size_t start = i;
+    for (; i < text_len && text[i] != ';'; ++i) {
+      const char c = text[i];
+      int digit;
+      if (c >= '0' && c <= '9') digit = c - '0';
+      else if (hex && c >= 'a' && c <= 'f') digit = c - 'a' + 10;
+      else if (hex && c >= 'A' && c <= 'F') digit = c - 'A' + 10;
+      else { i = start; break; }
+      codepoint = codepoint * (hex ? 16 : 10) + digit;
+    }
+    if (i > start && i < text_len && text[i] == ';' && codepoint > 0 && codepoint <= 0x10FFFF) {
+      int width = 0;
+      if (codepoint < 0x80) out[width++] = static_cast<char>(codepoint);
+      else if (codepoint < 0x800) {
+        out[width++] = 0xC0 | (codepoint >> 6);
+        out[width++] = 0x80 | (codepoint & 0x3F);
+      } else if (codepoint < 0x10000) {
+        out[width++] = 0xE0 | (codepoint >> 12);
+        out[width++] = 0x80 | ((codepoint >> 6) & 0x3F);
+        out[width++] = 0x80 | (codepoint & 0x3F);
+      } else {
+        out[width++] = 0xF0 | (codepoint >> 18);
+        out[width++] = 0x80 | ((codepoint >> 12) & 0x3F);
+        out[width++] = 0x80 | ((codepoint >> 6) & 0x3F);
+        out[width++] = 0x80 | (codepoint & 0x3F);
+      }
+      *wrote = width;
+      return i + 1;
+    }
+  }
+  return 0;
+}
+
+bool tagAttribute(const char* tag, size_t tag_len, const char* attribute,
+                  char* out, size_t cap) {
+  const size_t attribute_len = strlen(attribute);
+  for (size_t i = 0; i + attribute_len + 1 < tag_len; ++i) {
+    if (!ciPrefix(tag + i, tag_len - i, attribute)) continue;
+    if (i > 0 && tag[i - 1] != ' ' && tag[i - 1] != '\t' &&
+        tag[i - 1] != '\r' && tag[i - 1] != '\n') continue;
+    size_t cursor = i + attribute_len;
+    while (cursor < tag_len && (tag[cursor] == ' ' || tag[cursor] == '\t')) ++cursor;
+    if (cursor >= tag_len || tag[cursor] != '=') continue;
+    ++cursor;
+    while (cursor < tag_len && (tag[cursor] == ' ' || tag[cursor] == '\t')) ++cursor;
+    char quote = 0;
+    if (cursor < tag_len && (tag[cursor] == '"' || tag[cursor] == '\'')) {
+      quote = tag[cursor++];
+    }
+    size_t written = 0;
+    while (cursor < tag_len && written + 1 < cap) {
+      const char c = tag[cursor];
+      if (quote ? c == quote : (c == ' ' || c == '>' || c == '\t')) break;
+      out[written++] = c;
+      ++cursor;
+    }
+    out[written] = 0;
+    return written > 0;
+  }
+  return false;
+}
+
+}  // namespace
+
+bool resolveUrl(const char* base, const char* href, char* out, size_t cap) {
+  if (!base || !href || !out || cap == 0) return false;
+  while (*href == ' ') ++href;
+  const size_t href_len = strlen(href);
+  if (!href_len || href[0] == '#') return false;
+  if (ciPrefix(href, href_len, "javascript:") || ciPrefix(href, href_len, "mailto:") ||
+      ciPrefix(href, href_len, "tel:") || ciPrefix(href, href_len, "data:")) return false;
+
+  if (ciPrefix(href, href_len, "http://") || ciPrefix(href, href_len, "https://") ||
+      ciPrefix(href, href_len, "sd:/")) {
+    snprintf(out, cap, "%s", href);
+  } else if (ciPrefix(base, strlen(base), "sd:/")) {
+    if (href[0] == '/' && href[1] == '/') {
+      snprintf(out, cap, "https:%s", href);
+    } else if (href[0] == '/') {
+      snprintf(out, cap, "sd:%s", href);
+    } else {
+      const char* last_slash = strrchr(base + 3, '/');
+      if (last_slash) snprintf(out, cap, "%.*s%s", static_cast<int>(last_slash - base + 1), base, href);
+      else            snprintf(out, cap, "sd:/%s", href);
+    }
+  } else {
+    const char* scheme_end = strstr(base, "://");
+    if (!scheme_end) return false;
+    const int scheme_len = static_cast<int>(scheme_end - base);
+    const char* host = scheme_end + 3;
+    const char* host_end = strchr(host, '/');
+    const int host_len = host_end ? static_cast<int>(host_end - host) : static_cast<int>(strlen(host));
+    if (href[0] == '/' && href[1] == '/') {
+      snprintf(out, cap, "%.*s:%s", scheme_len, base, href);
+    } else if (href[0] == '/') {
+      snprintf(out, cap, "%.*s://%.*s%s", scheme_len, base, host_len, host, href);
+    } else {
+      const char* last_slash = strrchr(base, '/');
+      if (last_slash && last_slash > scheme_end + 2)
+        snprintf(out, cap, "%.*s%s", static_cast<int>(last_slash - base + 1), base, href);
+      else
+        snprintf(out, cap, "%.*s://%.*s/%s", scheme_len, base, host_len, host, href);
+    }
+  }
+  char* fragment = strchr(out, '#');
+  if (fragment) *fragment = 0;
+  return out[0] != 0;
+}
+
+size_t htmlToText(const char* html, size_t html_len,
+                  char* out, size_t out_cap, const char* base,
+                  Link* links, size_t link_capacity, size_t* link_count) {
+  if (link_count) *link_count = 0;
+  if (!html || !out || out_cap == 0) return 0;
+
+  size_t out_len = 0;
+  size_t links_len = 0;
+  int pending_newlines = 0;
+  bool pending_space = false;
+  bool started = false;
+  bool in_anchor = false;
+  uint32_t anchor_start = 0;
+  char anchor_href[HREF_CAPACITY] = "";
+  auto emit = [&](char c) { if (out_len + 1 < out_cap) out[out_len++] = c; };
+  auto flush = [&]() {
+    if (!started) {
+      pending_newlines = 0;
+      pending_space = false;
+      return;
+    }
+    while (pending_newlines > 0) { emit('\n'); --pending_newlines; }
+    if (pending_space) { emit(' '); pending_space = false; }
+  };
+  auto finishAnchor = [&]() {
+    if (in_anchor && out_len > anchor_start && links && links_len < link_capacity) {
+      links[links_len].start = anchor_start;
+      links[links_len].end = static_cast<uint32_t>(out_len);
+      snprintf(links[links_len].href, sizeof links[links_len].href, "%s", anchor_href);
+      ++links_len;
+    }
+    in_anchor = false;
+  };
+  static const char* blocks[] = {
+    "p","div","br","li","ul","ol","tr","h1","h2","h3","h4","h5","h6",
+    "section","article","header","footer","table","blockquote","pre","hr","nav","title","body", nullptr
+  };
+
+  size_t i = 0;
+  while (i < html_len && out_len + 5 < out_cap) {
+    const char c = html[i];
+    if (c == '<') {
+      if (html_len - i >= 4 && html[i + 1] == '!' && html[i + 2] == '-' && html[i + 3] == '-') {
+        size_t end = i + 4;
+        while (end + 2 < html_len && !(html[end] == '-' && html[end + 1] == '-' && html[end + 2] == '>')) ++end;
+        i = end + 2 < html_len ? end + 3 : html_len;
+        continue;
+      }
+      const bool script = ciPrefix(html + i, html_len - i, "<script");
+      const bool style = !script && ciPrefix(html + i, html_len - i, "<style");
+      if (script || style) {
+        const char* closing_tag = script ? "</script" : "</style";
+        size_t end = i + 1;
+        while (end < html_len && !(html[end] == '<' && ciPrefix(html + end, html_len - end, closing_tag))) ++end;
+        while (end < html_len && html[end] != '>') ++end;
+        i = end < html_len ? end + 1 : html_len;
+        if (pending_newlines < 2) ++pending_newlines;
+        continue;
+      }
+
+      size_t name_cursor = i + 1;
+      const bool closing = name_cursor < html_len && html[name_cursor] == '/';
+      if (closing) ++name_cursor;
+      char name[12];
+      int name_len = 0;
+      while (name_cursor < html_len && name_len < 11) {
+        char value = html[name_cursor];
+        if ((value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z') ||
+            (value >= '0' && value <= '9')) {
+          name[name_len++] = value >= 'A' && value <= 'Z' ? value + 32 : value;
+          ++name_cursor;
+        } else {
+          break;
+        }
+      }
+      name[name_len] = 0;
+      size_t tag_end = i + 1;
+      while (tag_end < html_len && html[tag_end] != '>') ++tag_end;
+      if (name[0] == 'a' && name[1] == 0) {
+        finishAnchor();
+        if (!closing) {
+          char raw_href[300];
+          if (base && links &&
+              tagAttribute(html + i, (tag_end < html_len ? tag_end : html_len) - i,
+                           "href", raw_href, sizeof raw_href) &&
+              resolveUrl(base, raw_href, anchor_href, sizeof anchor_href)) {
+            flush();
+            in_anchor = true;
+            anchor_start = static_cast<uint32_t>(out_len);
+          }
+        }
+      }
+      i = tag_end < html_len ? tag_end + 1 : html_len;
+      for (int block = 0; blocks[block]; ++block) {
+        if (strcmp(name, blocks[block]) == 0) {
+          pending_space = false;
+          if (pending_newlines < 2) ++pending_newlines;
+          break;
+        }
+      }
+      continue;
+    }
+    if (c == '&') {
+      char entity[8];
+      int width = 0;
+      const size_t used = decodeEntity(html + i, html_len - i, entity, &width);
+      if (used) {
+        for (int byte = 0; byte < width; ++byte) {
+          if (entity[byte] == ' ') {
+            if (started) pending_space = true;
+          } else {
+            flush(); emit(entity[byte]); started = true;
+          }
+        }
+        i += used;
+        continue;
+      }
+      flush(); emit('&'); started = true; ++i;
+      continue;
+    }
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+      if (started) pending_space = true;
+      ++i;
+      continue;
+    }
+    flush(); emit(c); started = true; ++i;
+  }
+  finishAnchor();
+  out[out_len < out_cap ? out_len : out_cap - 1] = 0;
+  if (link_count) *link_count = links_len;
+  return out_len;
+}
+
+}  // namespace ReaderContent

--- a/src/ui-touch/ReaderContent.h
+++ b/src/ui-touch/ReaderContent.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ReaderContent {
+
+constexpr size_t HREF_CAPACITY = 240;
+
+struct Link {
+  uint32_t start;
+  uint32_t end;
+  char href[HREF_CAPACITY];
+};
+
+bool resolveUrl(const char* base, const char* href, char* out, size_t cap);
+
+size_t htmlToText(const char* html, size_t html_len,
+                  char* out, size_t out_cap, const char* base,
+                  Link* links, size_t link_capacity, size_t* link_count);
+
+}  // namespace ReaderContent

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -111,6 +111,7 @@
 #include "LuaAppHost.h"       // sandboxed Lua apps (LUA_APPS.md Phase 1; self-gated on CAP_LUA_APPS)
 
 #include "AppPage.h"          // shared full-screen app-page chrome (both of the above use it)
+#include "ReaderContent.h"    // host-tested HTML text extraction + local/network link resolution
 
 #if defined(HAS_TOUCH_UI)
   #include <lvgl.h>
@@ -22162,6 +22163,7 @@ static void openSignalInfoPopup() {
 // runs on a core-0 worker task so LVGL never blocks; the UI loop polls s_reader_dirty.
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
 static const char    kReaderDefaultUrl[] = "wadamesh.com";
+static const char    kReaderHomeUrl[] = "sd:/home.htm";
 static lv_obj_t*     s_reader_root   = nullptr;
 static lv_obj_t*     s_reader_url_ta = nullptr;
 static lv_obj_t*     s_reader_go     = nullptr;
@@ -22173,13 +22175,19 @@ static char*         s_reader_text   = nullptr;    // PSRAM: extracted text (NUL
 static volatile bool s_reader_dirty  = false;      // worker -> UI: text/status changed
 static volatile bool s_reader_busy   = false;      // a fetch is in flight
 static volatile bool s_reader_ok     = false;      // last fetch produced a page (worker -> UI)
+static volatile bool s_reader_home_missing = false; // initial SD probe failed; restore URL-entry state
+static volatile bool s_reader_sd_busy = false;      // open reader File owns the removable-card VFS
+static TaskHandle_t  s_reader_sd_owner = nullptr;
+static volatile uint32_t s_reader_generation = 0;
+static volatile uint32_t s_reader_task_generation = 0;
+static char          s_reader_pending_url[300] = "";
 static char          s_reader_msg[110] = "";       // status text (worker writes, UI shows)
 static TaskHandle_t  s_reader_task    = nullptr;
 static bool          s_reader_pristine = false;    // URL field still holds the untouched default
 static const size_t  kReaderRawCap  = 192 * 1024;  // max raw HTML we buffer (PSRAM)
 static const size_t  kReaderTextCap =  60 * 1024;  // max extracted text we keep
 // Links found on the page: byte range in s_reader_text + resolved absolute href.
-struct ReaderLink { uint32_t start, end; char href[240]; };
+using ReaderLink = ReaderContent::Link;
 static const int     kReaderMaxLinks = 280;
 static ReaderLink*   s_reader_links   = nullptr;   // PSRAM array, lazily allocated
 static int           s_reader_nlinks  = 0;
@@ -22194,7 +22202,7 @@ static lv_obj_t*     s_reader_back     = nullptr;
 static lv_obj_t*     s_reader_fwd      = nullptr;
 
 static void closeReaderPage();
-static void readerNavigate(const char* in, bool push);
+static bool readerNavigate(const char* in, bool push);
 static void readerUpdateNavButtons();
 static void readerRenderBody();
 static void readerSetAddrExpanded(bool exp);
@@ -22207,135 +22215,107 @@ static bool readerCiPrefix(const char* s, size_t n, const char* pfx) {
     if (a >= 'A' && a <= 'Z') a += 32; if (b >= 'A' && b <= 'Z') b += 32; if (a != b) return false; }
   return true;
 }
-// Decode one HTML entity at s[0]=='&'. Writes UTF-8 to out (>=4 bytes), sets *wrote,
-// returns consumed input length; 0 if unrecognised (caller emits '&' literally).
-static size_t readerEntity(const char* s, size_t n, char* out, int* wrote) {
-  static const struct { const char* name; const char* utf8; } named[] = {
-    {"amp;","&"},{"lt;","<"},{"gt;",">"},{"quot;","\""},{"apos;","'"},{"nbsp;"," "},
-    {"mdash;","\xe2\x80\x94"},{"ndash;","\xe2\x80\x93"},{"hellip;","\xe2\x80\xa6"},
-    {"lsquo;","\xe2\x80\x98"},{"rsquo;","\xe2\x80\x99"},{"ldquo;","\xe2\x80\x9c"},
-    {"rdquo;","\xe2\x80\x9d"},{"copy;","\xc2\xa9"},{"reg;","\xc2\xae"},{"euro;","\xe2\x82\xac"},
-    {"deg;","\xc2\xb0"},{"middot;","\xc2\xb7"},{"bull;","\xe2\x80\xa2"},{"trade;","\xe2\x84\xa2"},
+// A bounded Stream lets HTTPClient remove chunk framing while writing directly into
+// PSRAM. Short-writing at the cap stops oversized pages without allocating a String.
+class ReaderBufferStream final : public Stream {
+ public:
+  ReaderBufferStream(uint8_t* data, size_t capacity, uint32_t generation)
+      : data_(data), capacity_(capacity), generation_(generation) {}
+  using Print::write;
+  size_t write(uint8_t byte) override { return write(&byte, 1); }
+  size_t write(const uint8_t* data, size_t size) override {
+    const size_t before = size_;
+    const size_t room = size_ < capacity_ ? capacity_ - size_ : 0;
+    const size_t copied = size < room ? size : room;
+    if (copied) {
+      memcpy(data_ + size_, data, copied);
+      size_ += copied;
+      if (generation_ == s_reader_generation && (before >> 14) != (size_ >> 14)) {
+        snprintf(s_reader_msg, sizeof s_reader_msg, "Loading\xe2\x80\xa6 %uk", (unsigned)(size_ / 1024));
+        s_reader_dirty = true;
+      }
+    }
+    return copied;
+  }
+  int available() override { return 0; }
+  int read() override { return -1; }
+  int peek() override { return -1; }
+  void flush() override {}
+  size_t size() const { return size_; }
+  bool full() const { return size_ == capacity_; }
+
+ private:
+  uint8_t* data_;
+  size_t capacity_;
+  uint32_t generation_;
+  size_t size_ = 0;
+};
+
+enum class ReaderLocalResult : uint8_t { Ok, NoStorage, NotFound, ReadFailed };
+
+static ReaderLocalResult readerReadLocal(const char* url, uint8_t* raw, size_t capacity,
+                                         size_t* total, uint32_t generation) {
+  fs::FS* storage = nullptr;
+  bool storage_claimed = false;
+  auto releaseStorage = [&]() {
+    if (!storage_claimed) return;
+    s_reader_sd_owner = nullptr;
+    s_reader_sd_busy = false;
+    storage_claimed = false;
   };
-  for (auto& e : named) { size_t ln = strlen(e.name);
-    if (n > ln && strncmp(s + 1, e.name, ln) == 0) { int w = strlen(e.utf8); memcpy(out, e.utf8, w); *wrote = w; return ln + 1; } }
-  if (n > 3 && s[1] == '#') {                            // &#NNN; or &#xHH;
-    long cp = 0; bool hex = (s[2] == 'x' || s[2] == 'X'); size_t i = hex ? 3 : 2, start = i;
-    for (; i < n && s[i] != ';'; i++) { char c = s[i]; int d;
-      if (c >= '0' && c <= '9') d = c - '0';
-      else if (hex && c >= 'a' && c <= 'f') d = c - 'a' + 10;
-      else if (hex && c >= 'A' && c <= 'F') d = c - 'A' + 10; else { i = start; break; }
-      cp = cp * (hex ? 16 : 10) + d; }
-    if (i > start && i < n && s[i] == ';' && cp > 0 && cp <= 0x10FFFF) {
-      int w = 0;
-      if (cp < 0x80) out[w++] = (char)cp;
-      else if (cp < 0x800) { out[w++] = 0xC0 | (cp >> 6); out[w++] = 0x80 | (cp & 0x3F); }
-      else if (cp < 0x10000) { out[w++] = 0xE0 | (cp >> 12); out[w++] = 0x80 | ((cp >> 6) & 0x3F); out[w++] = 0x80 | (cp & 0x3F); }
-      else { out[w++] = 0xF0 | (cp >> 18); out[w++] = 0x80 | ((cp >> 12) & 0x3F); out[w++] = 0x80 | ((cp >> 6) & 0x3F); out[w++] = 0x80 | (cp & 0x3F); }
-      *wrote = w; return i + 1;
-    }
+#if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER) || defined(HAS_THINKNODE_M9) || defined(HELTEC_LORA_V4_R8)
+  s_reader_sd_busy = true;
+  s_reader_sd_owner = xTaskGetCurrentTaskHandle();
+  storage_claimed = true;
+  if (sdAdoptLiveMount()) storage = &SD;
+  else if (!sdRuntimeLifecycleBusy() && fmSdTryMount()) storage = &SD;
+#elif defined(HAS_TANMATSU) || defined(HAS_TDISPLAY_P4)
+  s_reader_sd_busy = true;
+  s_reader_sd_owner = xTaskGetCurrentTaskHandle();
+  storage_claimed = true;
+  if (tanSdTryMount()) storage = &SD_MMC;
+#endif
+  if (!storage) { releaseStorage(); return ReaderLocalResult::NoStorage; }
+
+  char path[300];
+  snprintf(path, sizeof path, "%s", url + 3);
+  char* query = strchr(path, '?');
+  if (query) *query = 0;
+  if (path[0] != '/') { releaseStorage(); return ReaderLocalResult::NotFound; }
+
+  markSdIo();
+  File file = storage->open(path, "r");
+  if (!file || file.isDirectory()) {
+    if (file) file.close();
+    releaseStorage();
+    return ReaderLocalResult::NotFound;
   }
-  return 0;
-}
-// Extract attribute `attr` (e.g. "href") from a tag body h[0..len) into out. Handles
-// quoted ("..", '..') and unquoted values. Returns true if found.
-static bool readerTagAttr(const char* h, size_t len, const char* attr, char* out, size_t cap) {
-  size_t al = strlen(attr);
-  for (size_t i = 0; i + al + 1 < len; i++) {
-    if (!readerCiPrefix(h + i, len - i, attr)) continue;
-    size_t j = i + al; while (j < len && (h[j] == ' ' || h[j] == '\t')) j++;
-    if (j >= len || h[j] != '=') continue;
-    j++; while (j < len && (h[j] == ' ' || h[j] == '\t')) j++;
-    char q = 0; if (j < len && (h[j] == '"' || h[j] == '\'')) { q = h[j]; j++; }
-    size_t o = 0;
-    while (j < len && o + 1 < cap) { char c = h[j]; if (q ? (c == q) : (c == ' ' || c == '>' || c == '\t')) break; out[o++] = c; j++; }
-    out[o] = 0; return o > 0;
-  }
-  return false;
-}
-// Resolve href against base into out (absolute). Returns false for unusable schemes
-// (#fragment, javascript:, mailto:, tel:, data:).
-static bool readerResolveUrl(const char* base, const char* href, char* out, size_t cap) {
-  while (*href == ' ') href++;
-  size_t hl = strlen(href);
-  if (!hl || href[0] == '#') return false;
-  if (readerCiPrefix(href, hl, "javascript:") || readerCiPrefix(href, hl, "mailto:") ||
-      readerCiPrefix(href, hl, "tel:") || readerCiPrefix(href, hl, "data:")) return false;
-  if (readerCiPrefix(href, hl, "http://") || readerCiPrefix(href, hl, "https://")) { snprintf(out, cap, "%s", href); }
-  else {
-    const char* se = strstr(base, "://"); if (!se) return false;
-    int sl = (int)(se - base); const char* host = se + 3;
-    const char* he = strchr(host, '/'); int hlen = he ? (int)(he - host) : (int)strlen(host);
-    if (href[0] == '/' && href[1] == '/')      snprintf(out, cap, "%.*s:%s", sl, base, href);            // //host/path
-    else if (href[0] == '/')                   snprintf(out, cap, "%.*s://%.*s%s", sl, base, hlen, host, href);  // root-relative
-    else {                                                                                              // relative to base dir
-      const char* ls = strrchr(base, '/');
-      if (ls && ls > se + 2) snprintf(out, cap, "%.*s%s", (int)(ls - base + 1), base, href);
-      else                   snprintf(out, cap, "%.*s://%.*s/%s", sl, base, hlen, host, href);
+
+  bool read_failed = false;
+  while (*total < capacity && file.available()) {
+    const size_t request = ((capacity - *total) < 4096) ? (capacity - *total) : 4096;
+    const int read_count = file.read(raw + *total, request);
+    if (read_count <= 0) { read_failed = true; break; }
+    *total += (size_t)read_count;
+    if (generation == s_reader_generation && ((*total) & 0x3FFF) == 0) {
+      snprintf(s_reader_msg, sizeof s_reader_msg, "Opening SD page\xe2\x80\xa6 %uk", (unsigned)(*total / 1024));
+      s_reader_dirty = true;
     }
+    vTaskDelay(1);
   }
-  char* frag = strchr(out, '#'); if (frag) *frag = 0;
-  return out[0] != 0;
+  file.close();
+  releaseStorage();
+  return read_failed ? ReaderLocalResult::ReadFailed : ReaderLocalResult::Ok;
 }
-// One-pass HTML -> text. Drops comments + <script>/<style> bodies, turns block tags
-// into newlines, decodes entities, collapses whitespace, and records <a href> ranges
-// (byte offsets into out + resolved absolute href) in s_reader_links. Returns text len.
-static size_t readerHtmlToText(const char* h, size_t n, char* out, size_t cap, const char* base) {
-  size_t o = 0; int pend_nl = 0; bool pend_sp = false, started = false;
-  s_reader_nlinks = 0;
-  bool in_a = false; uint32_t a_start = 0; char a_href[240] = "";
-  auto emit = [&](char c) { if (o + 1 < cap) out[o++] = c; };
-  auto flush = [&]() { if (!started) return; while (pend_nl > 0) { emit('\n'); pend_nl--; } if (pend_sp) { emit(' '); pend_sp = false; } };
-  static const char* blocks[] = { "p","div","br","li","ul","ol","tr","h1","h2","h3","h4","h5","h6",
-    "section","article","header","footer","table","blockquote","pre","hr","nav","title","body", nullptr };
-  size_t i = 0;
-  while (i < n && o + 5 < cap) {
-    char c = h[i];
-    if (c == '<') {
-      if (n - i >= 4 && h[i+1] == '!' && h[i+2] == '-' && h[i+3] == '-') {        // comment
-        size_t j = i + 4; while (j + 2 < n && !(h[j] == '-' && h[j+1] == '-' && h[j+2] == '>')) j++;
-        i = (j + 2 < n) ? j + 3 : n; continue;
-      }
-      bool scr = readerCiPrefix(h + i, n - i, "<script"), sty = !scr && readerCiPrefix(h + i, n - i, "<style");
-      if (scr || sty) {                                                          // skip body wholesale
-        const char* close = scr ? "</script" : "</style"; size_t j = i + 1;
-        while (j < n && !(h[j] == '<' && readerCiPrefix(h + j, n - j, close))) j++;
-        while (j < n && h[j] != '>') j++; i = (j < n) ? j + 1 : n;
-        if (pend_nl < 2) pend_nl++; continue;
-      }
-      size_t j = i + 1; bool closing = (j < n && h[j] == '/'); if (closing) j++;  // tag name
-      char name[12]; int ni = 0;
-      while (j < n && ni < 11) { char t = h[j]; if ((t>='a'&&t<='z')||(t>='A'&&t<='Z')||(t>='0'&&t<='9')) { name[ni++] = (t>='A'&&t<='Z')?t+32:t; j++; } else break; }
-      name[ni] = 0;
-      size_t k = i + 1; while (k < n && h[k] != '>') k++;                          // k = '>' position
-      // Links: record the anchor-text byte range + resolved href.
-      if (name[0] == 'a' && name[1] == 0) {
-        if (in_a) { if (o > a_start && s_reader_links && s_reader_nlinks < kReaderMaxLinks) {
-            s_reader_links[s_reader_nlinks].start = a_start; s_reader_links[s_reader_nlinks].end = (uint32_t)o;
-            snprintf(s_reader_links[s_reader_nlinks].href, sizeof s_reader_links[0].href, "%s", a_href); s_reader_nlinks++; }
-          in_a = false; }
-        if (!closing) { char raw[300];
-          if (base && s_reader_links && readerTagAttr(h + i, (k < n ? k : n) - i, "href", raw, sizeof raw) &&
-              readerResolveUrl(base, raw, a_href, sizeof a_href)) { in_a = true; a_start = (uint32_t)o; } }
-      }
-      i = (k < n) ? k + 1 : n;
-      for (int b = 0; blocks[b]; b++) if (strcmp(name, blocks[b]) == 0) { pend_sp = false; if (pend_nl < 2) pend_nl++; break; }
-      continue;
-    }
-    if (c == '&') {
-      char buf[8]; int w = 0; size_t used = readerEntity(h + i, n - i, buf, &w);
-      if (used) { for (int q = 0; q < w; q++) { char e = buf[q]; if (e == ' ') { if (started) pend_sp = true; } else { flush(); emit(e); started = true; } } i += used; continue; }
-      flush(); emit('&'); started = true; i++; continue;
-    }
-    if (c == ' ' || c == '\t' || c == '\r' || c == '\n') { if (started) pend_sp = true; i++; continue; }
-    flush(); emit(c); started = true; i++;
-  }
-  out[o < cap ? o : cap - 1] = 0; return o;
-}
-// Worker (core 0): fetch s_reader_url, strip to s_reader_text, publish via s_reader_dirty.
+
+// Worker (core 0): load s_reader_url, strip to s_reader_text, publish via s_reader_dirty.
 static void readerFetchTaskFn(void*) {
+  const uint32_t generation = s_reader_task_generation;
   char url[300]; strncpy(url, s_reader_url, sizeof url - 1); url[sizeof url - 1] = 0;
-  s_reader_ok = false;
+  bool result_ok = false;
+  bool result_home_missing = false;
+  char result_msg[sizeof s_reader_msg] = "";
+  const bool local = readerCiPrefix(url, strlen(url), "sd:/");
   const bool https = readerCiPrefix(url, strlen(url), "https://");
   // Big contiguous PSRAM is scarce on the 2 MB V4 (a chat's message ring fragments it),
   // so fall back to smaller buffers — a typical text page still fits in 48 KB.
@@ -22344,62 +22324,102 @@ static void readerFetchTaskFn(void*) {
   if (!raw) { rawcap = 96 * 1024; raw = (uint8_t*)heap_caps_malloc(rawcap, MALLOC_CAP_SPIRAM); }
   if (!raw) { rawcap = 48 * 1024; raw = (uint8_t*)heap_caps_malloc(rawcap, MALLOC_CAP_SPIRAM); }
   if (!raw) { rawcap = 24 * 1024; raw = (uint8_t*)heap_caps_malloc(rawcap, MALLOC_CAP_SPIRAM); }
-  int code = -1; size_t total = 0;
+  int code = -1; size_t total = 0; bool source_ok = false;
+  ReaderLocalResult local_result = ReaderLocalResult::NoStorage;
   if (raw) {
-    HTTPClient httpc;
-    httpc.setReuse(false); httpc.setConnectTimeout(9000); httpc.setTimeout(15000);
-    httpc.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS); httpc.setUserAgent("wadamesh-reader");
-    WiFiClientSecure scli; WiFiClient pcli; bool began;
-    if (https) { scli.setInsecure(); began = httpc.begin(scli, url); }
-    else       {                       began = httpc.begin(pcli, url); }
-    if (began) { httpc.addHeader("Accept-Encoding", "identity"); code = httpc.GET(); }
-    if (code == HTTP_CODE_OK) {
-      auto* st = httpc.getStreamPtr();   // NetworkClient* on arduino 3.x (P4: C6Client behind it)
-      unsigned long t0 = millis();
-      while (st && total < rawcap - 1 && (millis() - t0) < 20000) {
-        int a = st->available();
-        if (a <= 0) { if (!httpc.connected()) break; vTaskDelay(pdMS_TO_TICKS(8)); continue; }
-        int r = st->read(raw + total, (rawcap - 1) - total);
-        if (r <= 0) { if (!httpc.connected()) break; vTaskDelay(pdMS_TO_TICKS(5)); continue; }
-        total += (size_t)r;
-        if ((total & 0x3FFF) == 0) { snprintf(s_reader_msg, sizeof s_reader_msg, "Loading\xe2\x80\xa6 %uk", (unsigned)(total / 1024)); s_reader_dirty = true; }
-        vTaskDelay(1);
+    if (local) {
+      local_result = readerReadLocal(url, raw, rawcap - 1, &total, generation);
+      source_ok = local_result == ReaderLocalResult::Ok;
+    } else {
+      HTTPClient httpc;
+      httpc.setReuse(false); httpc.setConnectTimeout(9000); httpc.setTimeout(15000);
+      httpc.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS); httpc.setUserAgent("wadamesh-reader");
+      WiFiClientSecure scli; WiFiClient pcli; bool began;
+      if (https) { scli.setInsecure(); began = httpc.begin(scli, url); }
+      else       {                       began = httpc.begin(pcli, url); }
+      if (began) { httpc.addHeader("Accept-Encoding", "identity"); code = httpc.GET(); }
+      if (code == HTTP_CODE_OK) {
+        ReaderBufferStream sink(raw, rawcap - 1, generation);
+        const int transfer_result = httpc.writeToStream(&sink);
+        total = sink.size();
+        source_ok = transfer_result >= 0 || sink.full() || total > 0;
       }
+      httpc.end();
     }
-    httpc.end();
   }
-  if (!raw) snprintf(s_reader_msg, sizeof s_reader_msg, "Out of memory");
-  else if (code == HTTP_CODE_OK && total >= 2 && raw[0] == 0x1f && (uint8_t)raw[1] == 0x8b)
-    snprintf(s_reader_msg, sizeof s_reader_msg, "Page is gzip-compressed \xe2\x80\x94 not supported yet");
-  else if (code == HTTP_CODE_OK && total > 0) {
+  if (!raw) snprintf(result_msg, sizeof result_msg, "Out of memory");
+  else if (source_ok && total >= 2 && raw[0] == 0x1f && (uint8_t)raw[1] == 0x8b)
+    snprintf(result_msg, sizeof result_msg, "Page is gzip-compressed \xe2\x80\x94 not supported yet");
+  else if (source_ok) {
     if (!s_reader_text)  s_reader_text  = (char*)heap_caps_malloc(kReaderTextCap, MALLOC_CAP_SPIRAM);
     if (!s_reader_links) s_reader_links = (ReaderLink*)heap_caps_malloc(sizeof(ReaderLink) * kReaderMaxLinks, MALLOC_CAP_SPIRAM);
-    if (s_reader_text) { size_t tl = readerHtmlToText((const char*)raw, total, s_reader_text, kReaderTextCap, s_reader_url);
+    if (s_reader_text) { size_t parsed_links = 0;
+      size_t tl = ReaderContent::htmlToText((const char*)raw, total, s_reader_text, kReaderTextCap,
+                                            url, s_reader_links, kReaderMaxLinks, &parsed_links);
+      s_reader_nlinks = (int)parsed_links;
       if (tl == 0) { strcpy(s_reader_text, "(no readable text on this page)"); s_reader_nlinks = 0; }
-      snprintf(s_reader_msg, sizeof s_reader_msg, "%s", s_reader_url); s_reader_ok = true; }
-    else snprintf(s_reader_msg, sizeof s_reader_msg, "Out of memory");
+      snprintf(result_msg, sizeof result_msg, "%s", url); result_ok = true; }
+    else snprintf(result_msg, sizeof result_msg, "Out of memory");
   }
-  else if (code > 0) { snprintf(s_reader_msg, sizeof s_reader_msg, "HTTP %d", code); }
-  else               { snprintf(s_reader_msg, sizeof s_reader_msg, "Couldn't load (offline, bad URL, or TLS failed)"); }
+  else if (local) {
+    const bool home = strcmp(url, kReaderHomeUrl) == 0;
+    result_home_missing = home;
+    if (home) snprintf(result_msg, sizeof result_msg, "No SD /home.htm found");
+    else if (local_result == ReaderLocalResult::NoStorage) snprintf(result_msg, sizeof result_msg, "SD card not available");
+    else if (local_result == ReaderLocalResult::ReadFailed) snprintf(result_msg, sizeof result_msg, "Couldn't read SD file");
+    else snprintf(result_msg, sizeof result_msg, "SD file not found");
+  }
+  else if (code > 0) { snprintf(result_msg, sizeof result_msg, "HTTP %d", code); }
+  else               { snprintf(result_msg, sizeof result_msg, "Couldn't load (offline, bad URL, or TLS failed)"); }
   if (raw) heap_caps_free(raw);
-  s_reader_busy = false; s_reader_dirty = true; s_reader_task = nullptr;
+  if (generation == s_reader_generation) {
+    s_reader_ok = result_ok;
+    s_reader_home_missing = result_home_missing;
+    snprintf(s_reader_msg, sizeof s_reader_msg, "%s", result_msg);
+  }
+  s_reader_task = nullptr; s_reader_busy = false; s_reader_dirty = true;
   vTaskDelete(nullptr);
 }
 // Navigate to a URL. push=true records it in history (a fresh navigation from Go / a
 // link / Enter); push=false is a back / forward / refresh replay that must NOT grow
 // history. readerStart() is the public "new navigation" entry point.
-static void readerNavigate(const char* in, bool push) {
-  if (s_reader_busy || !in) return;
+static bool readerNavigate(const char* in, bool push) {
+  if (s_reader_busy || !in) return false;
   while (*in == ' ') in++;
-  if (readerCiPrefix(in, strlen(in), "http://") || readerCiPrefix(in, strlen(in), "https://"))
-       snprintf(s_reader_url, sizeof s_reader_url, "%s", in);
-  else snprintf(s_reader_url, sizeof s_reader_url, "https://%s", in);   // default to https
+  const bool local = readerCiPrefix(in, strlen(in), "sd:/");
+  char next_url[sizeof s_reader_url];
+  if (local || readerCiPrefix(in, strlen(in), "http://") || readerCiPrefix(in, strlen(in), "https://"))
+    snprintf(next_url, sizeof next_url, "%s", in);
+  else snprintf(next_url, sizeof next_url, "https://%s", in);   // default to https
+  if (!next_url[0] || (!local && !strchr(next_url, '.'))) { snprintf(s_reader_msg, sizeof s_reader_msg, "Enter a valid URL"); s_reader_dirty = true; if (s_reader_root) readerSetAddrExpanded(true); return false; }
+  if (!local && WiFi.status() != WL_CONNECTED) { snprintf(s_reader_msg, sizeof s_reader_msg, "Wi-Fi not connected (Settings \xe2\x86\x92 Wi-Fi)"); s_reader_dirty = true; if (s_reader_root) readerSetAddrExpanded(true); return false; }
+  char previous_url[sizeof s_reader_url];
+  snprintf(previous_url, sizeof previous_url, "%s", s_reader_url);
+  snprintf(s_reader_url, sizeof s_reader_url, "%s", next_url);
   // Keep the address field in sync with what we're actually loading, so a failed load
   // shows the URL we tried (not the stale default that made it look like it "opened
   // wadamesh.com").
   if (s_reader_url_ta) { lv_textarea_set_text(s_reader_url_ta, s_reader_url); s_reader_pristine = false; }
-  if (!s_reader_url[0] || !strchr(s_reader_url, '.')) { snprintf(s_reader_msg, sizeof s_reader_msg, "Enter a valid URL"); s_reader_dirty = true; if (s_reader_root) readerSetAddrExpanded(true); return; }
-  if (WiFi.status() != WL_CONNECTED) { snprintf(s_reader_msg, sizeof s_reader_msg, "Wi-Fi not connected (Settings \xe2\x86\x92 Wi-Fi)"); s_reader_dirty = true; if (s_reader_root) readerSetAddrExpanded(true); return; }
+  s_reader_ok = false;
+  s_reader_home_missing = false;
+  s_reader_task_generation = ++s_reader_generation;
+  s_reader_busy = true; snprintf(s_reader_msg, sizeof s_reader_msg, "%s", local ? "Opening SD page\xe2\x80\xa6" : "Connecting\xe2\x80\xa6"); s_reader_dirty = true;
+  // Immediate feedback (we're on the UI thread): collapse the URL into the topbar and
+  // show a Loading placeholder at once, so a tapped link visibly does something now.
+  if (s_reader_root) { readerSetAddrExpanded(false); readerShowLoading(); }
+  if (xTaskCreatePinnedToCore(readerFetchTaskFn, "reader", 16384, nullptr, 4, &s_reader_task, 0) != pdPASS) {
+    // Couldn't spawn the fetch worker (low internal RAM) — don't leave it stuck on
+    // "Loading…" forever; surface it and drop the busy flag so a retry works.
+    s_reader_task = nullptr; s_reader_busy = false;
+    snprintf(s_reader_msg, sizeof s_reader_msg, "Low memory \xe2\x80\x94 try again");
+    s_reader_ok = false; s_reader_dirty = true;
+    snprintf(s_reader_url, sizeof s_reader_url, "%s", previous_url);
+    if (s_reader_url_ta) {
+      lv_textarea_set_text(s_reader_url_ta, previous_url[0] ? previous_url : kReaderDefaultUrl);
+      s_reader_pristine = !previous_url[0];
+    }
+    return false;
+  }
   if (push && s_reader_hist) {
     // Drop any forward tail, then push (unless it repeats the current entry).
     if (s_reader_hist_pos < 0 || strcmp(s_reader_hist[s_reader_hist_pos], s_reader_url) != 0) {
@@ -22411,31 +22431,23 @@ static void readerNavigate(const char* in, bool push) {
     }
     s_reader_hist_n = s_reader_hist_pos + 1;
   }
-  s_reader_busy = true; snprintf(s_reader_msg, sizeof s_reader_msg, "Connecting\xe2\x80\xa6"); s_reader_dirty = true;
   readerUpdateNavButtons();
-  // Immediate feedback (we're on the UI thread): collapse the URL into the topbar and
-  // show a Loading placeholder at once, so a tapped link visibly does something now.
-  if (s_reader_root) { readerSetAddrExpanded(false); readerShowLoading(); }
-  if (xTaskCreatePinnedToCore(readerFetchTaskFn, "reader", 16384, nullptr, 4, &s_reader_task, 0) != pdPASS) {
-    // Couldn't spawn the fetch worker (low internal RAM) — don't leave it stuck on
-    // "Loading…" forever; surface it and drop the busy flag so a retry works.
-    s_reader_task = nullptr; s_reader_busy = false;
-    snprintf(s_reader_msg, sizeof s_reader_msg, "Low memory \xe2\x80\x94 try again");
-    s_reader_ok = false; s_reader_dirty = true;
-  }
+  return true;
 }
 static void readerStart(const char* in) { readerNavigate(in, true); }
 static void readerBackCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED || s_reader_busy) return;
-  if (s_reader_hist_pos > 0) readerNavigate(s_reader_hist[--s_reader_hist_pos], false);
-  else closeReaderPage();   // at the first page, the ◀ button exits the browser (reliable exit)
+  if (s_reader_hist_pos > 0) {
+    const int target = s_reader_hist_pos - 1;
+    if (readerNavigate(s_reader_hist[target], false)) { s_reader_hist_pos = target; readerUpdateNavButtons(); }
+  }
 }
-static void readerFwdCb(lv_event_t* e)     { if (lv_event_get_code(e) == LV_EVENT_CLICKED && !s_reader_busy && s_reader_hist && s_reader_hist_pos + 1 < s_reader_hist_n) readerNavigate(s_reader_hist[++s_reader_hist_pos], false); }
+static void readerFwdCb(lv_event_t* e)     { if (lv_event_get_code(e) == LV_EVENT_CLICKED && !s_reader_busy && s_reader_hist && s_reader_hist_pos + 1 < s_reader_hist_n) { const int target = s_reader_hist_pos + 1; if (readerNavigate(s_reader_hist[target], false)) { s_reader_hist_pos = target; readerUpdateNavButtons(); } } }
 static void readerRefreshCb(lv_event_t* e) { if (lv_event_get_code(e) == LV_EVENT_CLICKED && !s_reader_busy && s_reader_url[0])                             readerNavigate(s_reader_url, false); }
 // Dim the back / forward arrows when there's nowhere to go that way.
 static void readerUpdateNavButtons() {
   auto dim = [](lv_obj_t* b, bool on) { if (!b) return; lv_obj_t* l = lv_obj_get_child(b, 0); if (l) lv_obj_set_style_text_opa(l, on ? LV_OPA_COVER : LV_OPA_30, LV_PART_MAIN); };
-  dim(s_reader_back, true);   // always active: goes back in history, or exits at the first page
+  dim(s_reader_back, s_reader_hist && s_reader_hist_pos > 0);
   dim(s_reader_fwd,  s_reader_hist && s_reader_hist_pos + 1 < s_reader_hist_n);
 }
 static void readerGoCb(lv_event_t*) { if (s_reader_url_ta) readerStart(lv_textarea_get_text(s_reader_url_ta)); }
@@ -22512,21 +22524,36 @@ static void readerRenderBody() {
     return;
   }
   // Walk the text, emitting text[cursor..link.start] as paragraphs and each link
-  // range as a tappable label. NUL-swap in place so we never copy big runs.
+  // range as a tappable label. Boundary whitespace is redundant once a range becomes
+  // its own flex row; trimming it prevents paragraph newlines from becoming blank rows.
+  // NUL-swap in place so we never copy big runs.
   const uint32_t tlen = (uint32_t)strlen(s_reader_text);
+  auto mkRange = [&](uint32_t start, uint32_t end, bool link, int idx) {
+    auto boundarySpace = [](char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; };
+    while (start < end && boundarySpace(s_reader_text[start])) start++;
+    while (end > start && boundarySpace(s_reader_text[end - 1])) end--;
+    if (start == end) return false;
+    char saved = s_reader_text[end];
+    s_reader_text[end] = 0;
+    mkLabel(s_reader_text + start, link, idx);
+    s_reader_text[end] = saved;
+    return true;
+  };
   uint32_t cursor = 0; int blocks = 0;
   for (int i = 0; i < s_reader_nlinks && blocks < 500; i++) {
     ReaderLink& lk = s_reader_links[i];
     if (lk.start < cursor || lk.end > tlen || lk.end <= lk.start) continue;
-    if (lk.start > cursor) { char sv = s_reader_text[lk.start]; s_reader_text[lk.start] = 0; mkLabel(s_reader_text + cursor, false, -1); s_reader_text[lk.start] = sv; blocks++; }
-    { char sv = s_reader_text[lk.end]; s_reader_text[lk.end] = 0; mkLabel(s_reader_text[lk.start] ? s_reader_text + lk.start : "(link)", true, i); s_reader_text[lk.end] = sv; blocks++; }
+    if (lk.start > cursor && mkRange(cursor, lk.start, false, -1)) blocks++;
+    if (mkRange(lk.start, lk.end, true, i)) blocks++;
     cursor = lk.end;
   }
-  if (cursor < tlen) mkLabel(s_reader_text + cursor, false, -1);
+  if (cursor < tlen) mkRange(cursor, tlen, false, -1);
   lv_obj_scroll_to_y(s_reader_scroll, 0, LV_ANIM_OFF);
 }
 static void closeReaderPage() {
   if (!s_reader_root) return;
+  ++s_reader_generation;
+  s_reader_pending_url[0] = 0;
   s_apppage_title = nullptr; s_apppage_close = nullptr;
   s_reader_bar_url = false;   // un-hide the status-bar clock
   s_reader_page_open = false; // restore the tall-bar glass fade for other pages
@@ -22542,7 +22569,7 @@ static void readerEditBtnCb(lv_event_t* e) {
   readerSetAddrExpanded(true);
   if (s_reader_url_ta) { lv_textarea_set_text(s_reader_url_ta, s_reader_url); s_reader_pristine = false; lv_group_focus_obj(s_reader_url_ta); }
 }
-static void openReaderPage() {
+static void openReaderPage(const char* initial_url = nullptr) {
   closeReaderPage();
   const lv_coord_t sw = lv_disp_get_hor_res(nullptr);
   const lv_coord_t sh = lv_disp_get_ver_res(nullptr);
@@ -22628,7 +22655,8 @@ static void openReaderPage() {
   s_reader_fwd     = navBtn(LV_SYMBOL_RIGHT,   readerFwdCb);
   navBtn(LV_SYMBOL_REFRESH, readerRefreshCb);
   s_reader_editbtn = navBtn(LV_SYMBOL_EDIT,    readerEditBtnCb);
-  readerRenderBody();
+  if (s_reader_busy) readerShowLoading();
+  else               readerRenderBody();
   // Reopen after a successful load -> collapsed (fullscreen reading); first open or
   // after an error -> expanded so you can type a URL.
   readerSetAddrExpanded(!(s_reader_ok && s_reader_text && s_reader_text[0]));
@@ -22637,6 +22665,15 @@ static void openReaderPage() {
   // this page opens over a chat, leaving the tall bar's lower row (the back tap) buried
   // under the reader root.
   if (g_statusbar.root) lv_obj_move_foreground(g_statusbar.root);
+  const char* target = initial_url && initial_url[0] ? initial_url : kReaderHomeUrl;
+  if (s_reader_busy) {
+    snprintf(s_reader_pending_url, sizeof s_reader_pending_url, "%s", target);
+    readerSetAddrExpanded(false);
+    readerShowLoading();
+  } else {
+    s_reader_pending_url[0] = 0;
+    readerStart(target);
+  }
 }
 #endif  // Reader
 
@@ -34099,7 +34136,7 @@ static void urlMenuOpenWebCb(lv_event_t* e) {
   // new fetch) and the previous page so openReaderPage doesn't re-render the last URL.
   if (!s_reader_task) s_reader_busy = false;
   s_reader_ok = false;
-  openReaderPage(); readerStart(u);
+  openReaderPage(u);
 }
 #endif
 static void openUrlMenu(const char* url) {
@@ -42247,7 +42284,7 @@ static void docCaptureTour() {
   // On-device web browser (8 MB boards only) + the chat-link menu + the QR popup.
   // The reader renders from the UI-update poll (which doesn't run while this tour
   // blocks the loop), so drive the fetch-wait + render inline here.
-  openReaderPage(); readerStart("wadamesh.com");
+  openReaderPage("wadamesh.com");
   { int _w = 0; while (s_reader_busy && _w < 700) { lv_timer_handler(); delay(22); ++_w; } esp_task_wdt_reset(); }
   if (s_reader_ok) { readerRenderBody(); readerSetAddrExpanded(false); }
   else             { readerShowMessage(s_reader_msg[0] ? s_reader_msg : "Couldn't load page", 0xE0A0A0); readerSetAddrExpanded(true); }
@@ -43635,14 +43672,31 @@ static void refreshStatusLabels() {
   // The page is a full-screen overlay (any tab), so gate on the page being open.
   if (s_reader_dirty && s_reader_root) {
     s_reader_dirty = false;
-    if (s_reader_status) lv_label_set_text(s_reader_status, s_reader_msg);
-    if (!s_reader_busy) {                   // the fetch finished
-      if (s_reader_ok) {                    // …with a page
-        readerRenderBody();
-        readerSetAddrExpanded(false);       // collapse the address bar -> fullscreen reading
-      } else {                              // …with an error — SHOW it (don't sit on "Loading…")
-        readerShowMessage(s_reader_msg[0] ? s_reader_msg : "Couldn't load page", 0xE0A0A0);
-        readerSetAddrExpanded(true);        // expand so the address bar + retry are reachable
+    if (!s_reader_busy && s_reader_pending_url[0]) {
+      char pending_url[sizeof s_reader_pending_url];
+      snprintf(pending_url, sizeof pending_url, "%s", s_reader_pending_url);
+      s_reader_pending_url[0] = 0;
+      readerStart(pending_url);
+    } else {
+      if (s_reader_status) lv_label_set_text(s_reader_status, s_reader_msg);
+      if (!s_reader_busy) {                 // the fetch finished
+        if (s_reader_ok) {                  // …with a page
+          readerRenderBody();
+          readerSetAddrExpanded(false);     // collapse the address bar -> fullscreen reading
+        } else if (s_reader_home_missing) { // no optional SD home page: retain the normal URL-entry UX
+          s_reader_home_missing = false;
+          s_reader_hist_n = 0; s_reader_hist_pos = -1;
+          s_reader_url[0] = 0;
+          if (s_reader_text) s_reader_text[0] = 0;
+          s_reader_nlinks = 0;
+          if (s_reader_url_ta) lv_textarea_set_text(s_reader_url_ta, kReaderDefaultUrl);
+          s_reader_pristine = true;
+          readerRenderBody();
+          readerSetAddrExpanded(true);
+        } else {                            // …with an error — SHOW it (don't sit on "Loading…")
+          readerShowMessage(s_reader_msg[0] ? s_reader_msg : "Couldn't load page", 0xE0A0A0);
+          readerSetAddrExpanded(true);      // expand so the address bar + retry are reachable
+        }
       }
     }
   }
@@ -52546,6 +52600,11 @@ static bool sdRuntimeLifecycleBusy() {
   bool busy = s_hist_flush_busy || s_hist_flush_req || s_sdinfo_request ||
               s_sdinfo_busy ||
               touchPrefsIoBusy();
+#if defined(MULTI_TRANSPORT_COMPANION)
+  const bool reader_is_caller = s_reader_sd_busy &&
+                                s_reader_sd_owner == xTaskGetCurrentTaskHandle();
+  busy = busy || (s_reader_sd_busy && !reader_is_caller);
+#endif
 #if defined(HAS_TDECK_GT911) || defined(TLORA_PAGER)
   busy = busy || s_notify_playing;
 #endif

--- a/test/test_reader_content.cpp
+++ b/test/test_reader_content.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <assert.h>
+#include <string.h>
+
+#include "ui-touch/ReaderContent.h"
+
+int main() {
+  static const char html[] =
+      "<!doctype html><html><body><h1>Bookmarks</h1>"
+      "<p><a href='https://lite.cnn.com'>CNN</a></p>"
+      "<p><a href='news.htm'>Local news</a> &amp; weather</p>"
+      "<script>12345</script></body></html>";
+  char text[256];
+  ReaderContent::Link links[4] = {};
+  size_t link_count = 0;
+  const size_t text_len = ReaderContent::htmlToText(
+      html, strlen(html), text, sizeof text, "sd:/home.htm",
+      links, 4, &link_count);
+
+  assert(text_len == strlen(text));
+  assert(strstr(text, "Bookmarks") != nullptr);
+  assert(strstr(text, "CNN") != nullptr);
+  assert(strstr(text, "Local news & weather") != nullptr);
+  assert(strstr(text, "12345") == nullptr);
+  assert(link_count == 2);
+  assert(strcmp(links[0].href, "https://lite.cnn.com") == 0);
+  assert(strcmp(links[1].href, "sd:/news.htm") == 0);
+  assert(strncmp(text + links[0].start, "CNN", links[0].end - links[0].start) == 0);
+  assert(strncmp(text + links[1].start, "Local news", links[1].end - links[1].start) == 0);
+
+  char resolved[240];
+  assert(ReaderContent::resolveUrl("sd:/bookmarks/home.htm", "../index.htm",
+                                   resolved, sizeof resolved));
+  assert(strcmp(resolved, "sd:/bookmarks/../index.htm") == 0);
+  assert(ReaderContent::resolveUrl("sd:/home.htm", "//text.npr.org",
+                                   resolved, sizeof resolved));
+  assert(strcmp(resolved, "https://text.npr.org") == 0);
+  assert(!ReaderContent::resolveUrl("sd:/home.htm", "javascript:alert(1)",
+                                    resolved, sizeof resolved));
+
+  static const char attribute_html[] =
+      "<a data-href='sd:/wrong.htm' xhref='sd:/also-wrong.htm' href='right.htm'>Right</a>";
+  link_count = 0;
+  ReaderContent::htmlToText(attribute_html, strlen(attribute_html), text, sizeof text,
+                            "sd:/home.htm", links, 4, &link_count);
+  assert(link_count == 1);
+  assert(strcmp(links[0].href, "sd:/right.htm") == 0);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Open `sd:/home.htm` automatically when the Web reader is launched from the app drawer.
- Keep the existing URL-entry screen when the SD card or `/home.htm` is unavailable.
- Resolve links in local pages to HTTP/HTTPS destinations or other SD-relative HTML files.
- Keep the bottom Back button inside browser history; the top-left status-bar control remains the browser close action.
- Remove the leading-text and excess-spacing artifacts around parsed links.

## Why

Entering URLs on a device keyboard is slow and error-prone. A small HTML file at the SD-card root provides a user-maintained home page and bookmark list without adding another management screen or persistence format.

The bottom toolbar previously closed the reader at the first history entry even though a dedicated close control already exists. Rendering also exposed parser and transport boundaries as visible first-line text or blank rows around links.

## Implementation

The reader now treats `sd:/` as a first-class source alongside HTTP and HTTPS. App-drawer launches probe `sd:/home.htm` asynchronously; explicit chat links still open their requested URL directly. Missing optional home files reset cleanly to the existing `wadamesh.com` URL-entry state.

HTML extraction and URL resolution moved into the hardware-independent `ReaderContent` module. It supports SD-relative, root-relative, protocol-relative, HTTP, and HTTPS links while rejecting unusable schemes. Attribute-boundary checks prevent `data-href` or `xhref` from being mistaken for `href`.

Network responses use `HTTPClient::writeToStream()` with a bounded PSRAM-backed stream. This lets `HTTPClient` remove chunked-transfer framing before parsing without allocating an unbounded `String`.

Reader workers now use request generations so a result cannot render into a page that was closed and reopened. Pending reopen targets start after the previous worker exits. SD ownership covers mount/open/read/close so runtime remount logic cannot invalidate the file, and Back/Forward commit history and current-URL state only after navigation starts successfully.

The renderer trims whitespace that only exists at LVGL label boundaries, while the parser discards pending block whitespace before the first visible character and keeps paragraph separators outside link ranges.

## Testing

Passed host parser/link regression:

```text
c++ -std=c++17 -Wall -Wextra -Werror -Isrc \
  src/ui-touch/ReaderContent.cpp test/test_reader_content.cpp \
  -o /tmp/wadamesh-test-reader-content
/tmp/wadamesh-test-reader-content
```

Passed full firmware build:

```text
pio run --environment LilyGo_TDeck_companion_radio_touch
1 succeeded in 00:00:50.212
RAM:   32.1% (105156 / 327680 bytes)
Flash: 78.5% (3190457 / 4063232 bytes)
```

`git diff --check` and VS Code diagnostics also pass. The build retains the existing LVGL macro-redefinition warnings.

## Hardware verification

Runtime behavior still needs deliberate on-device verification with an SD card: launch with and without `/home.htm`, follow local and remote links, exercise Back/Forward, close and reopen during a slow load, and confirm SD removal/reinsert behavior. The T-Deck build covers the Arduino-SD code path; an SD_MMC board should also be checked before merge.

Closes #302
