### PR TITLE
touch: a long name no longer pushes the author into the message body

### DIFF
--- a/src/ui-touch/ChannelSenderSplit.h
+++ b/src/ui-touch/ChannelSenderSplit.h
@@ -11,6 +11,11 @@
 // and show only the body underneath.
 namespace ChannelSenderSplit {
 
+// The widest author a channel post can legitimately name. MeshCore keeps every
+// name in a char[32] (ContactInfo::name, ChannelDetails::name,
+// NodePrefs::node_name), so 31 characters is the whole wire width.
+constexpr size_t kMaxWireName = 31;
+
 // Copies the embedded author into `sender_out` (always NUL-terminated, empty when
 // there is nothing to split) and returns the start of the body — `text` itself
 // when the string carries no author prefix.
@@ -19,6 +24,13 @@ namespace ChannelSenderSplit {
 // run to 31 chars while UIMessage::sender holds 24, and refusing the split for
 // the overflowing ones is what put the channel name in the bubble header and left
 // "nick: message" in the body.
+//
+// A prefix wider than kMaxWireName is a different thing entirely and IS rejected:
+// no name can be that long, so the ": " belongs to an unprefixed message ("the
+// repeater at Ouderkerk: it works"). Splitting there would invent an author and
+// hide the start of the body. That plausibility check is what the old
+// `slen <= MAX_SENDER_NAME` test provided; it has to be the WIRE width and not
+// the destination width, or a long real name gets rejected all over again.
 //
 // A truncated name ends in "..." (ASCII, like chatFitLeadingEllipsis — the baked
 // fonts carry no U+2026), so a cut name reads as cut rather than as a different
@@ -31,6 +43,7 @@ inline const char* split(const char* text, char* sender_out, size_t sender_cap) 
 
   const char* colon = strstr(text, ": ");
   if (!colon || colon == text) return text;
+  if (static_cast<size_t>(colon - text) > kMaxWireName) return text;   // not a name — see above
 
   static const char kEllipsis[] = "...";
   const size_t kEllipsisLen = sizeof(kEllipsis) - 1;

--- a/src/ui-touch/ChannelSenderSplit.h
+++ b/src/ui-touch/ChannelSenderSplit.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+// A channel/group post arrives on the wire as "SenderName: body" — the author is
+// part of the text, not a separate field (unlike a DM, where the sender rides
+// along as from_name). Split it so the UI can label the bubble with the author
+// and show only the body underneath.
+namespace ChannelSenderSplit {
+
+// Copies the embedded author into `sender_out` (always NUL-terminated, empty when
+// there is nothing to split) and returns the start of the body — `text` itself
+// when the string carries no author prefix.
+//
+// A name longer than the destination is TRUNCATED, not rejected. MeshCore names
+// run to 31 chars while UIMessage::sender holds 24, and refusing the split for
+// the overflowing ones is what put the channel name in the bubble header and left
+// "nick: message" in the body.
+//
+// A truncated name ends in "..." (ASCII, like chatFitLeadingEllipsis — the baked
+// fonts carry no U+2026), so a cut name reads as cut rather than as a different
+// node with a shorter name. The marker is part of the stored sender, so the
+// bubble label, the chat-list preview and block-by-name all agree on one string.
+inline const char* split(const char* text, char* sender_out, size_t sender_cap) {
+  if (sender_out && sender_cap > 0) sender_out[0] = '\0';
+  if (!text) return "";
+  if (!sender_out || sender_cap < 2) return text;
+
+  const char* colon = strstr(text, ": ");
+  if (!colon || colon == text) return text;
+
+  static const char kEllipsis[] = "...";
+  const size_t kEllipsisLen = sizeof(kEllipsis) - 1;
+
+  const size_t cap = sender_cap - 1;   // bytes available, NUL excluded
+  size_t slen = static_cast<size_t>(colon - text);
+  const bool truncated = slen > cap;
+  // Only mark when the name still gets at least as many bytes as the marker —
+  // on a destination too small for that, "nick" says more than "n...".
+  const bool mark = truncated && cap >= 2 * kEllipsisLen;
+  if (truncated) {
+    slen = mark ? cap - kEllipsisLen : cap;
+    // Never cut a multi-byte character in half: step back to the start of the
+    // sequence the cap lands inside, so the label gets valid UTF-8 rather than a
+    // stray '*' from the missing-glyph sanitiser.
+    while (slen > 0 && (static_cast<uint8_t>(text[slen]) & 0xC0U) == 0x80U) --slen;
+    if (slen == 0) return text;   // one long sequence and nothing fits — leave it whole
+  }
+
+  memcpy(sender_out, text, slen);
+  if (mark) {
+    memcpy(sender_out + slen, kEllipsis, kEllipsisLen);
+    slen += kEllipsisLen;
+  }
+  sender_out[slen] = '\0';
+  return colon + 2;
+}
+
+}  // namespace ChannelSenderSplit

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -128,6 +128,11 @@ static void* wadaMp3Scratch() { return s_wada_mp3_scratch; }
 #include "AppPage.h"          // shared full-screen app-page chrome (both of the above use it)
 #include "ReaderContent.h"    // host-tested HTML text extraction + local/network link resolution
 #include "ChannelSenderSplit.h"  // host-tested "SenderName: body" split for channel/room posts
+// The split refuses a "SenderName: " prefix wider than the wire can carry, so that cap
+// must never sit BELOW what UIMessage::sender can hold — otherwise a name the field
+// stores fine gets rejected as implausible and the author lands back in the body.
+static_assert(ChannelSenderSplit::kMaxWireName >= (size_t)UITask::MAX_SENDER_NAME,
+              "the split would reject a name UIMessage::sender can hold");
 
 #if defined(HAS_TOUCH_UI)
   #include <lvgl.h>

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -127,6 +127,7 @@ static void* wadaMp3Scratch() { return s_wada_mp3_scratch; }
 
 #include "AppPage.h"          // shared full-screen app-page chrome (both of the above use it)
 #include "ReaderContent.h"    // host-tested HTML text extraction + local/network link resolution
+#include "ChannelSenderSplit.h"  // host-tested "SenderName: body" split for channel/room posts
 
 #if defined(HAS_TOUCH_UI)
   #include <lvgl.h>
@@ -33576,15 +33577,10 @@ static void chatParseMessageDisplay(const UITask::UIMessage& m, bool channel_mod
        (channel_mode &&
         (m.sender[0] == '\0' ||
          (m.sender[0] == 'r' && m.sender[1] == 'x' && m.sender[2] == '\0'))))) {
-    const char* colon = strstr(m.text, ": ");
-    if (colon) {
-      const int slen = static_cast<int>(colon - m.text);
-      if (slen > 0 && slen <= UITask::MAX_SENDER_NAME) {
-        strncpy(d.retro_sender, m.text, slen);
-        d.retro_sender[slen] = '\0';
-        d.show_sender = d.retro_sender;
-        d.show_text   = colon + 2;
-      }
+    const char* body = ChannelSenderSplit::split(m.text, d.retro_sender, sizeof(d.retro_sender));
+    if (d.retro_sender[0]) {
+      d.show_sender = d.retro_sender;
+      d.show_text   = body;
     }
   }
   copyUtf8ReplacingMissingGlyphs(&g_font_12, d.san_sender, sizeof(d.san_sender), d.show_sender);
@@ -53598,17 +53594,8 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
   char parsed_sender[MAX_SENDER_NAME + 1];
   parsed_sender[0] = '\0';
   const char* body = text ? text : "";
-  if (channel && text && !have_sender_override) {
-    const char* colon = strstr(text, ": ");
-    if (colon) {
-      int slen = static_cast<int>(colon - text);
-      if (slen > 0 && slen <= MAX_SENDER_NAME) {
-        strncpy(parsed_sender, text, slen);
-        parsed_sender[slen] = '\0';
-        body = colon + 2;
-      }
-    }
-  }
+  if (channel && text && !have_sender_override)
+    body = ChannelSenderSplit::split(text, parsed_sender, sizeof(parsed_sender));
   const char* sender = have_sender_override
       ? sender_override
       : (channel

--- a/test/test_channel_sender_split.cpp
+++ b/test/test_channel_sender_split.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <assert.h>
+#include <string.h>
+
+#include "ui-touch/ChannelSenderSplit.h"
+
+// UIMessage::sender is char[MAX_SENDER_NAME + 1] with MAX_SENDER_NAME == 24.
+static const size_t kSenderCap = 25;
+
+int main() {
+  char sender[kSenderCap];
+
+  // Ordinary channel post: author out, body in.
+  const char* body = ChannelSenderSplit::split("nick: hello there", sender, sizeof sender);
+  assert(strcmp(sender, "nick") == 0);
+  assert(strcmp(body, "hello there") == 0);
+
+  // The regression: a 27-char MeshCore name (they run to 31) used to fail the
+  // split outright, so the bubble header showed the channel and the body kept
+  // reading "nick: message". It must split, truncating the label instead — and a
+  // truncated label ends in "..." so it does not read as a shorter name.
+  const char* long_name = "Ouderkerk Repeater Node Two: on air";
+  body = ChannelSenderSplit::split(long_name, sender, sizeof sender);
+  assert(strlen(sender) == 24);
+  assert(strcmp(sender, "Ouderkerk Repeater No...") == 0);
+  assert(strcmp(body, "on air") == 0);
+
+  // Truncation lands on a character boundary, never inside a multi-byte sequence.
+  // "Ouderkerkk" (10) + U+2600 (3 bytes) x 5 = 25 bytes; the 21-byte name budget
+  // (24 minus the marker) falls inside the fourth sun, so it backs off to 19.
+  const char* utf8_name = "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
+  body = ChannelSenderSplit::split(utf8_name, sender, sizeof sender);
+  assert(strcmp(sender, "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
+  assert(strlen(sender) == 22);
+  assert(strcmp(body, "hi") == 0);
+
+  // Same shape one char shorter, so the budget already sits on a boundary: the
+  // back-off must not eat a whole character that fits.
+  const char* utf8_fits = "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
+  body = ChannelSenderSplit::split(utf8_fits, sender, sizeof sender);
+  assert(strcmp(sender, "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
+  assert(strlen(sender) == 24);
+  assert(strcmp(body, "hi") == 0);
+
+  // One char over the cap still gets the marker (name budget 21, not 24).
+  const char* one_over = "1234567890123456789012345: body";
+  body = ChannelSenderSplit::split(one_over, sender, sizeof sender);
+  assert(strcmp(sender, "123456789012345678901...") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // Destination too small to hold a marker: truncate plainly rather than
+  // spending the whole label on dots.
+  char tiny[5];
+  body = ChannelSenderSplit::split("nickname: body", tiny, sizeof tiny);
+  assert(strcmp(tiny, "nick") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // Exactly at the cap: 24 chars, no truncation.
+  const char* exact = "123456789012345678901234: body";
+  body = ChannelSenderSplit::split(exact, sender, sizeof sender);
+  assert(strcmp(sender, "123456789012345678901234") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // No author prefix — text passes through untouched, sender stays empty so the
+  // caller falls back to from_name.
+  const char* plain = "just a message";
+  body = ChannelSenderSplit::split(plain, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == plain);
+
+  // A bare colon without the space is not a separator.
+  const char* no_space = "nick:hello";
+  body = ChannelSenderSplit::split(no_space, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == no_space);
+
+  // Leading separator: empty author is not a name.
+  const char* leading = ": body";
+  body = ChannelSenderSplit::split(leading, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == leading);
+
+  // First separator wins — a colon in the body does not re-split.
+  body = ChannelSenderSplit::split("nick: ratio 3: 1", sender, sizeof sender);
+  assert(strcmp(sender, "nick") == 0);
+  assert(strcmp(body, "ratio 3: 1") == 0);
+
+  // Degenerate inputs.
+  assert(strcmp(ChannelSenderSplit::split(nullptr, sender, sizeof sender), "") == 0);
+  assert(sender[0] == '\0');
+  const char* keep = "nick: hi";
+  assert(ChannelSenderSplit::split(keep, nullptr, 0) == keep);
+  return 0;
+}

--- a/test/test_channel_sender_split.cpp
+++ b/test/test_channel_sender_split.cpp
@@ -49,6 +49,30 @@ int main() {
   assert(strcmp(sender, "123456789012345678901...") == 0);
   assert(strcmp(body, "body") == 0);
 
+  // The widest name the wire can carry (31) still splits — truncated to the
+  // 24-char field with the marker, but the author is out of the body.
+  const char* widest = "1234567890123456789012345678901: body";
+  assert(strlen(widest) == 37);
+  body = ChannelSenderSplit::split(widest, sender, sizeof sender);
+  assert(strcmp(sender, "123456789012345678901...") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // One char PAST the wire width is not a name at all — no node can be called
+  // this — so the ": " belongs to the message. Leave the text whole rather than
+  // inventing an author and hiding the start of the body.
+  const char* not_a_name = "12345678901234567890123456789012: body";
+  assert(strlen(not_a_name) == 38);
+  body = ChannelSenderSplit::split(not_a_name, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == not_a_name);
+
+  // The realistic shape of that: an unprefixed post whose body just happens to
+  // contain ": ". It must survive intact.
+  const char* prose = "the repeater at Ouderkerk is back up: full quieting again";
+  body = ChannelSenderSplit::split(prose, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == prose);
+
   // Destination too small to hold a marker: truncate plainly rather than
   // spending the whole label on dots.
   char tiny[5];


### PR DESCRIPTION
# touch: a long name no longer pushes the author into the message body

## Summary

Occasionally a channel message rendered as

```
#channel      date
nick: message
```

instead of the author over their own message. It was not random — it happened for every post
from a node whose name is longer than 24 characters.

## Root cause

A channel post arrives on the wire as `"SenderName: body"` — the author is part of the text,
not a separate field (unlike a DM, where the sender rides along as `from_name`). Two places
split that prefix off, and both **gave up entirely** when the name was longer than
`MAX_SENDER_NAME` (24):

- `newMsgImpl` — on receive. Giving up meant `sender` fell back to `from_name`, which for a
  channel is the *channel* name, and `body` kept the whole `"nick: message"` string. That is
  the reported layout, and it is what got persisted.
- `chatParseMessageDisplay` — the render-time fallback for stored messages with no separate
  sender.

MeshCore names run to 31 characters (`ContactInfo::name[32]`), so the 24-char field could
never hold them — hence "occasionally".

## What this does

Truncates the label instead of rejecting the split, backing off to a UTF-8 character boundary
so a multi-byte name is never cut mid-sequence (the missing-glyph sanitiser would render the
tail as `*`), and marks the cut with `"..."` so a shortened name does not read as a different
node.

The two copies of the split are now one host-tested header, matching how `Utf8Text` and
`ReaderContent` are factored.

## The length test still has a job to do

Dropping `slen <= MAX_SENDER_NAME` outright went too far. That test was rejecting long names
— the bug — but it was *also* the only thing establishing that the prefix could plausibly BE
a name. Without it, a post that carries no author and merely contains `": "` gets read as one:

```
the repeater at Ouderkerk is back up: full quieting again
```

That is a 36-character "author", and splitting there invents a sender **and** hides the start
of the body — worse than the layout this PR set out to fix.

So the check comes back, at the **wire** width rather than the destination width:
`ChannelSenderSplit::kMaxWireName` is 31, because MeshCore keeps every name in a `char[32]`
(`ContactInfo::name`, `ChannelDetails::name`, `NodePrefs::node_name`). A 31-char name still
splits and truncates; a 32-plus prefix is left in the body where it belongs, which is exactly
what the code did before this PR for those inputs.

Getting the width wrong in either direction is a real bug, so it is pinned rather than
commented: a `static_assert` requires `kMaxWireName >= MAX_SENDER_NAME`, so widening the field
(#377) can never leave the split rejecting names the field holds fine.

**No record layout, version constant or stored file is touched by this PR.** Widening the
field is the real cure and is a separate change — it has a persistence-format argument to make
that does not belong in a display fix.

## Testing

```
c++ -std=c++17 -O2 -Wall -Wextra -Werror -I src test/test_channel_sender_split.cpp -o /tmp/t && /tmp/t
```

New host test covering: the ordinary split, the long-name regression, UTF-8 back-off on the
truncation boundary, a cap that already sits on a boundary, the widest name the wire can carry
(31, which must still split), one character past it (which must not), the prose case above,
no-prefix and bare-colon inputs, a colon inside the body, and a destination too small to hold
the marker.

Built clean on `LilyGo_TDeck_companion_radio_touch` and
`heltec_v4_tft_companion_radio_usb_tcp_touch`. Not exercised on physical hardware.

