### PR TITLE
Fix direct-message timestamps

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ framework = arduino
 board = heltec_v4
 monitor_speed = 115200
 board_build.partitions = partitions_tft_touch.csv
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, merge-bin.py
 
 build_flags =
   ; 1.17 core: ESP32Board.cpp includes <target.h> -> MicroNMEALocationProvider.h (header-only
@@ -330,7 +330,7 @@ framework = arduino
 board = attaky_mesh_series
 monitor_speed = 115200
 board_build.partitions = partitions_tft_touch.csv
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, merge-bin.py
 
 build_flags =
   ; 1.17 core: ESP32Board.cpp includes <target.h> -> MicroNMEALocationProvider.h (header-only
@@ -516,7 +516,7 @@ framework = arduino
 board = t-deck
 monitor_speed = 115200
 board_build.partitions = variants/lilygo_tdeck/partitions_tdeck_touch.csv
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, merge-bin.py
 
 build_flags =
   ; 1.17 core: ESP32Board.cpp includes <target.h> -> MicroNMEALocationProvider.h (header-only
@@ -693,7 +693,7 @@ framework = arduino
 board = lilygo-t-lora-pager
 monitor_speed = 115200
 board_build.partitions = variants/lilygo_tlora_pager/partitions_tlora_pager_touch.csv
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_nimble_freertos_timer.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, pre:scripts/build/patch_nimble_freertos_timer.py, merge-bin.py
 
 build_flags =
   ; 1.17 core: ESP32Board.cpp includes <target.h> -> MicroNMEALocationProvider.h (header-only
@@ -928,7 +928,7 @@ framework = arduino
 board = lilygo-t-lora-pager
 monitor_speed = 115200
 board_build.partitions = variants/lilygo_tlora_pager/partitions_tlora_pager_touch.csv
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_nimble_freertos_timer.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, pre:scripts/build/patch_nimble_freertos_timer.py, merge-bin.py
 
 build_flags =
   ; 1.17 core: ESP32Board.cpp includes <target.h> -> MicroNMEALocationProvider.h (header-only
@@ -1152,7 +1152,7 @@ board_build.partitions = variants/thinknode_m9/partitions_m9_touch.csv
 ; DriveDiosInSleepMode (0x012A, FW 0x0308+) with CMD_PERR -> begin() = -706.
 ; The pre-script makes RadioLib's config() skip it on old FW (idempotent,
 ; per-env libdeps copy). See scripts/build/patch_radiolib_lr11x0.py.
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_radiolib_lr11x0.py, pre:scripts/build/patch_meshcore_rv3028_define.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, pre:scripts/build/patch_radiolib_lr11x0.py, pre:scripts/build/patch_meshcore_rv3028_define.py, merge-bin.py
 
 build_unflags =
   -std=gnu++11
@@ -1412,7 +1412,7 @@ board = rak_tap_v2
 monitor_speed = 115200
 board_build.flash_mode = dio                ; RAK3312 requires DIO (board JSON defaults to qio)
 board_build.partitions = variants/rak_tap_v2/partitions_rak_tap_v2_touch.csv
-extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, merge-bin.py
+extra_scripts = pre:scripts/build/pre_gen_baked.py, pre:scripts/inject_wifi_env.py, pre:scripts/build/patch_meshcore_txt_timestamp.py, merge-bin.py
 
 ; Round-1b USB: MODE=1 HW CDC (single COM7). No 1200bps touch — use DTR/RTS reset.
 build_unflags =

--- a/scripts/build/patch_meshcore_txt_timestamp.py
+++ b/scripts/build/patch_meshcore_txt_timestamp.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# MeshCore core-v1.17.4 seeds _txt_last_ts from an unrestricted random uint32.
+# BaseChatMesh::sendMessage() then raises the real RTC timestamp above that
+# value and writes it into the encrypted TXT payload. On current dates this
+# produces a future timestamp on most boots (issue #374).
+#
+# Keep the real clock-derived timestamp and its within-boot monotonic ratchet.
+# The other randomized fields remain unchanged. This patch is temporary until
+# the same fix is available in a tagged meshcomod core dependency.
+#
+# Idempotent and fail-closed. On a fresh checkout, pre-scripts run before
+# PlatformIO fetches lib_deps, so the pre-link action patches the newly fetched
+# source and fails that first link. Re-running then compiles the patched source;
+# no firmware artifact can be linked from the known-bad source.
+
+import os
+import sys
+
+MARKER = "wadamesh-real-txt-timestamp-patch"
+OLD = """  g->random(w, 4);
+  _txt_last_ts = (uint32_t)w[0] | ((uint32_t)w[1] << 8) | ((uint32_t)w[2] << 16) | ((uint32_t)w[3] << 24);"""
+NEW = """  // wadamesh-real-txt-timestamp-patch: this field is a semantic Unix
+  // timestamp, not a nonce. sendMessage() seeds it from the validated RTC on
+  // first use and ratchets it only for later sends in this boot.
+  _txt_last_ts = 0;"""
+REQUIRED_SEND_LINES = (
+        "  uint32_t uniq_ts = getRTCClock()->getCurrentTimeUnique();",
+        "  if (uniq_ts <= _txt_last_ts) uniq_ts = _txt_last_ts + 1;",
+        "  _txt_last_ts = uniq_ts;",
+        "composeMsgPacket(recipient, uniq_ts, uniq_attempt, text",
+)
+
+
+def patch_source(source):
+    if any(source.count(line) != 1 for line in REQUIRED_SEND_LINES):
+        raise RuntimeError(
+            "BaseChatMesh direct-message timestamp path does not match core-v1.17.4 "
+            "(MeshCore version drift?)"
+        )
+    old_count = source.count(OLD)
+    new_count = source.count(NEW)
+    marker_count = source.count(MARKER)
+    if old_count == 0 and new_count == 1 and marker_count == 1:
+        return source, False
+    if old_count != 1 or new_count != 0 or marker_count != 0:
+        raise RuntimeError(
+            "BaseChatMesh timestamp initialization does not match core-v1.17.4 "
+            "(MeshCore version drift?)"
+        )
+    patched = source.replace(OLD, NEW, 1)
+    if patched.count(OLD) != 0 or patched.count(NEW) != 1 or patched.count(MARKER) != 1:
+        raise RuntimeError("BaseChatMesh timestamp patch verification failed")
+    return patched, True
+
+
+def patch_file(path):
+    with open(path, encoding="utf-8") as source_file:
+        source = source_file.read()
+    patched, changed = patch_source(source)
+    if changed:
+        with open(path, "w", encoding="utf-8") as source_file:
+            source_file.write(patched)
+    return changed
+
+
+def verify_source(source):
+    _, changed = patch_source(source)
+    if changed:
+        raise RuntimeError("BaseChatMesh contains the unpatched random timestamp seed")
+
+
+def verify_file(path):
+    with open(path, encoding="utf-8") as source_file:
+        verify_source(source_file.read())
+
+
+def self_test():
+    fixture = "before\n" + OLD + "\n" + "\n".join(REQUIRED_SEND_LINES) + "\nafter\n"
+    patched, changed = patch_source(fixture)
+    assert changed
+    assert MARKER in patched
+    assert "_txt_last_ts = 0;" in patched
+    assert "g->random(w, 4);" not in patched
+
+    same, changed = patch_source(patched)
+    assert not changed
+    assert same == patched
+    verify_source(patched)
+
+    try:
+        verify_source(fixture)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("verification must reject an unpatched source")
+
+    try:
+        patch_source("void initTxtTxUniquenessFromRng() {}\n")
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("version drift must fail closed")
+
+    for invalid in (fixture + OLD, patched + OLD, "// " + MARKER + "\n" + fixture):
+        try:
+            patch_source(invalid)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("ambiguous or poisoned patch state must fail closed")
+
+    print("patch_meshcore_txt_timestamp self-test passed")
+
+
+def install(platformio_env):
+    path = os.path.join(
+        platformio_env.subst("$PROJECT_LIBDEPS_DIR"),
+        platformio_env.subst("$PIOENV"),
+        "MeshCore",
+        "src",
+        "helpers",
+        "BaseChatMesh.cpp",
+    )
+
+    def apply_or_error():
+        if not os.path.isfile(path):
+            return "MeshCore patch target is missing: %s" % path
+        try:
+            changed = patch_file(path)
+        except (OSError, RuntimeError) as error:
+            return str(error)
+        print(
+            "[patch_meshcore_txt_timestamp] %s"
+            % ("patched BaseChatMesh.cpp" if changed else "already patched")
+        )
+        return None
+
+    if os.path.isfile(path):
+        error = apply_or_error()
+        if error is not None:
+            print("[patch_meshcore_txt_timestamp] ERROR: %s" % error)
+            platformio_env.Exit(1)
+    else:
+        print(
+            "[patch_meshcore_txt_timestamp] MeshCore not fetched yet - "
+            "patch deferred to pre-link check"
+        )
+
+    def verify_patched(target, source, env):
+        del target, source
+        if os.path.isfile(path):
+            try:
+                verify_file(path)
+                return 0
+            except (OSError, RuntimeError):
+                pass
+        error = apply_or_error()
+        if error is not None:
+            print("[patch_meshcore_txt_timestamp] ERROR: %s" % error)
+            return 1
+        print("[patch_meshcore_txt_timestamp] ERROR: MeshCore was patched after compilation")
+        print("[patch_meshcore_txt_timestamp] ERROR: re-run `pio run` to compile the fix")
+        return 1
+
+    platformio_env.AddPreAction("$BUILD_DIR/${PROGNAME}.elf", verify_patched)
+
+
+try:
+    Import("env")  # noqa: F821 - provided by PlatformIO/SCons
+except NameError:
+    env = None
+
+if env is not None:
+    install(env)
+
+if env is None and __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
+        self_test()
+    elif len(sys.argv) == 3 and sys.argv[1] == "--patch-file":
+        try:
+            changed = patch_file(sys.argv[2])
+            print(
+                "patch_meshcore_txt_timestamp: %s"
+                % ("patched" if changed else "already patched")
+            )
+        except (OSError, RuntimeError) as error:
+            print("patch_meshcore_txt_timestamp: ERROR: %s" % error, file=sys.stderr)
+            raise SystemExit(1)
+    elif len(sys.argv) == 3 and sys.argv[1] == "--verify-file":
+        try:
+            verify_file(sys.argv[2])
+            print("patch_meshcore_txt_timestamp: verified")
+        except (OSError, RuntimeError) as error:
+            print("patch_meshcore_txt_timestamp: ERROR: %s" % error, file=sys.stderr)
+            raise SystemExit(1)
+    else:
+        raise SystemExit(
+            "usage: patch_meshcore_txt_timestamp.py "
+            "(--self-test | --patch-file PATH | --verify-file PATH)"
+        )

--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -22,6 +22,9 @@
 #include <helpers/HttpOtaDisplayState.h>
 #include <helpers/RepeaterTcpOtaEmit.h>
 #include "WiFiConfig.h"
+#if defined(ESP32) && defined(HAS_TOUCH_UI)
+#include "helpers/esp32/TouchPrefsStore.h"
+#endif
 #ifdef ESP32
 #if defined(WIFI_SSID) || defined(MULTI_TRANSPORT_COMPANION)
 #include <WiFi.h>
@@ -38,6 +41,15 @@
 /** While `ota url` runs, pin WS/TCP reply target so OTA progress survives yield() and checkRecvFrame. */
 static int s_companion_ota_pinned_reply_target = -1;
 #endif
+
+static void persistProtocolClockBeforeReset(mesh::RTCClock* clock) {
+#if defined(ESP32) && defined(HAS_TOUCH_UI)
+  if (clock) touchPrefsSetClockFloor(clock->getCurrentTime());
+  touchPrefsFlush();
+#else
+  (void)clock;
+#endif
+}
 
 #define CMD_APP_START                 1
 #define CMD_SEND_TXT_MSG              2
@@ -678,6 +690,7 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
   if (isCmd(p, "reboot")) {
     pushMeshcomodReply("rebooting...");
     delay(150);
+    persistProtocolClockBeforeReset(getRTCClock());
     board.reboot();
     return true;   // not reached
   }
@@ -702,6 +715,7 @@ bool MyMesh::handleMeshcomodCommand(const char* text, int text_len) {
     uint32_t opt1 = REG_READ(RTC_CNTL_OPTION1_REG);
     REG_WRITE(RTC_CNTL_OPTION1_REG, opt1 | RTC_CNTL_FORCE_DOWNLOAD_BOOT);
 #endif
+    persistProtocolClockBeforeReset(getRTCClock());
     board.reboot();   // Tanmatsu/P4: plain reboot (the launcher manages flashing)
 #else
     pushMeshcomodReply("bootloader: ESP32-only");
@@ -4596,6 +4610,7 @@ void MyMesh::handleCmdFrame(size_t len) {
     // was the "read and unread messages deleted after a manual reboot" report.
     if (_ui) _ui->persistHistoryNow();
     persistSyncHistoryNow();   // and the app-sync replay ring
+    persistProtocolClockBeforeReset(getRTCClock());
     board.reboot();
   } else if (cmd_frame[0] == CMD_GET_BATT_AND_STORAGE) {
     uint8_t reply[11];
@@ -5569,6 +5584,7 @@ void MyMesh::checkCLIRescueCmd() {
       cliPutEnd();
 #endif
     } else if (strcmp(cli_command, "reboot") == 0) {
+      persistProtocolClockBeforeReset(getRTCClock());
       board.reboot();  // doesn't return
     } else {
       Serial.println("  Error: unknown command");

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -11923,6 +11923,8 @@ static void sdRestoreRun() {
   }
   meshcomodClearSdMigLatch();           // manual copy succeeded -> re-arm boot auto-adoption (GH #142/#148)
   touchPrefsSetUseSdStorage(true);      // make sure the reboot adopts the card
+  touchPrefsSetClockFloor(rtc_clock.getFloor());
+  touchPrefsFlush();                    // persist storage selection + protocol floor before reset
   delay(400);                           // let the alert render before the restart
   board.reboot();
 }
@@ -38172,6 +38174,8 @@ static void doBackupImportChosen() {
   g_lv.task->showAlert(dmsg, 2600);
   lv_refr_now(nullptr);
   delay(2600);
+  touchPrefsSetClockFloor(rtc_clock.getFloor());
+  touchPrefsFlush();
   ESP.restart();
 }
 static void backupChosenCb(lv_event_t* e) {
@@ -40097,6 +40101,7 @@ static void powerOffCb(lv_event_t* e) {
     discoveredFlushNow();                  // and the Discovered ring
     the_mesh.flushContactsIfDirty();       // and any coalesced contacts refresh
     the_mesh.persistSyncHistoryNow();      // and the app-sync replay ring (RAM is lost in deep sleep)
+    touchPrefsSetClockFloor(rtc_clock.getFloor());   // preserve protocol monotonicity after wake
     touchPrefsFlush();                     // and all queued A/B preference snapshots
     // Name the control this board actually has. "Click trackball" was shown on
     // every board that reached here, trackball or not.
@@ -40174,6 +40179,7 @@ static void powerDownloadCb(lv_event_t* e) {
     g_lv.task->persistHistoryNow();   // flush chat before we go down
     discoveredFlushNow();             // and the Discovered ring
     the_mesh.persistSyncHistoryNow(); // and the app-sync replay ring
+    touchPrefsSetClockFloor(rtc_clock.getFloor());   // preserve protocol monotonicity after flashing
     touchPrefsFlush();                 // and all queued A/B preference snapshots
     g_lv.task->showAlert(TR("Download mode\xE2\x80\xA6 reflash over USB"), 1500);
   }
@@ -53873,6 +53879,7 @@ void UITask::rebootDevice() {
   discoveredFlushNow();   // persist the Discovered ring before we go down
   the_mesh.flushContactsIfDirty();   // and any coalesced contacts refresh (card-less devices)
   the_mesh.persistSyncHistoryNow();  // and the app-sync replay ring
+  touchPrefsSetClockFloor(rtc_clock.getFloor());   // preserve protocol monotonicity across this reboot
   touchPrefsFlush();       // finish queued A/B snapshots before reset
   if (_board) _board->reboot();
 }
@@ -53893,6 +53900,7 @@ void UITask::rebootDevice() {
 void consoleHostRebootToUi() {
   touchPrefsSetConsoleMode(false);
   if (g_lv.task) { g_lv.task->rebootDevice(); return; }
+  touchPrefsSetClockFloor(rtc_clock.getFloor());
   touchPrefsFlush();   // no UITask (should not happen): at least do not lose the pref
   ESP.restart();
 }

--- a/tanmatsu/components/meshcore/CMakeLists.txt
+++ b/tanmatsu/components/meshcore/CMakeLists.txt
@@ -9,6 +9,20 @@
 #   - helpers/sensors/*   -> telemetry; deferred (re-add with the sensor libs later)
 #   - the MC_VENDORED_TOUCH_APP files -> our own src/ ships them (avoid duplicate symbols)
 set(CORE "core/src")
+set(TXT_TIMESTAMP_SOURCE "${CMAKE_CURRENT_LIST_DIR}/${CORE}/helpers/BaseChatMesh.cpp")
+if(NOT EXISTS "${TXT_TIMESTAMP_SOURCE}")
+  message(FATAL_ERROR "MeshCore sources are missing; run tanmatsu/fetch-deps.sh")
+endif()
+execute_process(
+  COMMAND python3 "${CMAKE_CURRENT_LIST_DIR}/../../../scripts/build/patch_meshcore_txt_timestamp.py"
+          --verify-file "${TXT_TIMESTAMP_SOURCE}"
+  RESULT_VARIABLE TXT_TIMESTAMP_VERIFY_RESULT
+  OUTPUT_VARIABLE TXT_TIMESTAMP_VERIFY_OUT
+  ERROR_VARIABLE TXT_TIMESTAMP_VERIFY_ERR
+)
+if(NOT TXT_TIMESTAMP_VERIFY_RESULT EQUAL 0)
+  message(FATAL_ERROR "Vendored MeshCore failed issue #374 verification; run tanmatsu/fetch-deps.sh\n${TXT_TIMESTAMP_VERIFY_OUT}${TXT_TIMESTAMP_VERIFY_ERR}")
+endif()
 file(GLOB_RECURSE CORE_SRCS "${CMAKE_CURRENT_LIST_DIR}/${CORE}/*.cpp")
 list(FILTER CORE_SRCS EXCLUDE REGEX "/helpers/radiolib/")
 list(FILTER CORE_SRCS EXCLUDE REGEX "/helpers/sensors/")

--- a/tanmatsu/fetch-deps.sh
+++ b/tanmatsu/fetch-deps.sh
@@ -19,6 +19,8 @@ cp -R "$LIBDEPS/MeshCore/src"      components/meshcore/core/src
 cp -R "$LIBDEPS/MeshCore/variants" components/meshcore/core/variants 2>/dev/null || true
 mkdir -p components/meshcore/core/lib
 cp -R "$LIBDEPS/MeshCore/lib/ed25519" components/meshcore/core/lib/ed25519   # bundled C ed25519 (Identity.cpp)
+python3 ../scripts/build/patch_meshcore_txt_timestamp.py \
+  --patch-file components/meshcore/core/src/helpers/BaseChatMesh.cpp
 echo "vendored: meshcore core ($(find components/meshcore/core/src -name '*.cpp' | wc -l | tr -d ' ') cpp)"
 
 # --- LVGL 8.4 (own component; big; uses the repo's include/lv_conf.h) ---

--- a/tdisplay_p4/components/meshcore/CMakeLists.txt
+++ b/tdisplay_p4/components/meshcore/CMakeLists.txt
@@ -8,7 +8,31 @@
 # Everything else mirrors the Tanmatsu selection (see its CMakeLists): drop nRF52/TBeam boards,
 # the S3 panel drivers, sensors, other-platform helpers, ESP-NOW, and the MC_VENDORED_TOUCH_APP
 # files our own src/ ships.
+set(CORE_LINK "${CMAKE_CURRENT_LIST_DIR}/core")
+if(NOT IS_SYMLINK "${CORE_LINK}")
+  message(FATAL_ERROR "T-Display P4 MeshCore is not the shared Tanmatsu symlink; run tdisplay_p4/fetch-deps.sh")
+endif()
+get_filename_component(CORE_REAL "${CORE_LINK}" REALPATH)
+get_filename_component(CORE_EXPECTED_REAL "${CMAKE_CURRENT_LIST_DIR}/../../../tanmatsu/components/meshcore/core" REALPATH)
+if(NOT "${CORE_REAL}" STREQUAL "${CORE_EXPECTED_REAL}")
+  message(FATAL_ERROR "T-Display P4 MeshCore points to the wrong source; run tdisplay_p4/fetch-deps.sh")
+endif()
+
 set(CORE "core/src")
+set(TXT_TIMESTAMP_SOURCE "${CMAKE_CURRENT_LIST_DIR}/${CORE}/helpers/BaseChatMesh.cpp")
+if(NOT EXISTS "${TXT_TIMESTAMP_SOURCE}")
+  message(FATAL_ERROR "MeshCore sources are missing; run tdisplay_p4/fetch-deps.sh")
+endif()
+execute_process(
+  COMMAND python3 "${CMAKE_CURRENT_LIST_DIR}/../../../scripts/build/patch_meshcore_txt_timestamp.py"
+          --verify-file "${TXT_TIMESTAMP_SOURCE}"
+  RESULT_VARIABLE TXT_TIMESTAMP_VERIFY_RESULT
+  OUTPUT_VARIABLE TXT_TIMESTAMP_VERIFY_OUT
+  ERROR_VARIABLE TXT_TIMESTAMP_VERIFY_ERR
+)
+if(NOT TXT_TIMESTAMP_VERIFY_RESULT EQUAL 0)
+  message(FATAL_ERROR "Vendored MeshCore failed issue #374 verification; run tdisplay_p4/fetch-deps.sh\n${TXT_TIMESTAMP_VERIFY_OUT}${TXT_TIMESTAMP_VERIFY_ERR}")
+endif()
 file(GLOB_RECURSE CORE_SRCS "${CMAKE_CURRENT_LIST_DIR}/${CORE}/*.cpp")
 # NOTE: helpers/radiolib/ is NOT excluded here (unlike the Tanmatsu) — the P4 needs it.
 # helpers/sensors/ is NOT fully excluded either: the P4 has a real GPS (L76K), so it compiles

--- a/tdisplay_p4/fetch-deps.sh
+++ b/tdisplay_p4/fetch-deps.sh
@@ -15,7 +15,14 @@ mkdir -p components
 #     Run tanmatsu/fetch-deps.sh first (or let it be run by this one) to materialize it.
 [ -d ../tanmatsu/components/meshcore/core/src ] || ../tanmatsu/fetch-deps.sh
 mkdir -p components/meshcore
-[ -e components/meshcore/core ] || ln -s ../../../tanmatsu/components/meshcore/core components/meshcore/core
+CORE_LINK="components/meshcore/core"
+CORE_TARGET="../../../tanmatsu/components/meshcore/core"
+if [ ! -L "$CORE_LINK" ] || [ "$(readlink "$CORE_LINK")" != "$CORE_TARGET" ]; then
+  rm -rf "$CORE_LINK"
+  ln -s "$CORE_TARGET" "$CORE_LINK"
+fi
+python3 ../scripts/build/patch_meshcore_txt_timestamp.py \
+  --patch-file "$CORE_LINK/src/helpers/BaseChatMesh.cpp"
 echo "linked: meshcore core -> tanmatsu's vendored copy"
 
 # --- LVGL 8.4 (own component; big; uses the repo's include/lv_conf.h) ---


### PR DESCRIPTION
## Summary

Fixes outbound direct-message packets being stamped with arbitrary future dates after boot. The issue was caused by MeshCore's direct-message uniqueness state treating a random 32-bit value as a Unix timestamp floor.

Closes #374.

## Root cause

`core-v1.17.4` initializes `BaseChatMesh::_txt_last_ts` from unrestricted RNG state at boot. `sendMessage()` then obtains the correct RTC time but raises it above that random value before serializing the timestamp into the encrypted TXT payload.

The packet attached to #374 contains timestamp `3135105232`, or 2069-05-06 UTC, while the device clock is correct. At the current epoch, a random 32-bit seed exceeds real time on roughly 58% of boots, matching the reported behavior where repeated restarts eventually produce a good boot and an OTA restart can bring the fault back.

The normal clock display and `Sync clock from system` cannot repair this because they update the real RTC, not the private random `_txt_last_ts` watermark.

Room posts use the same direct plaintext path. A future-dated post can advance a room server's per-client replay watermark, causing later Join, request, or keep-alive traffic to be rejected as stale.

## Changes

- Adds an idempotent, fail-closed build patch for pinned MeshCore `core-v1.17.4`.
- Removes only the unrestricted random `_txt_last_ts` seed; other RNG-derived diagnostic state remains unchanged.
- Leaves `getCurrentTimeUnique()` and the within-boot `_txt_last_ts` ratchet intact, so direct messages remain monotonic while carrying real Unix time.
- Verifies the complete RTC-to-ratchet-to-serializer source contract before applying or accepting the patch.
- Rejects missing, duplicated, partially patched, marker-only, or version-drifted core sources.
- Handles existing PlatformIO dependencies before compilation.
- On a fresh dependency fetch, patches at pre-link and deliberately fails that first link so an unpatched object cannot ship; the next build compiles the corrected source.
- Registers the patch for all PlatformIO touch target families, including the inherited Heltec V4-R8 environment.
- Applies and verifies the patch when vendoring MeshCore for Tanmatsu.
- Requires T-Display P4 to use the canonical Tanmatsu-shared core, replacing stale standalone generated trees during dependency fetch and failing CMake configuration for a wrong link or unverified source.
- Persists the live `ClockFloorRTC` floor before controlled non-factory reboots, download mode, backup-import restart, SD migration restart, and deep sleep.
- Leaves factory reset excluded because it intentionally erases identity and replay state.

## Compatibility

The encrypted TXT wire layout is unchanged. Timestamp, attempt bits, text, ACK derivation, retries, and packet framing retain their existing format. Core-managed retries remain exact packet clones.

This is carried as a temporary dependency patch because both the pinned tag and current `ALLFATHER-BV/meshcomod` main still contain the defect and no corrected core tag exists. It can be removed when the same fix is released in a new core tag.

Already-poisoned room-server client records may need to be deleted/reset once so their replay watermark returns to current time.

## Validation

All repository hardware targets compiled at commit `0b7afc2`.

PlatformIO (`scripts/build-all-targets.sh --pio`):

- `heltec_v4_tft_companion_radio_usb_tcp_touch`
- `heltec_v4_r8_tft_companion_radio_usb_tcp_touch`
- `attaky_mesh_series_companion_radio_touch`
- `LilyGo_TDeck_companion_radio_touch`
- `tlora_pager_lr1121_companion_radio_touch`
- `tlora_pager_sx1262_companion_radio_touch`
- `ThinkNode_M9_companion_radio_touch`
- `rak_tap_v2_companion_radio_touch`

ESP-IDF 5.5.1:

- T-Display P4 linked successfully; `application.bin` is 3,478,816 bytes with 17% of the app partition free.
- Tanmatsu compiled and linked successfully from a no-space worktree; `application.bin` is 3,160,752 bytes. Its final generic OTA `app_check_size` reports the expected 2 MiB partition overflow because Tanmatsu ships this binary as an AppFS application; the repository's app-store release script explicitly treats this check as non-fatal after rejecting real compiler/linker errors.

Additional checks:

- Patcher self-test covers exact patching, idempotency, source drift, duplicate blocks, poisoned markers, and strict verification.
- Exact pinned `BaseChatMesh.cpp` rejects verification before patching and passes afterward.
- Simulated existing and fresh PlatformIO/SCons dependency lifecycles pass.
- Tanmatsu/P4 vendoring and CMake success/failure guards pass.
- PlatformIO configuration parsing passes with all target hooks present exactly once.
- Python, C++, and CMake editor diagnostics are clean.
- Shell syntax checks and `git diff --check` pass.

Hardware packet capture was not performed. Abrupt power removal can still lose timestamp-floor progress made since the last durable preference snapshot; controlled reset paths now persist it explicitly.
