### PR TITLE
Measure GPS acquisition from when it started, not when you looked

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -51368,6 +51368,10 @@ void UITask::begin(DisplayDriver* display, SensorManager* sensors, NodePrefs* no
   // reliably starts the NMEA reader.
   if (_sensors && _node_prefs && _node_prefs->gps_enabled) {
     _sensors->setSettingValue("gps", "1");
+    // Same reason as toggleGPS: without this the acquisition clock would start
+    // whenever the user first opened the GPS page, not at the boot that actually
+    // started the receiver.
+    { const uint32_t t = millis(); s_gps_acq_since = t ? t : 1u; }
   }
   // Map options exposes the same source toggle on T-Deck and T-Pager. Restore
   // that choice on both boards; forcing it off on Pager made a selected SD pack
@@ -52853,6 +52857,15 @@ void UITask::toggleGPS() {
   // still consistent — same behaviour as before.
   (void)hw_ok;
   _node_prefs->gps_enabled = target_on ? 1 : 0;
+  // Start the acquisition clock HERE. It used to be stamped lazily on the first
+  // gpsStatusStr() call, and that function only runs from the GPS settings page
+  // and the Control Center chip — so the "searching Nm" figure measured time
+  // since the user first LOOKED at it, not since the GPS was switched on. A
+  // receiver that had been searching for twenty minutes reported "0m02s" the
+  // moment you opened the page, which reads as "it only starts when I navigate
+  // here". Non-zero sentinel: millis() can legitimately be 0 at boot, and
+  // gpsStatusStr treats 0 as "not started yet".
+  { const uint32_t t = millis(); s_gps_acq_since = target_on ? (t ? t : 1u) : 0u; }
   the_mesh.savePrefs();
 }
 


### PR DESCRIPTION
Reported as "GPS only seems to start when I navigate into the GPS view, even
though it's toggled on". The receiver is fine — the **timer is measuring the
wrong thing**.

`s_gps_acq_since` is stamped in exactly one place: lazily inside
`gpsStatusStr()`, on its first call (`UITask.cpp:2585`). And `gpsStatusStr()` is
only ever called from four sites — the GPS settings page (build + live refresh)
and the Control Center GPS chip (build + refresh).

So `"GPS: searching Nm"` measures **time since you first looked at the status**,
not since the receiver was switched on. Boot with GPS enabled, walk around for
twenty minutes, then open the GPS page: it reports `searching 0m02s`, exactly as
if the module had just come up.

The GPS itself starts correctly. `UITask::begin` already re-applies the saved
`gps_enabled` pref at boot, and the M9 sets `ENV_SKIP_GPS_DETECT=1` so the
boot-time detect race can't suppress it.

### Fix

Stamp the clock where the state actually changes — in `toggleGPS()` and at the
boot resume — and keep the lazy stamp in `gpsStatusStr()` as a fallback. Both
new sites use a non-zero sentinel, because `millis()` can legitimately be 0 at
boot and `gpsStatusStr()` treats 0 as "not started yet".

### Why it's worth fixing rather than shrugging at

The comment above that string explains the design: the driver exposes no
satellites-in-view, no SNR and no HDOP, so it deliberately reports *how long it
has been trying* and points at the remedy. The elapsed figure **is** the
diagnostic — and it was reporting the wrong quantity, in the one place a user
goes to work out whether their GPS is broken or just cold.

### Testing

Builds clean on M9, LilyGo T-Deck and Heltec V4 TFT. Behaviour change is confined
to when the timestamp is taken; the string and its formatting are untouched.
