### PR TITLE
Reopen chat keyboard on tap

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -7015,7 +7015,12 @@ static void keyboardCb(lv_event_t* e) {
 }
 
 static void composerFocusCb(lv_event_t* e) {
-  if (lv_event_get_code(e) != LV_EVENT_FOCUSED) return;
+  const lv_event_code_t code = lv_event_get_code(e);
+  if (code != LV_EVENT_FOCUSED && code != LV_EVENT_CLICKED) return;
+  if (code == LV_EVENT_CLICKED) {
+    lv_indev_t* act = lv_indev_get_act();
+    if (act && (lv_indev_get_scroll_obj(act) || lv_indev_get_scroll_dir(act) != LV_DIR_NONE)) return;
+  }
   auto* p = static_cast<LvChatPanel*>(lv_event_get_user_data(e));
   if (p && p->detail_open) { showKb(p); noteKbActivity(); }
 }
@@ -31256,6 +31261,11 @@ static void makeChatDetail(LvChatPanel& p) {
   }
   // Tap on composer → show keyboard
   lv_obj_add_event_cb(p.composer_ta, composerFocusCb, LV_EVENT_FOCUSED, &p);
+#if CAP_TOUCH && !CAP_KEYBOARD
+  // A composer may remain group-focused after the keyboard is dismissed, so
+  // a later tap emits CLICKED without another FOCUSED event.
+  lv_obj_add_event_cb(p.composer_ta, composerFocusCb, LV_EVENT_CLICKED, &p);
+#endif
   lv_obj_add_event_cb(p.composer_ta, kbActivityPressCb, LV_EVENT_PRESSED, nullptr);
   // Grow / shrink the composer row as the message wraps (every text change).
   lv_obj_add_event_cb(p.composer_ta, composerAutoGrowCb, LV_EVENT_VALUE_CHANGED, &p);


### PR DESCRIPTION
## Summary

- Reopen the existing on-screen keyboard when a touch-only device taps an already-focused chat composer.
- Reuse the current `showKb()` path, including composer lifting, message-area resizing, rotation controls, language layouts, and Attaky keyboard suppression.
- Ignore `CLICKED` events produced by active scrolling so a swipe beginning over the composer does not summon the keyboard.
- Keep physical-keyboard builds on their existing focus-only behavior.

## Context

The firmware already creates a shared LVGL keyboard and shows it when a chat composer first receives `LV_EVENT_FOCUSED`. That satisfies the core request in #299 and was confirmed on a Heltec V4.

The remaining gap occurs after the keyboard is dismissed: the composer can remain the focus group's selected object. A later tap then emits `LV_EVENT_CLICKED` without another focus transition, so the focus-only callback does not call `showKb()` and the keyboard stays hidden.

This change registers a click callback only when `CAP_TOUCH && !CAP_KEYBOARD`. Deliberate taps use the same established keyboard path, while physical-keyboard devices are unaffected. Attaky's detachable keyboard continues to use its existing runtime suppression inside `showKb()`.

## Validation

- Heltec V4 firmware compiled and uploaded successfully with `platformio run --target upload --environment heltec_v4_tft_companion_radio_usb_tcp_touch`.
- Existing first-tap keyboard behavior was confirmed on Heltec V4.
- Editor diagnostics report no errors in `UITask.cpp`.
- `git diff --check` passes.

Closes #299
