### PR TITLE
Stop live labels overlapping the rows beneath them

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10021,7 +10021,12 @@ static void openDiscoveredModalCb(lv_event_t* e) {
       lv_obj_set_style_text_color(l, lv_color_hex(COLOR_ACCENT), LV_PART_MAIN);
       lv_obj_set_style_text_font(l, &g_font_12, LV_PART_MAIN);
       lv_obj_set_pos(l, 2, y);
-      y += SC(38);
+      // The text names every enabled type TWICE ("Auto-add on for chats,
+      // repeaters, rooms, sensors — new chats, repeaters, rooms, sensors land
+      // in Contacts automatically."), so with several types enabled it wraps
+      // well past the fixed SC(38) and printed over the first discovered card.
+      lv_obj_update_layout(l);
+      y += LV_MAX(SC(38), lv_obj_get_height(l) + SC(6));
     }
   }
 
@@ -10732,7 +10737,11 @@ static void buildRadioSettings() {
     lv_obj_set_style_text_font(rl, &g_font_12, LV_PART_MAIN);
     lv_obj_set_style_text_color(rl, lv_color_hex(COLOR_ACCENT), LV_PART_MAIN);
     lv_obj_set_pos(rl, 2, y);
-    y += SC(22);
+    // Width is set, so this label WRAPS. A 4-digit time-on-air (any SF11/SF12
+    // preset) or a longer translation takes it to two lines, and the fixed
+    // SC(22) advance ran the second line through the MESH section divider.
+    lv_obj_update_layout(rl);
+    y += LV_MAX(SC(22), lv_obj_get_height(rl) + SC(4));
   }
 
   mk_section("MESH");
@@ -14269,11 +14278,17 @@ static void buildBluetoothSettings() {
     y += SC(38);
 
     lv_obj_t* hint = lv_label_create(body);
+    // Give it a width so it WRAPS: with none, the label sizes to its text and
+    // simply runs off the right edge. The English string already overflows the
+    // grouped-settings width here, before any longer translation.
+    lv_label_set_long_mode(hint, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(hint, lv_pct(100));
     lv_label_set_text(hint, TR("Type a new 6-digit code \xC2\xB7 applies after a reboot"));
     lv_obj_set_style_text_color(hint, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
     lv_obj_set_style_text_font(hint, &g_font_12, LV_PART_MAIN);
     lv_obj_set_pos(hint, 2, y);
-    y += SC(18);
+    lv_obj_update_layout(hint);
+    y += LV_MAX(SC(18), lv_obj_get_height(hint) + SC(4));
   }
 
 #if defined(ESP32) && defined(MULTI_TRANSPORT_COMPANION)
@@ -17850,7 +17865,12 @@ static void openAddContactModalCb(lv_event_t* e) {
   lv_obj_set_style_text_font(s_addct_error_l, &g_font_12, LV_PART_MAIN);
   lv_label_set_text(s_addct_error_l, "");
   lv_obj_set_pos(s_addct_error_l, 2, y);
-  y += 24;
+  // This label is EMPTY at build time, so the 24 px below reserved space for
+  // text that did not exist yet. addContactSubmitCb then fills it with a
+  // validation message that wraps to two lines and printed over the submit
+  // button. Pin the height to the reservation so the error wraps INSIDE it.
+  lv_obj_set_height(s_addct_error_l, SC(30));
+  y += SC(34);
 
   lv_obj_t* b = lv_btn_create(body);
   lv_obj_set_size(b, lv_pct(100),36);
@@ -42344,6 +42364,10 @@ static void openAppGridSheet() {
   {
     const int ty = hdr + 2 * (btn_h + gap);
     lv_obj_t* hl = lv_label_create(card);
+    // Keep clear of the right-aligned switch below. With no width the label
+    // sizes to its text, so a longer translation ran straight under the switch.
+    lv_label_set_long_mode(hl, LV_LABEL_LONG_DOT);
+    lv_obj_set_width(hl, lv_pct(68));
     lv_label_set_text(hl, TR("App drawer as home"));
     lv_obj_set_style_text_font(hl, &g_font_12, LV_PART_MAIN);
     lv_obj_set_style_text_color(hl, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
@@ -44545,7 +44569,11 @@ static int setupHeader(const char* title, const char* blurb, const char* step_ta
   lv_obj_set_style_text_font(t, &g_font_16, LV_PART_MAIN);
   lv_obj_set_style_text_color(t, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
   lv_obj_set_pos(t, 12, 12);
-  int y = 12 + 24;
+  // The title has LV_LABEL_LONG_WRAP at width sw-84, so it is NOT always one
+  // line — a longer translation wraps and the hardcoded 24 px advance put the
+  // blurb (and every step's content under it) straight through the title.
+  lv_obj_update_layout(t);
+  int y = 12 + LV_MAX(24, lv_obj_get_height(t) + 2);
   if (step_tag && step_tag[0]) {
     lv_obj_t* s = lv_label_create(s_setup_root);
     lv_label_set_text(s, step_tag);
@@ -45454,6 +45482,13 @@ static void openChannelScopeModal(int slot, const char* name) {
   lv_obj_set_pos(nm, SC(8), SC(36));
 
   lv_obj_t* hint = lv_label_create(s_chanscope_modal);
+  // One line, ellipsized. With no width the label sizes to its text and its tail
+  // ran past the modal edge; wrapping is not an option here either, because the
+  // textarea below is pinned at SC(72) and this sits at SC(54) — 18 px of room,
+  // less than a second line. A longer translation loses its tail rather than
+  // printing over the input.
+  lv_label_set_long_mode(hint, LV_LABEL_LONG_DOT);
+  lv_obj_set_width(hint, sw - SC(16));
   lv_label_set_text(hint, TR("Region scope (#tag), blank = default."));
   lv_obj_set_style_text_color(hint, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
   lv_obj_set_style_text_font(hint, &g_font_12, LV_PART_MAIN);

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -11635,34 +11635,49 @@ static void buildSystemInfoSettings() {
   lv_obj_t* body = createSettingsModal(TR("System info"), SettingsModalKind::SystemInfo);
   char buf[704];
 
-  // Live tier (uptime + heap): a small constant-height label refreshed at 1 Hz.
+  // FLEX COLUMN, deliberately not the manual y cursor the rest of this file uses.
+  // Both labels below are re-texted AFTER build with text whose LINE COUNT
+  // genuinely varies:
+  //   • the live tier gains a hard '\n' the moment a chat-store write fails
+  //     (sysInfoTextLive's "last save: FAIL ...\n  append failed: ..." branch),
+  //     and it is refreshed at 1 Hz while this page is open;
+  //   • the slow tier grows as the off-thread microSD scan publishes its
+  //     size/free lines, and as the loop-stall ring fills from "none recorded"
+  //     to six "-Ns <tag> Nms" rows — on a page that is itself a documented
+  //     stall source.
+  // The old code pinned each child to the MEASURED height of the one above it,
+  // so any of that growth printed straight over the next widget: the live tier
+  // over the "Chip / ESP32-S3" heading, the slow tier over the Memory detail
+  // button. Reserving a worst case is not viable here — neither the stall ring
+  // nor the SD strings have a fixed upper bound — so let the container reflow
+  // instead. Children are created in visual order, which is what flex needs.
+  lv_obj_set_flex_flow(body, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_style_pad_row(body, 6, LV_PART_MAIN);
+  lv_obj_set_style_pad_left(body, 2, LV_PART_MAIN);
+
+  // Live tier (uptime + heap), refreshed at 1 Hz.
   lv_obj_t* lbl = lv_label_create(body);
   s_sysinfo_lbl = lbl;
   lv_label_set_long_mode(lbl, LV_LABEL_LONG_WRAP);
   lv_obj_set_width(lbl, lv_pct(100));
-  lv_obj_set_pos(lbl, 2, 0);
   lv_obj_set_style_text_font(lbl, &g_font_12, LV_PART_MAIN);
   lv_obj_set_style_text_color(lbl, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
   sysInfoTextLive(buf, sizeof buf);
   lv_label_set_text(lbl, buf);
 
   // Slow tier below it: chip/flash/SD/NVS/stalls/build — re-set only on change.
-  lv_obj_update_layout(lbl);
   lv_obj_t* rest = lv_label_create(body);
   s_sysinfo_rest_lbl = rest;
   lv_label_set_long_mode(rest, LV_LABEL_LONG_WRAP);
   lv_obj_set_width(rest, lv_pct(100));
-  lv_obj_set_pos(rest, 2, lv_obj_get_y(lbl) + lv_obj_get_height(lbl) + 2);
   lv_obj_set_style_text_font(rest, &g_font_12, LV_PART_MAIN);
   lv_obj_set_style_text_color(rest, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
   sysInfoTextRest(buf, sizeof buf);
   lv_label_set_text(rest, buf);
 
   // "Memory detail" button below the info text (per-region heap breakdown).
-  lv_obj_update_layout(rest);
   lv_obj_t* membtn = lv_btn_create(body);
   lv_obj_set_size(membtn, lv_pct(96), SC(34));
-  lv_obj_set_pos(membtn, 2, lv_obj_get_y(rest) + lv_obj_get_height(rest) + 8);
   styleButton(membtn);
   lv_obj_add_event_cb(membtn, openMemoryDetailCb, LV_EVENT_CLICKED, nullptr);
   lv_obj_t* mbl = lv_label_create(membtn);
@@ -12643,9 +12658,37 @@ static void buildDeviceSettings(int sec) {
   lv_obj_set_style_text_color(g_set_modal.gps_status, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
   lv_obj_set_style_text_font(g_set_modal.gps_status, &g_font_12, LV_PART_MAIN);
   lv_obj_set_pos(g_set_modal.gps_status, 4, y);
-  lv_label_set_text(g_set_modal.gps_status, gpsStatusStr());
-  lv_obj_update_layout(g_set_modal.gps_status);
-  y += LV_MAX(SC(22), lv_obj_get_height(g_set_modal.gps_status) + SC(6));   // status is 2 lines now
+  // RESERVE THE WORST-CASE HEIGHT, don't measure the current text. This label is
+  // re-texted every tick while the page is open (updateSettingsLiveFields), and
+  // every row below it is positioned ABSOLUTELY from this build-time `y` — so a
+  // status that grows after the page was built lands on top of them. Concretely:
+  // open the page with GPS off and the text is a one-line "GPS: off", so `y`
+  // advanced ~22 px; toggle GPS on — the obvious thing to do on this page — and
+  // the text becomes "GPS: searching Nm" plus the ~100-character cold-start
+  // sentence, which wraps to several lines on a 240 px panel and printed over
+  // the "GPS serial baud" label and its dropdown.
+  // Measure the tallest string this label can ever hold, with the real font and
+  // width, and PIN the height to it. A later refresh then cannot reflow anything.
+  // Both long variants are probed because which one is tallest depends on the
+  // active translation, not just on English.
+  {
+    char probe[200];
+    snprintf(probe, sizeof probe, "%s 00m00s\n%s", TR("GPS: searching"),
+             TR("No position yet. A cold start needs a clear view of the sky and can take several minutes."));
+    lv_label_set_text(g_set_modal.gps_status, probe);
+    lv_obj_update_layout(g_set_modal.gps_status);
+    lv_coord_t worst_h = lv_obj_get_height(g_set_modal.gps_status);
+
+    snprintf(probe, sizeof probe, "%s \xc2\xb7 00 sats \xc2\xb7 0000 m\n00.00000, 000.00000", TR("GPS: fix"));
+    lv_label_set_text(g_set_modal.gps_status, probe);
+    lv_obj_update_layout(g_set_modal.gps_status);
+    if (lv_obj_get_height(g_set_modal.gps_status) > worst_h)
+      worst_h = lv_obj_get_height(g_set_modal.gps_status);
+
+    lv_obj_set_height(g_set_modal.gps_status, worst_h);
+    lv_label_set_text(g_set_modal.gps_status, gpsStatusStr());
+    y += LV_MAX(SC(22), worst_h + SC(6));
+  }
 
   // (Expansion Kit moved to the Sensors page — see the DSEC_SENSORS block below.)
 
@@ -15400,6 +15443,15 @@ static void buildWifiSettings() {
   lv_obj_set_width(g_set_modal.wifi_sta_status_l, cw - SC(54));   // clear of the switch
   lv_obj_set_style_text_color(g_set_modal.wifi_sta_status_l, lv_color_hex(COLOR_SUB), LV_PART_MAIN);
   lv_obj_set_style_text_font(g_set_modal.wifi_sta_status_l, &g_font_12, LV_PART_MAIN);
+  // Pin it to ONE line, as the header comment above promises. LV_LABEL_LONG_DOT
+  // only ellipsizes against the object's HEIGHT — with the label's default
+  // LV_SIZE_CONTENT height there is nothing to ellipsize against, so a long
+  // status just wrapped and grew instead. That matters here because this label
+  // is re-texted live (wifiRefreshStatus) with SSIDs and IP addresses, and the
+  // header only reserves SC(30) below it: at the M9's narrow content width a
+  // two-line status ran from y+SC(7) straight into s_wifi_list_cont, which is
+  // pinned at SC(30) and painted after it. A fixed height makes the dots work.
+  lv_obj_set_height(g_set_modal.wifi_sta_status_l, SC(16));
   lv_obj_set_pos(g_set_modal.wifi_sta_status_l, 2, y + SC(7));
   lv_label_set_text(g_set_modal.wifi_sta_status_l, TR("Loading..."));
   y += SC(30);
@@ -22059,6 +22111,14 @@ static void buildFileManager(lv_obj_t* body) {
   lv_label_set_long_mode(s_fm_path_lbl, LV_LABEL_LONG_DOT);
   lv_obj_set_pos(s_fm_path_lbl, loc_x, 6);
   lv_obj_set_width(s_fm_path_lbl, loc_w);
+  // One line, fixed. LV_LABEL_LONG_DOT ellipsizes against the object's HEIGHT,
+  // and a label defaults to LV_SIZE_CONTENT — so with no height set, a path too
+  // long for loc_w wrapped and grew downward instead of getting its dots. This
+  // text changes every time the user walks into a directory, the field sits at
+  // y=6 inside a header only HDR_H (34) tall, and s_fm_list is pinned at HDR_H
+  // and painted after it, so the overflow disappeared under the list. Height =
+  // one line of g_font_12 plus the 3 px pad_ver either side.
+  lv_obj_set_height(s_fm_path_lbl, SC(21));
   lv_obj_set_style_text_font(s_fm_path_lbl, &g_font_12, LV_PART_MAIN);
   lv_obj_set_style_text_color(s_fm_path_lbl, lv_color_hex(COLOR_TEXT), LV_PART_MAIN);
   lv_obj_set_style_bg_color(s_fm_path_lbl, lv_color_hex(0x101418), LV_PART_MAIN);


### PR DESCRIPTION
Reported on the M9: the GPS settings page prints its status text over the rows
below it. Sweeping the other views turned up the same root pattern in ten more
places — a label measured **once at build time**, or given no width at all, then
handed text of a different length.

Most pages here lay out children with a manual cursor (`lv_obj_set_pos` then
`y += height`), so nothing reflows. Two failure shapes:

**Overlap** — the text grows over what is beneath:

* **Settings → GPS** (the reported one): `gps_status` is re-texted every tick.
  Built with GPS off it is a one-line `"GPS: off"`, so `y` advanced ~22 px;
  toggling GPS on swaps in `"GPS: searching Nm"` plus a ~100-character
  cold-start sentence that wraps to several lines and lands on the
  "GPS serial baud" row. Now reserves the tallest possible string, probing
  **both** long variants since which one wins depends on the language.
* **Settings → About**: three children each pinned to the measured height of the
  one above. The live tier gains a hard newline the moment a chat-store write
  fails; the slow tier grows as the microSD scan publishes and the stall ring
  fills from 0 to 6 rows. Neither has a fixed upper bound, so a worst-case
  reserve isn't possible — uses a flex column instead.
* **First-boot wizard header**: the title has `LONG_WRAP` but `y` advanced a
  hardcoded 24 px, so a wrapped title ran through the blurb *and every step's
  content under it*.
* **Radio & Mesh**: the duty-cycle readout wraps but had a fixed advance; any
  SF11/SF12 preset gives a 4-digit time-on-air that puts line two through the
  MESH divider.
* **Add contact / channel modals**: the error label is *empty* at build, so
  24 px was reserved for text that didn't exist; a validation message then
  wrapped over the submit button.
* **Contacts → Discovered**: the auto-add hint names every enabled type
  **twice**, so with several enabled it wraps past its reservation onto the
  first card.
* **App drawer → cog**: "App drawer as home" had no width and ran under its own
  right-aligned switch.

**Clip** — `LV_LABEL_LONG_DOT` only ellipsizes against the object's *height*,
and a label defaults to `LV_SIZE_CONTENT`. With no height set it wraps and grows
instead of getting its dots:

* **Settings → Wi-Fi** status ran into the network list; **Files** address bar
  grew under the file list. Both had a comment promising one line — now pinned.
* **Bluetooth pairing hint** and the channel **"Region & scope"** hint had no
  width at all and ran off the edge.

Worth noting how many of these only bite in a **non-English** build.
`i18n_builtin.h` carries German, Hungarian and Dutch, all markedly longer than
English, and these layouts were sized against English alone. The Bluetooth one
already overflows in English.

Two sweep findings are deliberately **not** changed, and I'd rather say so than
have them look overlooked:

* The Discover feed's `LV_LABEL_LONG_CLIP` is load-bearing — the comment records
  that one line per row is what makes the tap-to-add Y→row mapping work. Its
  clipped trailing columns are a content-priority question, not a layout bug.
* Compact chat rows bake their offsets into the virtualised list while the
  delivery glyph is in one state; a later glyph change grows the row into the
  next. Fixing that means re-measuring on delivery-state change — that's the
  chat virtualisation and deserves its own change with its own testing.

### Testing

Builds clean on all 8 environments including T-Deck and Heltec V4 TFT. The GPS
page is verified on M9 hardware; the rest are reasoned from the layout code.
