### PR TITLE
touch: store the whole sender name, not the first 24 characters

### DIFF
--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -1728,13 +1728,56 @@ bool touchPrefsSetIgnored(const uint8_t* pub_key6, bool ignored) {
 }
 
 // Ignored / blocked sender NAMES (channel/room senders that aren't contacts) ---
-// One NVS blob "ign_nm" of up to TOUCH_IGNORED_NAMES_MAX fixed-width,
+// One NVS blob "ign_nm2" of up to TOUCH_IGNORED_NAMES_MAX fixed-width,
 // NUL-padded TOUCH_IGNORED_NAME_LEN slots. Same read/replace/write scheme as
 // the 6-byte prefix list above.
-static const char* KEY_IGN_NAMES = "ign_nm";
+// The blob carries no header — the entry count is derived by dividing its length by the
+// slot width — so widening the slot re-slots every stored entry: slot 1 would start inside
+// the old name 0, every row after the first would render as a mangled suffix and would stop
+// matching, and the first write back would make that permanent. A new key sidesteps it: the
+// old blob is read once with the OLD stride, re-slotted, written here, and removed. A key
+// rename is unambiguous by construction, unlike sniffing the blob length (28 and 32 share
+// multiples at 224 and 448 bytes, both inside the 16-entry cap).
+static const char* KEY_IGN_NAMES     = "ign_nm2";
+static const char* KEY_IGN_NAMES_V1  = "ign_nm";
+constexpr int      TOUCH_IGN_NAME_LEN_V1 = 28;
+
+// One-shot: fold a pre-widening "ign_nm" blob into the current key. No-op once migrated
+// (and on a fresh device, where neither key exists). Latched for the boot because the
+// caller runs on the RX path for EVERY incoming message — two NVS key lookups per message
+// is not a price worth paying for a check that can only change once.
+static bool s_ign_names_migrated = false;
+
+static void ignNamesMigrateV1() {
+  if (s_ign_names_migrated) return;
+  s_ign_names_migrated = true;
+  if (!s_begun) touchPrefsBegin();
+  if (s_prefs.isKey(KEY_IGN_NAMES) || !s_prefs.isKey(KEY_IGN_NAMES_V1)) return;
+
+  char old_buf[TOUCH_IGNORED_NAMES_MAX * TOUCH_IGN_NAME_LEN_V1];
+  size_t n = s_prefs.getBytes(KEY_IGN_NAMES_V1, old_buf, sizeof(old_buf));
+  const int count = (n == 0 || n > sizeof(old_buf)) ? 0 : (int)(n / TOUCH_IGN_NAME_LEN_V1);
+
+  char buf[TOUCH_IGNORED_NAMES_MAX * TOUCH_IGNORED_NAME_LEN];
+  memset(buf, 0, sizeof(buf));
+  for (int i = 0; i < count; ++i) {
+    // Old slots hold at most 27 chars, so they always fit the wider one.
+    strncpy(&buf[i * TOUCH_IGNORED_NAME_LEN], &old_buf[i * TOUCH_IGN_NAME_LEN_V1],
+            TOUCH_IGN_NAME_LEN_V1 - 1);
+  }
+
+  s_prefs.end();
+  if (s_prefs.begin(TOUCH_NS, false)) {
+    if (count > 0) s_prefs.putBytes(KEY_IGN_NAMES, buf, (size_t)(count * TOUCH_IGNORED_NAME_LEN));
+    s_prefs.remove(KEY_IGN_NAMES_V1);   // drop the old key either way: it can only mis-read now
+    s_prefs.end();
+  }
+  s_begun = s_prefs.begin(TOUCH_NS, true);
+}
 
 static int ignNamesReadAll(char out[TOUCH_IGNORED_NAMES_MAX * TOUCH_IGNORED_NAME_LEN]) {
   if (!s_begun) touchPrefsBegin();
+  ignNamesMigrateV1();
   if (!s_prefs.isKey(KEY_IGN_NAMES)) return 0;   // absent on a fresh device — skip [E] NOT_FOUND
   size_t n = s_prefs.getBytes(KEY_IGN_NAMES, out, TOUCH_IGNORED_NAMES_MAX * TOUCH_IGNORED_NAME_LEN);
   if (n == 0 || n > (size_t)(TOUCH_IGNORED_NAMES_MAX * TOUCH_IGNORED_NAME_LEN)) return 0;

--- a/src/helpers/esp32/TouchPrefsStore.cpp
+++ b/src/helpers/esp32/TouchPrefsStore.cpp
@@ -1750,9 +1750,11 @@ static bool s_ign_names_migrated = false;
 
 static void ignNamesMigrateV1() {
   if (s_ign_names_migrated) return;
-  s_ign_names_migrated = true;
   if (!s_begun) touchPrefsBegin();
-  if (s_prefs.isKey(KEY_IGN_NAMES) || !s_prefs.isKey(KEY_IGN_NAMES_V1)) return;
+  if (s_prefs.isKey(KEY_IGN_NAMES) || !s_prefs.isKey(KEY_IGN_NAMES_V1)) {
+    s_ign_names_migrated = true;   // nothing to fold in, now or on any later call
+    return;
+  }
 
   char old_buf[TOUCH_IGNORED_NAMES_MAX * TOUCH_IGN_NAME_LEN_V1];
   size_t n = s_prefs.getBytes(KEY_IGN_NAMES_V1, old_buf, sizeof(old_buf));
@@ -1767,12 +1769,20 @@ static void ignNamesMigrateV1() {
   }
 
   s_prefs.end();
+  bool ok = false;
   if (s_prefs.begin(TOUCH_NS, false)) {
-    if (count > 0) s_prefs.putBytes(KEY_IGN_NAMES, buf, (size_t)(count * TOUCH_IGNORED_NAME_LEN));
-    s_prefs.remove(KEY_IGN_NAMES_V1);   // drop the old key either way: it can only mis-read now
+    ok = (count == 0) ||
+         s_prefs.putBytes(KEY_IGN_NAMES, buf, (size_t)(count * TOUCH_IGNORED_NAME_LEN)) > 0;
+    if (ok) s_prefs.remove(KEY_IGN_NAMES_V1);   // only once the new key actually holds the list
     s_prefs.end();
   }
   s_begun = s_prefs.begin(TOUCH_NS, true);
+  // Latch on SUCCESS only. Latching a failed fold would leave the list reading empty for
+  // the rest of the boot — every block silently stops firing — and the next Block tap
+  // would then write a fresh ign_nm2 that orphans every old entry for good. Retrying
+  // costs the two key lookups per message the latch exists to avoid, but only while the
+  // store is already refusing writes.
+  s_ign_names_migrated = ok;
 }
 
 static int ignNamesReadAll(char out[TOUCH_IGNORED_NAMES_MAX * TOUCH_IGNORED_NAME_LEN]) {

--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -392,7 +392,13 @@ int  touchPrefsCopyIgnored(uint8_t* out_buf);
  *  • touchPrefsCopyIgnoredNames: copy every stored name into `out_buf`
  *    (>= TOUCH_IGNORED_NAMES_MAX * TOUCH_IGNORED_NAME_LEN bytes); returns count. */
 constexpr int TOUCH_IGNORED_NAMES_MAX = 16;
-constexpr int TOUCH_IGNORED_NAME_LEN  = 28;   // fixed NUL-padded slot (>= MAX_SENDER_NAME+1)
+// Fixed NUL-padded slot, and it MUST stay >= UITask::MAX_SENDER_NAME + 1 — a slot narrower
+// than a sender stores a cut name that the full-width RX check can never match again, so
+// the block shows in the list and silently never fires. That invariant was prose only; it
+// is now a static_assert in UITask.cpp. Widened 28 -> 32 with MAX_SENDER_NAME 24 -> 31; the
+// slot width is baked into the stored blob (the entry count is its length / this), so the
+// key was renamed in the same change to migrate rather than mis-slot the old one.
+constexpr int TOUCH_IGNORED_NAME_LEN  = 32;
 bool touchPrefsIsNameIgnored(const char* name);
 bool touchPrefsSetNameIgnored(const char* name, bool ignored);
 int  touchPrefsCopyIgnoredNames(char* out_buf);

--- a/src/ui-touch/ChannelSenderSplit.h
+++ b/src/ui-touch/ChannelSenderSplit.h
@@ -11,6 +11,11 @@
 // and show only the body underneath.
 namespace ChannelSenderSplit {
 
+// The widest author a channel post can legitimately name. MeshCore keeps every
+// name in a char[32] (ContactInfo::name, ChannelDetails::name,
+// NodePrefs::node_name), so 31 characters is the whole wire width.
+constexpr size_t kMaxWireName = 31;
+
 // Copies the embedded author into `sender_out` (always NUL-terminated, empty when
 // there is nothing to split) and returns the start of the body — `text` itself
 // when the string carries no author prefix.
@@ -19,6 +24,13 @@ namespace ChannelSenderSplit {
 // run to 31 chars while UIMessage::sender holds 24, and refusing the split for
 // the overflowing ones is what put the channel name in the bubble header and left
 // "nick: message" in the body.
+//
+// A prefix wider than kMaxWireName is a different thing entirely and IS rejected:
+// no name can be that long, so the ": " belongs to an unprefixed message ("the
+// repeater at Ouderkerk: it works"). Splitting there would invent an author and
+// hide the start of the body. That plausibility check is what the old
+// `slen <= MAX_SENDER_NAME` test provided; it has to be the WIRE width and not
+// the destination width, or a long real name gets rejected all over again.
 //
 // A truncated name ends in "..." (ASCII, like chatFitLeadingEllipsis — the baked
 // fonts carry no U+2026), so a cut name reads as cut rather than as a different
@@ -31,6 +43,7 @@ inline const char* split(const char* text, char* sender_out, size_t sender_cap) 
 
   const char* colon = strstr(text, ": ");
   if (!colon || colon == text) return text;
+  if (static_cast<size_t>(colon - text) > kMaxWireName) return text;   // not a name — see above
 
   static const char kEllipsis[] = "...";
   const size_t kEllipsisLen = sizeof(kEllipsis) - 1;

--- a/src/ui-touch/ChannelSenderSplit.h
+++ b/src/ui-touch/ChannelSenderSplit.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+// A channel/group post arrives on the wire as "SenderName: body" — the author is
+// part of the text, not a separate field (unlike a DM, where the sender rides
+// along as from_name). Split it so the UI can label the bubble with the author
+// and show only the body underneath.
+namespace ChannelSenderSplit {
+
+// Copies the embedded author into `sender_out` (always NUL-terminated, empty when
+// there is nothing to split) and returns the start of the body — `text` itself
+// when the string carries no author prefix.
+//
+// A name longer than the destination is TRUNCATED, not rejected. MeshCore names
+// run to 31 chars while UIMessage::sender holds 24, and refusing the split for
+// the overflowing ones is what put the channel name in the bubble header and left
+// "nick: message" in the body.
+//
+// A truncated name ends in "..." (ASCII, like chatFitLeadingEllipsis — the baked
+// fonts carry no U+2026), so a cut name reads as cut rather than as a different
+// node with a shorter name. The marker is part of the stored sender, so the
+// bubble label, the chat-list preview and block-by-name all agree on one string.
+inline const char* split(const char* text, char* sender_out, size_t sender_cap) {
+  if (sender_out && sender_cap > 0) sender_out[0] = '\0';
+  if (!text) return "";
+  if (!sender_out || sender_cap < 2) return text;
+
+  const char* colon = strstr(text, ": ");
+  if (!colon || colon == text) return text;
+
+  static const char kEllipsis[] = "...";
+  const size_t kEllipsisLen = sizeof(kEllipsis) - 1;
+
+  const size_t cap = sender_cap - 1;   // bytes available, NUL excluded
+  size_t slen = static_cast<size_t>(colon - text);
+  const bool truncated = slen > cap;
+  // Only mark when the name still gets at least as many bytes as the marker —
+  // on a destination too small for that, "nick" says more than "n...".
+  const bool mark = truncated && cap >= 2 * kEllipsisLen;
+  if (truncated) {
+    slen = mark ? cap - kEllipsisLen : cap;
+    // Never cut a multi-byte character in half: step back to the start of the
+    // sequence the cap lands inside, so the label gets valid UTF-8 rather than a
+    // stray '*' from the missing-glyph sanitiser.
+    while (slen > 0 && (static_cast<uint8_t>(text[slen]) & 0xC0U) == 0x80U) --slen;
+    if (slen == 0) return text;   // one long sequence and nothing fits — leave it whole
+  }
+
+  memcpy(sender_out, text, slen);
+  if (mark) {
+    memcpy(sender_out + slen, kEllipsis, kEllipsisLen);
+    slen += kEllipsisLen;
+  }
+  sender_out[slen] = '\0';
+  return colon + 2;
+}
+
+}  // namespace ChannelSenderSplit

--- a/src/ui-touch/SenderExtField.h
+++ b/src/ui-touch/SenderExtField.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <stddef.h>
+#include <string.h>
+
+// A stored sender name is split across two on-disk fields: the head lives in the frozen
+// UiHistoryMsg::sender, and anything past it in UiSegMsg::sender_ext, which is appended at
+// the very end of the segment record. The split exists so the record can hold a full-width
+// name without moving any pre-existing field — see the comment on UiSegMsg::sender_ext.
+//
+// Nothing outside the persistence layer sees the split: UIMessage::sender is one string,
+// and these two calls are the only places the halves come apart and go back together.
+//
+// A multi-byte character may straddle the boundary. That is harmless — the halves are
+// always rejoined before the name is measured, drawn or compared — so this deliberately
+// does NOT try to split on a character boundary, which would waste bytes of a field sized
+// to hold the longest name exactly.
+namespace SenderExtField {
+
+// Writes `sender` into the two destination fields. `base` is always NUL-terminated; `ext`
+// carries the overflow and is NOT NUL-terminated when it is full (it is a fixed-width tail,
+// and its length is implied by base being full). Both are zero-filled first, so a short
+// name leaves a clean record.
+inline void store(const char* sender, char* base, size_t base_cap, char* ext, size_t ext_cap) {
+  if (base && base_cap > 0) memset(base, 0, base_cap);
+  if (ext && ext_cap > 0) memset(ext, 0, ext_cap);
+  if (!sender || !base || base_cap == 0) return;
+
+  // Walked with a pointer rather than indexed + memcpy'd: the copy length and the bounds
+  // check are then the same expression, which keeps -Warray-bounds quiet on inlined
+  // short literals. These are 31 bytes at most, so byte-at-a-time costs nothing.
+  const char* p = sender;
+  size_t head = 0;
+  while (head + 1 < base_cap && *p) base[head++] = *p++;
+  base[head] = '\0';
+  if (head + 1 < base_cap || !ext || ext_cap == 0) return;   // fitted, or nowhere to spill
+
+  size_t tail = 0;
+  while (tail < ext_cap && *p) ext[tail++] = *p++;
+}
+
+// Rejoins the two fields into `out`. Reads are bounded by the FIELD sizes, not by strlen:
+// a corrupt record may leave `base` unterminated, and it is followed on disk by the message
+// body, so an unbounded read would splice the text onto the name.
+inline void load(const char* base, size_t base_cap, const char* ext, size_t ext_cap,
+                 char* out, size_t out_cap) {
+  if (!out || out_cap == 0) return;
+  out[0] = '\0';
+  if (!base || base_cap == 0) return;
+
+  const size_t head_cap = base_cap - 1;
+  const char* p = base;
+  size_t head = 0;
+  while (head < head_cap && head + 1 < out_cap && *p) out[head++] = *p++;
+  out[head] = '\0';
+
+  // The tail only means anything when the head field is exactly full — that is the only
+  // way a name could have spilled. Anything else is an old record's zero-fill or garbage
+  // behind a short name, and must not be appended.
+  if (head != head_cap || !ext || ext_cap == 0) return;
+
+  const char* q = ext;
+  size_t n = head;
+  size_t tail = 0;
+  while (tail < ext_cap && n + 1 < out_cap && *q) { out[n++] = *q++; ++tail; }
+  out[n] = '\0';
+}
+
+}  // namespace SenderExtField

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -128,6 +128,7 @@ static void* wadaMp3Scratch() { return s_wada_mp3_scratch; }
 #include "AppPage.h"          // shared full-screen app-page chrome (both of the above use it)
 #include "ReaderContent.h"    // host-tested HTML text extraction + local/network link resolution
 #include "ChannelSenderSplit.h"  // host-tested "SenderName: body" split for channel/room posts
+#include "SenderExtField.h"   // host-tested split/rejoin of a sender across the two on-disk fields
 // The split refuses a "SenderName: " prefix wider than the wire can carry, so that cap
 // must never sit BELOW what UIMessage::sender can hold — otherwise a name the field
 // stores fine gets rejected as implausible and the author lands back in the body.
@@ -193,6 +194,11 @@ static_assert(ChannelSenderSplit::kMaxWireName >= (size_t)UITask::MAX_SENDER_NAM
     // its include path, so an angle include picks that up and misses accessors we
     // add here (e.g. the signal-probe prefs). Quotes force the local src/ copy.
     #include "../helpers/esp32/TouchPrefsStore.h"
+    // A block-list slot narrower than a sender name stores a cut name that the full-width
+    // RX check can never match again — the block shows in Settings and silently never
+    // fires. TouchPrefsStore.h stated this invariant in prose; prose is what let it rot.
+    static_assert(TOUCH_IGNORED_NAME_LEN >= UITask::MAX_SENDER_NAME + 1,
+                  "block-list slot must hold a full sender name, or blocking silently stops working");
     #include "../helpers/esp32/WebMirror.h"   // web UI mirror (framebuffer + pointer bridge)
     #include "../helpers/ClockFloorRTC.h"
     extern ClockFloorRTC rtc_clock;   // the board clock (variants/*/target.cpp); its send-timestamp floor is seeded/persisted from here (#89)
@@ -314,6 +320,15 @@ struct __attribute__((packed)) UiHistoryThread {
   char name[UITask::MAX_THREAD_NAME + 1];
 };
 
+// On-disk width of UiHistoryMsg::sender, FROZEN at what v6 blobs were written with.
+// Deliberately NOT tied to UITask::MAX_SENDER_NAME: `sender` sits between `thread` and
+// `text`, so growing it in place shifts `text` for every already-stored record. Nothing
+// detects that — the segment loader validates only magic/version/rec_size, so an old
+// record would prefix-read into the new offsets and every message would silently lose
+// the first bytes of its body. A sender too long for this field spills into
+// UiSegMsg::sender_ext instead (see SenderExtField.h).
+constexpr int k_ui_disk_sender_len = 25;   // == the historical MAX_SENDER_NAME + 1
+
 struct __attribute__((packed)) UiHistoryMsg {
   uint32_t ts;
   uint8_t channel;
@@ -328,7 +343,7 @@ struct __attribute__((packed)) UiHistoryMsg {
   int8_t  snr_q4;
   int8_t  rssi;
   char thread[UITask::MAX_THREAD_NAME + 1];
-  char sender[UITask::MAX_SENDER_NAME + 1];
+  char sender[k_ui_disk_sender_len];
   char text[UITask::MAX_MSG_TEXT + 1];
   // Append any FUTURE fields HERE (after text) and bump k_ui_history_version.
   // The v5+ loader zero-fills appended fields for older blobs, so appending
@@ -392,7 +407,27 @@ struct __attribute__((packed)) UiSegHeader {
 struct __attribute__((packed)) UiSegMsg {
   UiHistoryMsg m;
   uint32_t     seq;
+  // Names run to 31 chars on the wire (MeshCore's ContactInfo::name[32]) but m.sender
+  // freezes at the 24 the v6 record was written with. The tail lives HERE, appended at
+  // the very end — after seq, not inside m — so every pre-existing field keeps its
+  // offset and the min(rec_size) prefix read stays correct in BOTH directions: an old
+  // 233-byte record zero-fills this and yields its original short name, and an older
+  // firmware reading this 240-byte record copies the first 233 bytes and ignores the
+  // tail (the name falls back to 24 chars, nothing else changes). That is why
+  // k_ui_seg_version STAYS 1 — bumping it would make that older firmware reject the
+  // file outright (uiSegOpenValidated rejects version > k_ui_seg_version) and quarantine
+  // a perfectly readable history. Split/rejoin lives in SenderExtField.h.
+  char         sender_ext[UITask::MAX_SENDER_NAME + 1 - k_ui_disk_sender_len];
 };
+
+// Pin what an ALREADY-WRITTEN record's reader depends on. These are offsets, not the total
+// size, precisely because appending further fields at the tail stays safe — what must never
+// move is anything a v6-era record already holds, since nothing on the read path would
+// detect the shift. Growing the record past these offsets is fine; moving them is not.
+static_assert(sizeof(UiHistoryMsg) == 229, "v6 record layout changed — old blobs would mis-read");
+static_assert(offsetof(UiSegMsg, seq) == 229, "seq moved — old segments would mis-read");
+static_assert(offsetof(UiSegMsg, sender_ext) == 233,
+              "the appended tail must start where the old record ended, or old segments mis-read");
 } // namespace
 #endif
 
@@ -45288,7 +45323,7 @@ static void openBlockedUsersModal() {
     for (int j = 0; j < nc; ++j) {
       if (the_mesh.getContactByIdx((uint32_t)j, c) &&
           memcmp(c.id.pub_key, pub6, TOUCH_IGNORE_KEY_BYTES) == 0) {
-        snprintf(nm, sizeof nm, "%.24s", c.name); named = true; break;
+        snprintf(nm, sizeof nm, "%.31s", c.name); named = true; break;   // full name width
       }
     }
     if (!named) snprintf(nm, sizeof nm, "%02X%02X%02X%02X%02X%02X",
@@ -45337,7 +45372,7 @@ static void openBlockedUsersModal() {
 
     lv_obj_t* lbl = lv_label_create(row);
     char shown[40];
-    snprintf(shown, sizeof shown, "%.24s", nm);   // name-only entry
+    snprintf(shown, sizeof shown, "%.31s", nm);   // name-only entry, full name width
     lv_label_set_text(lbl, shown);
     lv_label_set_long_mode(lbl, LV_LABEL_LONG_DOT);
     lv_obj_set_width(lbl, sw - 16 - 96);
@@ -49302,8 +49337,8 @@ bool UITask::loadMsgsFromStorage() {
     d.rssi       = m.rssi;
     strncpy(d.thread, m.thread, MAX_THREAD_NAME);
     d.thread[MAX_THREAD_NAME] = '\0';
-    strncpy(d.sender, m.sender, MAX_SENDER_NAME);
-    d.sender[MAX_SENDER_NAME] = '\0';
+    strncpy(d.sender, m.sender, sizeof(m.sender) - 1);   // source is the frozen disk width
+    d.sender[sizeof(m.sender) - 1] = '\0';
     strncpy(d.text, m.text, MAX_MSG_TEXT);
     d.text[MAX_MSG_TEXT] = '\0';
   }
@@ -49623,8 +49658,8 @@ bool UITask::loadLegacyHistoryFromStorage() {
       _ui_msgs[i].rssi       = m.rssi;
       strncpy(_ui_msgs[i].thread, m.thread, MAX_THREAD_NAME);
       _ui_msgs[i].thread[MAX_THREAD_NAME] = '\0';
-      strncpy(_ui_msgs[i].sender, m.sender, MAX_SENDER_NAME);
-      _ui_msgs[i].sender[MAX_SENDER_NAME] = '\0';
+      strncpy(_ui_msgs[i].sender, m.sender, sizeof(m.sender) - 1);   // frozen disk width
+      _ui_msgs[i].sender[sizeof(m.sender) - 1] = '\0';
       strncpy(_ui_msgs[i].text, m.text, MAX_MSG_TEXT);
       _ui_msgs[i].text[MAX_MSG_TEXT] = '\0';
     } else {
@@ -49842,8 +49877,8 @@ static void uiSegMarshal(const UITask::UIMessage& s, UiSegMsg* d) {
   d->m.rssi       = s.rssi;
   strncpy(d->m.thread, s.thread, sizeof(d->m.thread) - 1);
   d->m.thread[sizeof(d->m.thread) - 1] = '\0';
-  strncpy(d->m.sender, s.sender, sizeof(d->m.sender) - 1);
-  d->m.sender[sizeof(d->m.sender) - 1] = '\0';
+  SenderExtField::store(s.sender, d->m.sender, sizeof(d->m.sender),
+                        d->sender_ext, sizeof(d->sender_ext));
   strncpy(d->m.text, s.text, sizeof(d->m.text) - 1);
   d->m.text[sizeof(d->m.text) - 1] = '\0';
   d->seq = s.seq;
@@ -50041,8 +50076,9 @@ static bool uiSegReadRec(File& f, uint16_t disk_sz, UITask::UIMessage* out, uint
   out->rssi       = rec.m.rssi;
   strncpy(out->thread, rec.m.thread, UITask::MAX_THREAD_NAME);
   out->thread[UITask::MAX_THREAD_NAME] = '\0';
-  strncpy(out->sender, rec.m.sender, UITask::MAX_SENDER_NAME);
-  out->sender[UITask::MAX_SENDER_NAME] = '\0';
+  SenderExtField::load(rec.m.sender, sizeof(rec.m.sender),
+                       rec.sender_ext, sizeof(rec.sender_ext),
+                       out->sender, sizeof(out->sender));
   strncpy(out->text, rec.m.text, UITask::MAX_MSG_TEXT);
   out->text[UITask::MAX_MSG_TEXT] = '\0';
   out->seq = rec.seq;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -128,6 +128,11 @@ static void* wadaMp3Scratch() { return s_wada_mp3_scratch; }
 #include "AppPage.h"          // shared full-screen app-page chrome (both of the above use it)
 #include "ReaderContent.h"    // host-tested HTML text extraction + local/network link resolution
 #include "ChannelSenderSplit.h"  // host-tested "SenderName: body" split for channel/room posts
+// The split refuses a "SenderName: " prefix wider than the wire can carry, so that cap
+// must never sit BELOW what UIMessage::sender can hold — otherwise a name the field
+// stores fine gets rejected as implausible and the author lands back in the body.
+static_assert(ChannelSenderSplit::kMaxWireName >= (size_t)UITask::MAX_SENDER_NAME,
+              "the split would reject a name UIMessage::sender can hold");
 
 #if defined(HAS_TOUCH_UI)
   #include <lvgl.h>

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -417,6 +417,14 @@ struct __attribute__((packed)) UiSegMsg {
   // k_ui_seg_version STAYS 1 — bumping it would make that older firmware reject the
   // file outright (uiSegOpenValidated rejects version > k_ui_seg_version) and quarantine
   // a perfectly readable history. Split/rejoin lives in SenderExtField.h.
+  //
+  // Rollback caveat, since two widths now exist in the wild: an older firmware READS
+  // this record correctly, but if it then APPENDS to the same segment it writes 233-byte
+  // records into a file whose header says 240, and everything after them reads at the
+  // wrong stride. Nothing on this side can prevent that (the write is the old build's),
+  // and a version bump would not help either — it would only make the old build reject
+  // the file instead. Our own direction of the same hazard IS handled: see the width
+  // check in loadMsgsFromSegments, which refuses to append across widths.
   char         sender_ext[UITask::MAX_SENDER_NAME + 1 - k_ui_disk_sender_len];
 };
 
@@ -49417,6 +49425,17 @@ bool UITask::loadMsgsFromSegments() {
     info.disk_recs = nrec;
     info.live_recs = nrec;
     info.bytes     = (uint32_t)sizeof(UiSegHeader) + (uint32_t)nrec * (uint32_t)rec_sz;
+    // A segment written at a DIFFERENT record width can be READ fine (the header is
+    // self-describing, and readHistoryRec prefix-reads or skips the surplus), but it
+    // must never be APPENDED to: the append writes sizeof(UiSegMsg) while the header
+    // still says rec_sz, so every record after the appended one is read at the wrong
+    // stride — silent garbage bubbles, a poisoned seq (which then drops every later
+    // segment), and the next compaction makes it permanent. Only a NON-FULL segment
+    // can ever receive an append, so flag just those for a full rewrite; step 0 of
+    // segBuildJob runs that before any append, and the rewrite lays down a fresh
+    // header at the current width. A full old-width segment is left alone — it is
+    // read correctly by its own header and costs nothing.
+    if ((size_t)rec_sz != sizeof(UiSegMsg) && nrec < k_ui_seg_records) info.rewrite_open = 1;
     // The file holds records the table doesn't account for — rewrite it so disk
     // and table agree again (also drops the dead weight for good).
     if (skipped) info.rewrite_open = 1;

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -127,6 +127,7 @@ static void* wadaMp3Scratch() { return s_wada_mp3_scratch; }
 
 #include "AppPage.h"          // shared full-screen app-page chrome (both of the above use it)
 #include "ReaderContent.h"    // host-tested HTML text extraction + local/network link resolution
+#include "ChannelSenderSplit.h"  // host-tested "SenderName: body" split for channel/room posts
 
 #if defined(HAS_TOUCH_UI)
   #include <lvgl.h>
@@ -33576,15 +33577,10 @@ static void chatParseMessageDisplay(const UITask::UIMessage& m, bool channel_mod
        (channel_mode &&
         (m.sender[0] == '\0' ||
          (m.sender[0] == 'r' && m.sender[1] == 'x' && m.sender[2] == '\0'))))) {
-    const char* colon = strstr(m.text, ": ");
-    if (colon) {
-      const int slen = static_cast<int>(colon - m.text);
-      if (slen > 0 && slen <= UITask::MAX_SENDER_NAME) {
-        strncpy(d.retro_sender, m.text, slen);
-        d.retro_sender[slen] = '\0';
-        d.show_sender = d.retro_sender;
-        d.show_text   = colon + 2;
-      }
+    const char* body = ChannelSenderSplit::split(m.text, d.retro_sender, sizeof(d.retro_sender));
+    if (d.retro_sender[0]) {
+      d.show_sender = d.retro_sender;
+      d.show_text   = body;
     }
   }
   copyUtf8ReplacingMissingGlyphs(&g_font_12, d.san_sender, sizeof(d.san_sender), d.show_sender);
@@ -53598,17 +53594,8 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
   char parsed_sender[MAX_SENDER_NAME + 1];
   parsed_sender[0] = '\0';
   const char* body = text ? text : "";
-  if (channel && text && !have_sender_override) {
-    const char* colon = strstr(text, ": ");
-    if (colon) {
-      int slen = static_cast<int>(colon - text);
-      if (slen > 0 && slen <= MAX_SENDER_NAME) {
-        strncpy(parsed_sender, text, slen);
-        parsed_sender[slen] = '\0';
-        body = colon + 2;
-      }
-    }
-  }
+  if (channel && text && !have_sender_override)
+    body = ChannelSenderSplit::split(text, parsed_sender, sizeof(parsed_sender));
   const char* sender = have_sender_override
       ? sender_override
       : (channel

--- a/src/ui-touch/UITask.h
+++ b/src/ui-touch/UITask.h
@@ -36,7 +36,11 @@ public:
   static const int MAX_UI_MESSAGES_SD = 5000;
   static const int MAX_UI_THREADS = 48;
   static const int MAX_THREAD_NAME = 32;
-  static const int MAX_SENDER_NAME = 24;
+  // Full MeshCore name width: ContactInfo::name / ChannelDetails::name / NodePrefs::
+  // node_name are all char[32], so 31 chars + NUL is exactly lossless. Was 24, which
+  // silently dropped every longer name. The PERSISTED width is frozen separately
+  // (k_ui_disk_sender_len in UITask.cpp) — raising this does not move any on-disk field.
+  static const int MAX_SENDER_NAME = 31;
   static const int MAX_MSG_TEXT = 160;   // full LoRa text length (was 96 -> cut long msgs ~3 lines)
   static const int MAX_UI_PATH = 32;  // inbound-route bytes/message for the Info popup (covers deep + multi-byte-hash routes)
 

--- a/test/test_channel_sender_split.cpp
+++ b/test/test_channel_sender_split.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <assert.h>
+#include <string.h>
+
+#include "ui-touch/ChannelSenderSplit.h"
+
+// UIMessage::sender is char[MAX_SENDER_NAME + 1] with MAX_SENDER_NAME == 24.
+static const size_t kSenderCap = 25;
+
+int main() {
+  char sender[kSenderCap];
+
+  // Ordinary channel post: author out, body in.
+  const char* body = ChannelSenderSplit::split("nick: hello there", sender, sizeof sender);
+  assert(strcmp(sender, "nick") == 0);
+  assert(strcmp(body, "hello there") == 0);
+
+  // The regression: a 27-char MeshCore name (they run to 31) used to fail the
+  // split outright, so the bubble header showed the channel and the body kept
+  // reading "nick: message". It must split, truncating the label instead — and a
+  // truncated label ends in "..." so it does not read as a shorter name.
+  const char* long_name = "Ouderkerk Repeater Node Two: on air";
+  body = ChannelSenderSplit::split(long_name, sender, sizeof sender);
+  assert(strlen(sender) == 24);
+  assert(strcmp(sender, "Ouderkerk Repeater No...") == 0);
+  assert(strcmp(body, "on air") == 0);
+
+  // Truncation lands on a character boundary, never inside a multi-byte sequence.
+  // "Ouderkerkk" (10) + U+2600 (3 bytes) x 5 = 25 bytes; the 21-byte name budget
+  // (24 minus the marker) falls inside the fourth sun, so it backs off to 19.
+  const char* utf8_name = "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
+  body = ChannelSenderSplit::split(utf8_name, sender, sizeof sender);
+  assert(strcmp(sender, "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
+  assert(strlen(sender) == 22);
+  assert(strcmp(body, "hi") == 0);
+
+  // Same shape one char shorter, so the budget already sits on a boundary: the
+  // back-off must not eat a whole character that fits.
+  const char* utf8_fits = "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
+  body = ChannelSenderSplit::split(utf8_fits, sender, sizeof sender);
+  assert(strcmp(sender, "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
+  assert(strlen(sender) == 24);
+  assert(strcmp(body, "hi") == 0);
+
+  // One char over the cap still gets the marker (name budget 21, not 24).
+  const char* one_over = "1234567890123456789012345: body";
+  body = ChannelSenderSplit::split(one_over, sender, sizeof sender);
+  assert(strcmp(sender, "123456789012345678901...") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // Destination too small to hold a marker: truncate plainly rather than
+  // spending the whole label on dots.
+  char tiny[5];
+  body = ChannelSenderSplit::split("nickname: body", tiny, sizeof tiny);
+  assert(strcmp(tiny, "nick") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // Exactly at the cap: 24 chars, no truncation.
+  const char* exact = "123456789012345678901234: body";
+  body = ChannelSenderSplit::split(exact, sender, sizeof sender);
+  assert(strcmp(sender, "123456789012345678901234") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // No author prefix — text passes through untouched, sender stays empty so the
+  // caller falls back to from_name.
+  const char* plain = "just a message";
+  body = ChannelSenderSplit::split(plain, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == plain);
+
+  // A bare colon without the space is not a separator.
+  const char* no_space = "nick:hello";
+  body = ChannelSenderSplit::split(no_space, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == no_space);
+
+  // Leading separator: empty author is not a name.
+  const char* leading = ": body";
+  body = ChannelSenderSplit::split(leading, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == leading);
+
+  // First separator wins — a colon in the body does not re-split.
+  body = ChannelSenderSplit::split("nick: ratio 3: 1", sender, sizeof sender);
+  assert(strcmp(sender, "nick") == 0);
+  assert(strcmp(body, "ratio 3: 1") == 0);
+
+  // Degenerate inputs.
+  assert(strcmp(ChannelSenderSplit::split(nullptr, sender, sizeof sender), "") == 0);
+  assert(sender[0] == '\0');
+  const char* keep = "nick: hi";
+  assert(ChannelSenderSplit::split(keep, nullptr, 0) == keep);
+  return 0;
+}

--- a/test/test_channel_sender_split.cpp
+++ b/test/test_channel_sender_split.cpp
@@ -49,6 +49,30 @@ int main() {
   assert(strcmp(sender, "123456789012345678901...") == 0);
   assert(strcmp(body, "body") == 0);
 
+  // The widest name the wire can carry (31) still splits — truncated to the
+  // 24-char field with the marker, but the author is out of the body.
+  const char* widest = "1234567890123456789012345678901: body";
+  assert(strlen(widest) == 37);
+  body = ChannelSenderSplit::split(widest, sender, sizeof sender);
+  assert(strcmp(sender, "123456789012345678901...") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // One char PAST the wire width is not a name at all — no node can be called
+  // this — so the ": " belongs to the message. Leave the text whole rather than
+  // inventing an author and hiding the start of the body.
+  const char* not_a_name = "12345678901234567890123456789012: body";
+  assert(strlen(not_a_name) == 38);
+  body = ChannelSenderSplit::split(not_a_name, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == not_a_name);
+
+  // The realistic shape of that: an unprefixed post whose body just happens to
+  // contain ": ". It must survive intact.
+  const char* prose = "the repeater at Ouderkerk is back up: full quieting again";
+  body = ChannelSenderSplit::split(prose, sender, sizeof sender);
+  assert(sender[0] == '\0');
+  assert(body == prose);
+
   // Destination too small to hold a marker: truncate plainly rather than
   // spending the whole label on dots.
   char tiny[5];

--- a/test/test_channel_sender_split.cpp
+++ b/test/test_channel_sender_split.cpp
@@ -5,8 +5,16 @@
 
 #include "ui-touch/ChannelSenderSplit.h"
 
-// UIMessage::sender is char[MAX_SENDER_NAME + 1] with MAX_SENDER_NAME == 24.
-static const size_t kSenderCap = 25;
+// UIMessage::sender is char[MAX_SENDER_NAME + 1] with MAX_SENDER_NAME == 31 — the full
+// MeshCore name width (ContactInfo::name[32]), so every real name now fits and the
+// truncation path is unreachable from the firmware's own callers. It is still exercised
+// below against narrower destinations: the helper is documented to truncate to whatever
+// it is handed, and the beta that shipped a 24-char field relies on exactly that.
+static const size_t kSenderCap = 32;
+
+// The frozen on-disk width (k_ui_disk_sender_len) — and what the previous beta's
+// UIMessage::sender was. The truncation + UTF-8 back-off cases run against this.
+static const size_t kNarrowCap = 25;
 
 int main() {
   char sender[kSenderCap];
@@ -16,75 +24,91 @@ int main() {
   assert(strcmp(sender, "nick") == 0);
   assert(strcmp(body, "hello there") == 0);
 
-  // The regression: a 27-char MeshCore name (they run to 31) used to fail the
-  // split outright, so the bubble header showed the channel and the body kept
-  // reading "nick: message". It must split, truncating the label instead — and a
-  // truncated label ends in "..." so it does not read as a shorter name.
+  // The regression this all started from: a 27-char name. It used to fail the split
+  // outright, so the bubble header showed the channel and the body kept reading
+  // "nick: message". At the full width it is stored whole, with no marker.
   const char* long_name = "Ouderkerk Repeater Node Two: on air";
   body = ChannelSenderSplit::split(long_name, sender, sizeof sender);
-  assert(strlen(sender) == 24);
-  assert(strcmp(sender, "Ouderkerk Repeater No...") == 0);
+  assert(strcmp(sender, "Ouderkerk Repeater Node Two") == 0);
+  assert(strlen(sender) == 27);
   assert(strcmp(body, "on air") == 0);
 
-  // Truncation lands on a character boundary, never inside a multi-byte sequence.
-  // "Ouderkerkk" (10) + U+2600 (3 bytes) x 5 = 25 bytes; the 21-byte name budget
-  // (24 minus the marker) falls inside the fourth sun, so it backs off to 19.
-  const char* utf8_name = "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
-  body = ChannelSenderSplit::split(utf8_name, sender, sizeof sender);
-  assert(strcmp(sender, "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
-  assert(strlen(sender) == 22);
-  assert(strcmp(body, "hi") == 0);
-
-  // Same shape one char shorter, so the budget already sits on a boundary: the
-  // back-off must not eat a whole character that fits.
-  const char* utf8_fits = "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
-  body = ChannelSenderSplit::split(utf8_fits, sender, sizeof sender);
-  assert(strcmp(sender, "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
-  assert(strlen(sender) == 24);
-  assert(strcmp(body, "hi") == 0);
-
-  // One char over the cap still gets the marker (name budget 21, not 24).
-  const char* one_over = "1234567890123456789012345: body";
-  body = ChannelSenderSplit::split(one_over, sender, sizeof sender);
-  assert(strcmp(sender, "123456789012345678901...") == 0);
+  // The longest name the wire can carry: 31 chars, stored exactly, no marker.
+  const char* longest = "1234567890123456789012345678901: body";
+  body = ChannelSenderSplit::split(longest, sender, sizeof sender);
+  assert(strlen(sender) == 31);
+  assert(strcmp(sender, "1234567890123456789012345678901") == 0);
   assert(strcmp(body, "body") == 0);
 
-  // The widest name the wire can carry (31) still splits — truncated to the
-  // 24-char field with the marker, but the author is out of the body.
-  const char* widest = "1234567890123456789012345678901: body";
-  assert(strlen(widest) == 37);
-  body = ChannelSenderSplit::split(widest, sender, sizeof sender);
-  assert(strcmp(sender, "123456789012345678901...") == 0);
-  assert(strcmp(body, "body") == 0);
-
-  // One char PAST the wire width is not a name at all — no node can be called
-  // this — so the ": " belongs to the message. Leave the text whole rather than
-  // inventing an author and hiding the start of the body.
+  // One char PAST the wire width is not a name at all — no node can be called this — so
+  // the ": " belongs to the message. Leave the text whole rather than inventing an author
+  // and hiding the start of the body.
   const char* not_a_name = "12345678901234567890123456789012: body";
   assert(strlen(not_a_name) == 38);
   body = ChannelSenderSplit::split(not_a_name, sender, sizeof sender);
   assert(sender[0] == '\0');
   assert(body == not_a_name);
 
-  // The realistic shape of that: an unprefixed post whose body just happens to
-  // contain ": ". It must survive intact.
+  // The realistic shape of that: an unprefixed post whose body just happens to contain
+  // ": ". It must survive intact, whole, with the caller's own sender label.
   const char* prose = "the repeater at Ouderkerk is back up: full quieting again";
   body = ChannelSenderSplit::split(prose, sender, sizeof sender);
   assert(sender[0] == '\0');
   assert(body == prose);
 
-  // Destination too small to hold a marker: truncate plainly rather than
-  // spending the whole label on dots.
+  // ---- Narrower destination: truncate the label, never reject the split -------------
+  char narrow[kNarrowCap];
+
+  // The 27-char name again. Too long for this field, so it is cut and marked with "..."
+  // — a shortened name must not read as a different node.
+  body = ChannelSenderSplit::split(long_name, narrow, sizeof narrow);
+  assert(strlen(narrow) == 24);
+  assert(strcmp(narrow, "Ouderkerk Repeater No...") == 0);
+  assert(strcmp(body, "on air") == 0);
+
+  // The widest name the wire can carry still splits here — cut, but the author is out
+  // of the body, which is the whole point.
+  body = ChannelSenderSplit::split(longest, narrow, sizeof narrow);
+  assert(strcmp(narrow, "123456789012345678901...") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // One char over the cap still gets the marker (name budget 21, not 24).
+  const char* one_over = "1234567890123456789012345: body";
+  body = ChannelSenderSplit::split(one_over, narrow, sizeof narrow);
+  assert(strcmp(narrow, "123456789012345678901...") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // Exactly at the cap: 24 chars, no truncation, no marker.
+  const char* exact = "123456789012345678901234: body";
+  body = ChannelSenderSplit::split(exact, narrow, sizeof narrow);
+  assert(strcmp(narrow, "123456789012345678901234") == 0);
+  assert(strcmp(body, "body") == 0);
+
+  // Truncation lands on a character boundary, never inside a multi-byte sequence.
+  // "Ouderkerkk" (10) + U+2600 (3 bytes) x 5 = 25 bytes; the 21-byte name budget
+  // (24 minus the marker) falls inside the fourth sun, so it backs off to 19.
+  const char* utf8_name = "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
+  body = ChannelSenderSplit::split(utf8_name, narrow, sizeof narrow);
+  assert(strcmp(narrow, "Ouderkerkk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
+  assert(strlen(narrow) == 22);
+  assert(strcmp(body, "hi") == 0);
+
+  // Same shape one char shorter, so the budget already sits on a boundary: the back-off
+  // must not eat a whole character that fits.
+  const char* utf8_fits = "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80: hi";
+  body = ChannelSenderSplit::split(utf8_fits, narrow, sizeof narrow);
+  assert(strcmp(narrow, "Ouderkerk\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80\xE2\x98\x80...") == 0);
+  assert(strlen(narrow) == 24);
+  assert(strcmp(body, "hi") == 0);
+
+  // Destination too small to hold a marker: truncate plainly rather than spending the
+  // whole label on dots.
   char tiny[5];
   body = ChannelSenderSplit::split("nickname: body", tiny, sizeof tiny);
   assert(strcmp(tiny, "nick") == 0);
   assert(strcmp(body, "body") == 0);
 
-  // Exactly at the cap: 24 chars, no truncation.
-  const char* exact = "123456789012345678901234: body";
-  body = ChannelSenderSplit::split(exact, sender, sizeof sender);
-  assert(strcmp(sender, "123456789012345678901234") == 0);
-  assert(strcmp(body, "body") == 0);
+  // ---- Nothing to split --------------------------------------------------------------
 
   // No author prefix — text passes through untouched, sender stays empty so the
   // caller falls back to from_name.

--- a/test/test_sender_ext_field.cpp
+++ b/test/test_sender_ext_field.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <assert.h>
+#include <string.h>
+
+#include "ui-touch/SenderExtField.h"
+
+// The on-disk shape: base is the frozen v6 field (24 chars + NUL), ext is the appended
+// tail, and together they hold MAX_SENDER_NAME == 31 chars.
+static const size_t kBaseCap = 25;
+static const size_t kExtCap = 7;
+static const size_t kOutCap = 32;
+
+int main() {
+  char base[kBaseCap], ext[kExtCap], out[kOutCap];
+
+  // Short name: fits the base field, ext stays empty.
+  SenderExtField::store("nick", base, sizeof base, ext, sizeof ext);
+  assert(strcmp(base, "nick") == 0);
+  for (size_t i = 0; i < kExtCap; ++i) assert(ext[i] == '\0');
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, "nick") == 0);
+
+  // Exactly 24: fills the base field with no spill. The tail must stay empty, or the
+  // "base is full" test below would resurrect garbage.
+  const char* exactly24 = "123456789012345678901234";
+  assert(strlen(exactly24) == 24);
+  SenderExtField::store(exactly24, base, sizeof base, ext, sizeof ext);
+  assert(strcmp(base, exactly24) == 0);
+  for (size_t i = 0; i < kExtCap; ++i) assert(ext[i] == '\0');
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, exactly24) == 0);
+
+  // A full 31-char name — the case the whole split exists for. Round-trips intact.
+  const char* full = "Ouderkerk Repeater Node Twelve";
+  assert(strlen(full) == 30);
+  SenderExtField::store(full, base, sizeof base, ext, sizeof ext);
+  assert(strncmp(base, full, 24) == 0 && base[24] == '\0');
+  assert(memcmp(ext, full + 24, 6) == 0);
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, full) == 0);
+
+  // The longest possible name fills ext completely, leaving it unterminated. load() is
+  // bounded by the field size, so it must not read past.
+  const char* longest = "1234567890123456789012345678901";
+  assert(strlen(longest) == 31);
+  SenderExtField::store(longest, base, sizeof base, ext, sizeof ext);
+  assert(memcmp(ext, longest + 24, kExtCap) == 0);   // no NUL anywhere in ext
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, longest) == 0);
+
+  // An OLD record: base written by a pre-widening build, ext zero-filled by the loader's
+  // prefix read. Must yield exactly the stored short name.
+  memset(ext, 0, sizeof ext);
+  memset(base, 0, sizeof base);
+  strcpy(base, "olde name");
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, "olde name") == 0);
+
+  // Garbage in ext behind a NON-full base must be ignored — that is the corrupt-record
+  // case, and appending it would splice junk onto a valid short name.
+  memset(ext, 'X', sizeof ext);
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, "olde name") == 0);
+
+  // An unterminated base field (corrupt record) must not read into the message body that
+  // follows it on disk: the copy stops at the field width.
+  char raw_base[kBaseCap];
+  memset(raw_base, 'A', sizeof raw_base);   // no NUL at all
+  memset(ext, 0, sizeof ext);
+  SenderExtField::load(raw_base, sizeof raw_base, ext, sizeof ext, out, sizeof out);
+  assert(strlen(out) == 24);
+
+  // A multi-byte character straddling the boundary: split anywhere, rejoin exact. The
+  // halves are never used apart, so the byte-level split is deliberately not aligned.
+  const char* utf8 = "Ouderkerkkkkkkkkkkkkkkk\xE2\x98\x80";   // 23 ASCII + 3-byte U+2600
+  assert(strlen(utf8) == 26);
+  SenderExtField::store(utf8, base, sizeof base, ext, sizeof ext);
+  assert((unsigned char)base[23] == 0xE2);   // sequence is cut mid-character on disk
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(strcmp(out, utf8) == 0);            // and comes back whole
+
+  // Degenerate inputs.
+  SenderExtField::store(nullptr, base, sizeof base, ext, sizeof ext);
+  assert(base[0] == '\0');
+  SenderExtField::load(base, sizeof base, ext, sizeof ext, out, sizeof out);
+  assert(out[0] == '\0');
+  return 0;
+}


### PR DESCRIPTION
# touch: store the whole sender name, not the first 24 characters

## Summary

MeshCore names run to 31 characters (`ContactInfo::name[32]`, `ChannelDetails::name[32]`,
`NodePrefs::node_name[32]`), but `UIMessage::sender` held 24. Every longer name was cut on
the way in. This raises `MAX_SENDER_NAME` to 31 — exactly the wire width, so nothing is lost
— **without a migration, a version bump, or a wiped chat history.**

This is the follow-up to #376, which made the cut *visible* rather than letting it push the
author into the message body. That fixed the reported layout; this stops the cut happening.

**Stacked on #376.** GitHub cannot base a cross-fork PR on a branch that lives only in my
fork, so this branch necessarily contains #376's two commits too. New here are
`touch: store the whole sender name...` and the two follow-ups below
(`...never append a wider record...`, `...latch the block-name migration...`). Merge #376
first and this reduces to those three.

## Why truncation was not enough

Three of these cannot be fixed by displaying the cut more honestly:

- **Ack / Mention.** Both insert `@[<sender>]` into the composer. `textMentionsMe` requires
  the whole name followed by `]`, so a mention of a long-named node never reached them.
- **Block-by-name is already broken for room posts.** The RX check tests the untruncated
  31-char `sender_override`, while the stored entry came from the 24-char field — so a room
  author with a long name has simply been unblockable. Not a new bug; this fixes it.
- **Info and the chat-list preview** showed a cut name.

## Why the obvious change would have been quietly destructive

Widening `UiHistoryMsg::sender` is the natural move and it must not be made. `sender` sits
between `thread` and `text`, so widening it shifts `text` for every record already on disk —
and nothing on the read path would catch it:

> `uiSegOpenValidated` checks only magic / version / `msg_rec_size`. It never consults
> `k_ui_history_version` or `k_ui_history_min_version` — those guard the legacy files alone,
> and the segment store is what actually holds messages now.

An old segment would have passed validation, prefix-read into the new offsets, **lost the
first 8 characters of every message body**, and read `seq` as 0 — so `loadMsgsFromSegments`
renumbers the whole history. No error, no quarantine. The next compaction writes it back
permanently.

Raising `k_ui_history_min_version` (what the comment on `UiHistoryMsg` tells you to do for a
mid-record change) would not have helped either: it is shared with `/ui_threads_v1.bin`, so
it would delete unread counts, DM pubkey mappings and channel slots whose layout never
changed — and it would still not touch the segment store.

## What this does instead

The on-disk width is frozen at 25 (`k_ui_disk_sender_len`) and the overflow is **appended to
`UiSegMsg`, after `seq`** — the evolution path `UiSegHeader` already documents ("future
fields append at the END… a reader of either size copies min(rec_size) and zero-fills the
rest"). Every pre-existing field keeps its offset, and the prefix read is correct in both
directions:

| | reads | result |
|---|---|---|
| New firmware, old 233-byte record | first 233 B, tail zero-filled | original short name, body intact |
| Old firmware, new 240-byte record | first 233 B, tail skipped | name falls back to 24 chars, nothing else changes |

That second row is why **`k_ui_seg_version` stays 1**: `uiSegOpenValidated` rejects
`version > k_ui_seg_version`, so bumping it would make older firmware reject and *quarantine*
a history it could have read perfectly well. Since the project ships betas people roll back,
that matters.

`static_assert`s now pin the offsets an already-written record depends on (they pin offsets
rather than the total size, because appending further fields at the tail stays legitimate).

**That table covers READS. Appending is a separate question, and it is where this nearly went
wrong — see the next section.**

## Two record widths in one file is the hazard, not two widths on disk

A self-describing header makes a mixed-width *set of files* safe. It does nothing for a
mixed-width *file*, and `uiSegAppendRecords` was about to produce one. It writes
`sizeof(UiSegMsg)` into whatever file the table points at, and right after an upgrade that
file is the still-non-full active segment — whose header says 233. Nothing detects the
mismatch, so the reader keeps striding at 233:

```
record 100: reader reads at 23316, record starts at 23316  (off by 0)
record 101: reader reads at 23549, record starts at 23556  (off by 7)
record 102: reader reads at 23782, record starts at 23796  (off by 14)
```

Every record after the first appended one is read at the wrong offset. The damage is silent
and it escalates: garbage bubbles first, then a `seq` read out of a long name's tail bytes
lands far in the future — which makes the loader's strictly-monotonic filter drop every
*later* segment and leaves `_ui_seq_next` poisoned. The next compaction writes the result back
for good. This needs nothing unusual to trigger: an upgrade over stored history, and one
received message.

The fix reuses machinery that already exists. Only a non-full segment can ever receive an
append, so `loadMsgsFromSegments` flags exactly those, when their on-disk width is not ours,
with `rewrite_open` — the "this file is untrusted, rewrite it before appending" flag the
failed-append path already sets. Step 0 of `segBuildJob` runs that repair before any append
and lays down a fresh header at the current width. A full old-width segment is left alone: it
reads correctly from its own header and costs nothing. The synchronous drain was never
exposed — it turns every append into a whole-segment rewrite already.

### So rollback is *readable*, not free

The mirror case cannot be fixed from this side and should not be glossed over: an older build
reads a 240-byte record correctly, but if it then **appends** to that segment it writes
233-byte records into a file whose header says 240 — the same misalignment, authored by the
old firmware. A version bump does not help; it only converts a corrupted tail into an outright
rejection of the whole file. So the honest claim is that a downgrade still *loads* history
(losing only the sender tail), and that receiving messages while downgraded can cost the
active segment. It is documented on `UiSegMsg` rather than papered over.

Net: no migration code, no version bump, no history loss on upgrade, and a downgrade still
reads.

## The block list has to move in lockstep

`TOUCH_IGNORED_NAME_LEN` 28 → 32. Left at 28, `touchPrefsSetNameIgnored` stores a 27-char cut
while the RX check passes the full name, so `strncmp` never matches — the block appears in
Settings and silently never fires (issue #177's shape, again).

Its NVS blob has no header; the entry count is the blob length divided by the slot width. So
re-slotting in place would start slot 1 inside old name 0, mangle every row after the first,
and the next write would make that permanent. The key is renamed `ign_nm` → `ign_nm2` and the
old blob folded in once at first read. A rename is unambiguous by construction, unlike
sniffing the blob length — 28 and 32 share multiples at 224 and 448 bytes, both inside the
16-entry cap. The migration is latched for the boot because the caller runs on the RX path
for every incoming message.

The latch has to be set **after** the fold, not on entry. Setting it first meant a failed
re-open for write (the same NVS failure `ignWriteAll` returns false for) latched a migration
that never happened: `ign_nm2` absent, `ign_nm` never consulted again, so `ignNamesReadAll`
returns 0 and every name block silently stops firing for the rest of the boot. Worse, the next
Block tap then writes a fresh `ign_nm2` holding only that one entry, and the next boot's
migration sees `ign_nm2` present and skips — the old list is orphaned for good. It now latches
on success only, and drops `ign_nm` only once the new key actually holds the list. Keeping the
old key on failure costs nothing: nothing but this function reads it, and it reads it at the
correct old stride. The "nothing to fold in" case still latches on the first call, so the
steady-state cost the latch exists for is unchanged.

The invariant `TOUCH_IGNORED_NAME_LEN >= MAX_SENDER_NAME + 1` was stated in prose in the
header. Prose is what let it rot; it is a `static_assert` now.

## Cost

`sizeof(UIMessage)` 284 → 292. ~4 KB RAM at `MAX_UI_MESSAGES` (500); ~39 KB PSRAM and ~39 KB
of card space at `MAX_UI_MESSAGES_SD` (5000). Segment records 233 → 240 bytes.

## Testing

Host tests, both with `-Wall -Wextra -Werror`:

```
c++ -std=c++17 -O2 -Wall -Wextra -Werror -I src test/test_sender_ext_field.cpp -o /tmp/t && /tmp/t
c++ -std=c++17 -O2 -Wall -Wextra -Werror -I src test/test_channel_sender_split.cpp -o /tmp/t && /tmp/t
```

`test_sender_ext_field.cpp` is new and covers the round trip: short name, exactly 24, a full
31, an ext field filled with no NUL, an **old record's zero-filled tail**, garbage in the tail
behind a short name (must be ignored), an unterminated name field (must not read into the
body that follows it on disk), and a multi-byte character straddling the split.
`test_channel_sender_split.cpp` is updated — at the old cap it would have kept passing while
silently testing the wrong width. At the new cap the truncation path is unreachable from the
firmware's own callers (every prefix either fits exactly or is rejected as too wide to be a
name), so the truncation and UTF-8 back-off cases now run against a 25-byte destination: the
frozen on-disk width, and what the shipped beta's `UIMessage::sender` was. The helper is
documented to truncate to whatever it is handed, and that is the width that still relies on it.

Neither the append-width guard nor the block-list migration is host-testable — both need a
filesystem or NVS. The append guard is argued from the loader and the write paths
(`uiSegAppendRecords` is the only writer that does not lay down a fresh header, and
`segBuildJob` step 0 provably precedes step 1), and it wants test 4 below.

All 8 PlatformIO targets build clean via `scripts/build-all-targets.sh --pio`:

```
heltec_v4_tft_companion_radio_usb_tcp_touch    OK
heltec_v4_r8_tft_companion_radio_usb_tcp_touch OK
attaky_mesh_series_companion_radio_touch       OK
LilyGo_TDeck_companion_radio_touch             OK
tlora_pager_lr1121_companion_radio_touch       OK
tlora_pager_sx1262_companion_radio_touch       OK
ThinkNode_M9_companion_radio_touch             OK
rak_tap_v2_companion_radio_touch               OK
```

**Not yet exercised on physical hardware — and for this change that gap is the important
one.** The compatibility argument above is from reading the loaders plus the `static_assert`s
on the record offsets; it has not been demonstrated against a real store. Before merging,
these four want doing on a device that already has stored history:

1. **Upgrade** — flash over an existing install with messages. Old bubbles must still show
   their *full* text. A body missing its first 8 characters means the offsets moved.
2. **Downgrade** — reflash the previous beta over the new store. Segments must still load,
   with only the sender tail lost. The whole design rests on this.
3. **Block list** — an existing list must survive `ign_nm` → `ign_nm2` with every entry
   intact and still matching.
4. **Upgrade, then keep receiving.** The one that would have caught the append bug, and the
   one no host test can reach: upgrade onto history whose newest segment is NOT full, take a
   dozen more messages, reboot. Every message from before AND after the upgrade must come back
   intact and in order. A garbled tail, or older messages vanishing, means the pre-append
   rewrite did not land.

## One note for reviewers

The bubble's header row puts the sender on the left and the timestamp/meta on the right, and
the meta gets whatever the sender leaves:

```
inner_w           = max(text_width, min(sender_w + meta_w + 6, kInnerMaxW))
available_meta_w  = inner_w - (sender_w + 6)
```

When `available_meta_w` drops below the width of `"..."`, the sender takes the row and
`chatFitLeadingEllipsis` trims the timestamp from the left to fit — a fragment like `...:42`
at first, a bare `"..."` in the worst case.

Nothing overflows: `header_w` is clamped to `kInnerMaxW` and the sender label gets
`LV_LABEL_LONG_DOT`. But on the 240 px boards (`kInnerMaxW` ≈ 166 px) a name near the full 31
chars is wider than the inner width on its own, so the timestamp collapses — and note this
depends only on the sender's width, **not** on how long the message is: a short message
cannot shrink the bubble below the header, because `header_w` floors `inner_w`.

That trade seems right to me (the author matters more than the clock, and the exact time is
in the Info sheet), and it is pre-existing behaviour rather than anything this PR adds — but
names this wide could not previously reach the label at all, so it is newly reachable on the
narrow boards and worth a second opinion. The pixel figures above are estimates from the
font's average advance; the exact cutoff depends on `g_font_12` metrics and the actual name.

