### PR TITLE
Stop the tile fetcher deleting the user's SD map pack

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -27385,7 +27385,16 @@ static void tileFetchTaskFn(void* arg) {
         tileCacheRemove(path_jpg);   // present but unreadable/short/bad -> fall through and re-download
       }
     }
-    tileCacheRemove(path_png);   // drop any stale .png from an older build — remove is a no-op if absent (don't gate on the broken exists())
+    // Drop any stale .png from an older build — but ONLY on the firmware's own
+    // LittleFS cache partition, which is what this cleanup was written for.
+    // s_tile_fs is re-pointed at the SD ROOT on boards that cache tiles to the
+    // card (M9 always; see UITask::begin), and s_tile_root is "" there — so
+    // unguarded this resolved to SD.remove("/tiles/<z>/<x>/<y>.png"), deleting
+    // the user's own offline map pack. The skip-check above only ever tests the
+    // .jpg, so every queued tile whose .jpg was absent erased the co-located
+    // .png. Same discriminator tileCacheMarkSdIo/tilesFsLowSpace already use.
+    if (s_tile_fs == &s_tiles_fs)
+      tileCacheRemove(path_png);   // no-op if absent (don't gate on the broken exists())
 
     // Heap-safety gate: opening a TCP socket costs ~6 KB of internal DMA
     // RAM, and the Wi-Fi driver needs more on top for RX. If internal


### PR DESCRIPTION
The tile fetch worker calls `tileCacheRemove(path_png)` to "drop any stale .png
from an older build". That cleanup was written for the firmware's own LittleFS
cache partition — but `tileCache*` resolves through `s_tile_fs` + `s_tile_root`,
and `UITask::begin` re-points those at the **SD card root** on every board that
caches tiles to the card:

* ThinkNode M9 — always (the card is built in)
* Heltec V4-R8 — with a card present at boot
* T-Deck under Launcher, T-Lora Pager under LauncherHub
* any of them with "Tiles from SD card" enabled

With `s_tile_root` empty, that call resolves to
`SD.remove("/tiles/<z>/<x>/<y>.png")` — a real file on the user's own offline
map pack, not a stale cache entry. The skip-check above it only ever tests the
`.jpg`, so **every queued tile whose `.jpg` is absent erases the co-located
`.png`**. `SD.remove()` is permanent; the pack is not recoverable.

Confirmed on M9 hardware — the boot log shows exactly this aliasing:

```
[TILE] caching Wi-Fi tiles on SD /tiles
[BOOT] storage: SD /meshcomod
```

### The fix

Gate the removal on the firmware's own partition, using the same discriminator
`tileCacheMarkSdIo()` and `tilesFsLowSpace()` already use:

```c
if (s_tile_fs == &s_tiles_fs)
  tileCacheRemove(path_png);
```

One line plus a comment. No behaviour change on the LittleFS cache, where the
cleanup was always intended to run.

### Scope

Wi-Fi-only trigger (`queueTileForFetch` returns early when Wi-Fi is down), and
it only reaches a pack laid out at `/tiles/<z>/<x>/<y>.png` — **not** the
documented `/maps/osm/...` layout.

Possibly related to #339 ("map shows nothing after beta_71"), where a user with
"Tiles from SD card" on reports previously-working tiles gone and re-downloading
not helping. I can't confirm that's the same thing without their directory
listing, so I'm **not** claiming this closes it — the live symptom there is
`d0/9` on the read path.

### Testing

Builds clean on all 8 PlatformIO environments, including the two this project
asks contributors to keep working (LilyGo T-Deck and Heltec V4 TFT). Running on
M9 hardware.
