### PR TITLE
M9 battery pass: reachable battery saver, GPS-off leakage, mid-session GPS UART ring (+ spectrum sweep wall-clock bound)

### DIFF
--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -5003,6 +5003,21 @@ void MyMesh::handleCmdFrame(size_t len) {
         #if ENV_INCLUDE_GPS == 1
         // Update node preferences for GPS settings
         if (strcmp(sp, "gps") == 0) {
+          // Companion-app "gps on" mid-session: same 4 KB RX-ring upgrade the
+          // touch UI's toggleGPS does — the boot-time gate in main.cpp only
+          // installs it when gps_enabled was already persisted, and
+          // setRxBufferSize is a no-op on the running UART. Matches
+          // setSettingValue's own enable test (anything but "0" starts the
+          // GPS — not just "1"), and runs only on SUCCESS so a refused enable
+          // (no GPS detected on the V4/R8 detect path) doesn't pay the 4 KB.
+          // Cycling just after start is benign: everything here runs on
+          // loopTask, and the module has barely powered up (EN-pin boards) or
+          // at worst loses one torn, checksum-rejected sentence (EN-less
+          // boards, whose modules stream even while "stopped").
+          if (strcmp(np, "0") != 0) {
+            extern void gpsEnsureBigRxRing();
+            gpsEnsureBigRxRing();
+          }
           _prefs.gps_enabled = (np[0] == '1') ? 1 : 0;
           savePrefs();
         } else if (strcmp(sp, "gps_interval") == 0) {

--- a/src/helpers/WadaNmeaLocationProvider.h
+++ b/src/helpers/WadaNmeaLocationProvider.h
@@ -16,7 +16,9 @@
 // wada.sys.gps() binding then reports speed_kmh/course on that board.
 //
 // Kept in lock-step with the core header it mirrors (meshcomod core-v1.17.4);
-// if the core provider gains behaviour, port it here too.
+// if the core provider gains behaviour, port it here too. ONE deliberate
+// deviation (2026-09-02 battery pass): the reset line is parked LOW — not
+// asserted — while the GPS is stopped; see the comment in the constructor.
 
 #include <helpers/sensors/MicroNMEALocationProvider.h>   // GPS_EN/GPS_RESET macros, LocationProvider
 #include <MicroNMEA.h>
@@ -45,7 +47,18 @@ public:
         _peripher_power(peripher_power), _pin_reset(pin_reset), _pin_en(pin_en) {
     if (_pin_reset != -1) {
       pinMode(_pin_reset, OUTPUT);
-      digitalWrite(_pin_reset, GPS_RESET_ACTIVE);
+      // Park the reset line LOW while the GPS is off — NOT "asserted" (the
+      // core's convention). On a direct-wired active-LOW reset LOW *is*
+      // asserted, so this changes nothing there. On the M9 the polarity is
+      // inverted by a transistor (GPS_RST1 -> R46 -> NPN Q16: GPIO HIGH =
+      // reset asserted), so the core convention holds the GPIO HIGH and
+      // sources (3.3 V - Vbe)/R46 of Q16 base current the entire time the
+      // GPS is OFF — its default state — for a module that is unpowered
+      // anyway (EN inactive cuts its rail; the reset level is moot). LOW is
+      // the zero-current level for both circuits. A clean reset at power-on
+      // is still guaranteed: every start path (initBasicGPS / start_gps)
+      // calls begin() then reset(), and reset() pulses the line explicitly.
+      digitalWrite(_pin_reset, LOW);
     }
     if (_pin_en != -1) {
       pinMode(_pin_en, OUTPUT);
@@ -80,7 +93,10 @@ public:
 
   void stop() override {
     if (_pin_en != -1) digitalWrite(_pin_en, !GPS_EN_ACTIVE);
-    if (_pin_reset != -1) digitalWrite(_pin_reset, GPS_RESET_ACTIVE);
+    // LOW, not GPS_RESET_ACTIVE — the zero-current park level for both reset
+    // circuits (see the constructor comment; on the M9 "asserted" = GPIO HIGH
+    // through R46 into Q16's base = a constant drain while the GPS is off).
+    if (_pin_reset != -1) digitalWrite(_pin_reset, LOW);
     release();
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -644,6 +644,41 @@ void meshcomodClearSdMigLatch() {
 }
 #endif
 
+#if defined(ENV_INCLUDE_GPS) && (ENV_INCLUDE_GPS == 1)
+// Whether Serial1 got the 4 KB RX ring (the boot-time gate in setup() below
+// only installs it when gps_enabled was already persisted).
+static bool s_gps_big_rx_ring = false;
+// Called by the "gps on" paths (UITask::toggleGPS, the companion
+// CMD_SET_CUSTOM_VAR("gps") handler) right after a SUCCESSFUL mid-session
+// start. Such an enable used to run the whole session on the stock 256 B
+// ring — setRxBufferSize is a no-op on a running UART, and initBasicGPS()
+// opened Serial1 at boot — with only ~22 ms of slack at the M9's 115200
+// baud, so any loop stall past that (a long LVGL frame; every 50 ms
+// battery-saver park) clipped NMEA bursts until the next reboot. Cycle it:
+// end -> resize -> begin, with the same pins/baud initBasicGPS() uses. Safe
+// even though the line may already carry NMEA (boards without a GPS EN pin —
+// T-Deck, pagers, RAK TAP — have always-powered modules that stream even
+// while "stopped"): every Serial1 reader runs on this same loopTask, so the
+// worst case is one torn, checksum-rejected sentence plus dropping the stale
+// 256 B backlog.
+void gpsEnsureBigRxRing() {
+  if (s_gps_big_rx_ring) return;
+  Serial1.end();
+  Serial1.setRxBufferSize(4096);
+  Serial1.setPins(PIN_GPS_TX, PIN_GPS_RX);  // same (module-perspective) order as initBasicGPS
+#ifdef GPS_BAUD_RATE
+  const uint32_t k_gps_baud_default = GPS_BAUD_RATE;
+#else
+  const uint32_t k_gps_baud_default = 9600;
+#endif
+#if defined(HAS_TOUCH_UI) && defined(ESP32)
+  Serial1.begin(touchPrefsGetGpsBaud(k_gps_baud_default));
+#else
+  Serial1.begin(k_gps_baud_default);
+#endif
+  s_gps_big_rx_ring = true;
+}
+#endif
 
 void setup() {
   Serial.begin(115200);
@@ -1424,15 +1459,17 @@ void setup() {
   // unconditional 4 KB ring permanently costs ~3.8 KB of scarce internal DRAM for nothing
   // on the GPS-off majority (the "RAM is higher now" reports). GPS-on users (who actually
   // hit the overflow) still get the big ring; default GPS-off keeps the stock 256 B. A user
-  // who enables GPS mid-session picks it up on the next reboot (gps_enabled is persisted).
+  // who enables GPS mid-session gets it immediately via gpsEnsureBigRxRing() above (it
+  // used to wait for the next reboot).
   {
 #if defined(ATTAKY_MESH_SERIES)
     // This fixed stack always carries the GPS, so take the larger RX ring
     // unconditionally; the default 256 B ring gives the slowest first fix.
     Serial1.setRxBufferSize(4096);
+    s_gps_big_rx_ring = true;
 #else
     auto* np = the_mesh.getNodePrefs();
-    if (np && np->gps_enabled) Serial1.setRxBufferSize(4096);
+    if (np && np->gps_enabled) { Serial1.setRxBufferSize(4096); s_gps_big_rx_ring = true; }
 #endif
   }
 #endif

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -12026,7 +12026,7 @@ static void uiScaleSelectCb(lv_event_t* e) {
 #endif
 
 // Hard-lock (not just dim) when the screen idles off, so the touchscreen is
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(HAS_THINKNODE_M9)
 // Toggle idle light-sleep via the Settings row. Updates NVS, the live
 // touchSleep state, and the status-bar icon in one shot (mirrors lockOnScreenOffToggleCb).
 static void sleepIdleToggleCb(lv_event_t* e) {
@@ -13912,12 +13912,19 @@ static void buildDeviceSettings(int sec) {
     lv_obj_center(l_bat);
     y += SC(42);
   }
-#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8)
+#if defined(HAS_TDECK_GT911) || defined(HELTEC_LORA_V4_R8) || defined(HAS_THINKNODE_M9)
   // Experimental battery saver (idle power-save) — throttles the CPU when the
   // device is parked (screen off, on battery, standalone). Moved here from
   // Settings -> Lock so it lives with the battery. T-Deck + V4-R8 (the old
   // "gate never passes on the V4" note was stale for the R8: batteryIsCharging
-  // can't block it there, and the other gates are user state).
+  // can't block it there, and the other gates are user state) + M9 (2026-09-02
+  // battery pass: the hooks were already installed and every gate works there —
+  // the throttle is a plain vTaskDelay in the loop task, wake is the keyboard
+  // poll that runs through it, and the M9 is in batteryIsCharging's #else
+  // branch (compile-time false), so the "USB powered" gate can never block —
+  // even stronger than the R8, whose runtime voltage heuristic can — but no
+  // M9 build ever compiled this switch, so on the M9 the pref was permanently
+  // OFF).
   {
     int h = settingsRowLabel(body, y, 6, TR("Battery saver (experimental)"), COLOR_TEXT, &g_font_12, 56);
     lv_obj_t* sw = lv_switch_create(body);
@@ -53382,6 +53389,23 @@ void UITask::toggleGPS() {
   const char* value = target_on ? "1" : "0";
   bool hw_ok = false;
   if (_sensors) hw_ok = _sensors->setSettingValue("gps", value);
+#if defined(ENV_INCLUDE_GPS) && (ENV_INCLUDE_GPS == 1)
+  // GPS just turned ON mid-session: give Serial1 the 4 KB RX ring. The
+  // boot-time gate in main.cpp installs it only when gps_enabled was already
+  // persisted, and setRxBufferSize is a no-op on a running UART — so without
+  // this the session that first enables GPS runs NMEA into the stock 256 B
+  // ring until reboot (~22 ms of slack at the M9's 115200 baud; a long LVGL
+  // frame or one 50 ms battery-saver park clips the burst). Gated on hw_ok so
+  // a refused enable (V4/R8 detect path, no module found) doesn't spend the
+  // 4 KB of internal DRAM; cycling just after a successful start is benign —
+  // same loopTask as every Serial1 reader, module barely powered (EN-pin
+  // boards) or at worst one torn, checksum-rejected sentence (EN-less boards,
+  // whose always-powered modules stream even while "stopped").
+  if (target_on && hw_ok) {
+    extern void gpsEnsureBigRxRing();
+    gpsEnsureBigRxRing();
+  }
+#endif
   // If the sensor manager doesn't recognise the setting (built without
   // ENV_INCLUDE_GPS), fall back to just flipping the pref so the UI is
   // still consistent — same behaviour as before.
@@ -55724,8 +55748,10 @@ void UITask::loop() {
     if (_screen_off || _manual_lock) kb_bl = 0;   // dark/locked screen -> keyboard dark too
     else if (s_msgflash_until && (int32_t)(now - s_msgflash_until) < 0) kb_bl = 255;   // notify pulse
     // Cache the last duty the controller ACTUALLY took, not the last one
-    // computed: the write is dropped while the controller (its own MCU on the
-    // switched rail) is still booting, or on a NACK — latching a dropped
+    // computed: the write is dropped while the controller (its own MCU, on
+    // always-on 3V3 via R3 per the schematic-verified note in platformio.ini
+    // — NOT the switched rail an earlier revision here claimed) is still
+    // booting, or on a NACK — latching a dropped
     // write would leave the controller on its power-on default until the
     // next mode/lock change. And 255 is a normal FIRST value (mode "On"
     // restored from prefs; auto during the first idle window), so a 0xFF

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -23540,7 +23540,28 @@ static void openDiscoverPage() {
 // the radio while we own it.
 static const int   SPEC_BINS      = 160;     // frequency bins across the span
 static const int   SPEC_WF_ROWS   = 48;      // waterfall height (rows of history; zoomed to fit width)
-static const int   SPEC_CHUNK     = 8;       // bins swept per timer tick (~5.5 ms/bin -> ~44 ms UI block)
+static const int   SPEC_CHUNK     = 8;       // MAX bins per timer tick (~5.5 ms/bin -> ~44 ms UI block)
+// The ~5.5 ms/bin figure above is CORRECT — verified on M9 hardware 2026-08-28,
+// which is the "re-verify with a micros() log on hardware" the standby(0x01)
+// comment further down asks for. Measured: 5181-5904 us/bin, so 8 bins really is
+// the ~44 ms tick the constant promises. Recorded here so nobody re-derives it.
+//
+// It was measured while chasing repeated ~1.7 s "ui:lvgl" stalls that appear
+// ONLY while this page is open, on the theory that the sweep was overrunning.
+// It is not: the sweep is on budget. The time is in the REDRAW path
+// (spectrumPushWaterfall / spectrumDrawTrace) — instrumenting the flush
+// callback showed ~1.8 s of LVGL compute against only ~190 ms of actual panel
+// flush, i.e. the cost is LVGL rendering, not SPI bandwidth.
+// Do not "fix" the sweep; look at the waterfall canvas and the 160-point chart.
+//
+// The wall-clock bound below therefore is NOT that fix. It is a cheap guard so a
+// slower radio or a busier bus can never turn this tick into a multi-second UI
+// block, plus the permanent per-bin measurement. It is clamped so it can only
+// ever REDUCE bins per tick, never raise them above SPEC_CHUNK — on hardware it
+// simply settles at 7-8, i.e. today's behaviour, on every board.
+static const uint32_t SPEC_TICK_BUDGET_US = 45000;   // the ~44 ms UI block this was designed around
+static int         s_spec_chunk   = SPEC_CHUNK;      // adaptive bins/tick, retuned each sweep chunk
+static uint32_t    s_spec_bin_us  = 0;               // last measured per-bin sweep cost
 // Honest-coverage note: 24 MHz / 160 bins = 150 kHz of bin pitch, but each bin
 // listens through a 62.5 kHz channel filter — only ~42% of the span is inside a
 // filter on any sweep, so a narrowband carrier sitting between bin centers is
@@ -23641,7 +23662,9 @@ static void spectrumUpdateFloor() {
 // snapshot almost always missed. (The mesh is paused — spectrumOwnsRadio() — so nothing
 // else touches the modem while we hop it across the band.)
 static bool spectrumSweepChunk() {
-  int end = s_spec_pos + SPEC_CHUNK;
+  const int      start_pos = s_spec_pos;
+  const uint32_t t_chunk0  = micros();
+  int end = s_spec_pos + s_spec_chunk;
   if (end > SPEC_BINS) end = SPEC_BINS;
 #if defined(RADIO_CLASS)
   for (int i = s_spec_pos; i < end; i++) {
@@ -23721,6 +23744,38 @@ static bool spectrumSweepChunk() {
   }
 #endif
   s_spec_pos = end;
+
+  // Size the NEXT tick from what these bins actually cost. micros() subtraction
+  // is unsigned, so the ~71 min wrap is handled. Always advance at least one bin
+  // (forward progress beats a perfectly smooth UI that never finishes a sweep),
+  // and never exceed SPEC_CHUNK so a radio that already met the 5.5 ms/bin
+  // assumption is bit-for-bit unchanged. The log fires only when the value moves,
+  // so it stays quiet in use — and it is the "micros() log on hardware" the
+  // standby(0x01) comment above asks for, now permanent instead of a one-off.
+  const int swept = end - start_pos;
+  if (swept > 0) {
+    const uint32_t tick_us = (uint32_t)(micros() - t_chunk0);
+    s_spec_bin_us = tick_us / (uint32_t)swept;
+    // HYSTERESIS, not a control loop that chases the jitter. Shrink as soon as a
+    // tick actually overruns the budget; grow only when the tick is comfortably
+    // (2x) inside it. Without this the chunk flapped 7<->8 forever, because
+    // 8 bins x ~5.5 ms sits within jitter of the 45 ms budget.
+    int want = s_spec_chunk;
+    if (tick_us > SPEC_TICK_BUDGET_US && s_spec_bin_us) {
+      want = (int)(SPEC_TICK_BUDGET_US / s_spec_bin_us);
+    } else if (tick_us * 2u < SPEC_TICK_BUDGET_US && s_spec_chunk < SPEC_CHUNK) {
+      want = s_spec_chunk + 1;
+    }
+    if (want < 1)          want = 1;    // always make progress
+    if (want > SPEC_CHUNK) want = SPEC_CHUNK;
+    if (want != s_spec_chunk) {
+      Serial.printf("[SPEC] %lu us/bin, tick %lu us -> %d bins/tick (was %d, budget %lu us)\n",
+                    (unsigned long)s_spec_bin_us, (unsigned long)tick_us, want, s_spec_chunk,
+                    (unsigned long)SPEC_TICK_BUDGET_US);
+      s_spec_chunk = want;
+    }
+  }
+
   if (s_spec_pos >= SPEC_BINS) { s_spec_pos = 0; spectrumUpdateFloor(); return true; }
   return false;
 }

--- a/variants/thinknode_m9/M9Keyboard.cpp
+++ b/variants/thinknode_m9/M9Keyboard.cpp
@@ -55,8 +55,12 @@ static void kbTryFindBus() {
 
 void m9KeyboardBegin() {
   Wire1.begin(PIN_KB_SDA, PIN_KB_SCL);
-  // The controller is its own MCU on the switched peripheral rail and may
-  // still be booting here — poll re-probes once a second until it answers.
+  // The controller is its own MCU (ESP32-S2) on the ALWAYS-ON 3V3 rail via R3
+  // (schematic-verified, see the keyboard-bus note in platformio.ini — an
+  // earlier revision of this comment said "switched peripheral rail", which
+  // matters for the deep-sleep drain budget: the S2 keeps drawing through a
+  // deep sleep, and only the power slider actually cuts it). It may still be
+  // booting here — poll re-probes once a second until it answers.
   kbTryFindBus();
   if (!s_bus) Serial.println("M9 keyboard: no controller yet (will keep probing)");
   s_inited = true;

--- a/variants/thinknode_m9/M9_PORT.md
+++ b/variants/thinknode_m9/M9_PORT.md
@@ -873,6 +873,106 @@ Still open on the map, in win/risk order: a priority lane for visible tiles
 29-tile background prefetch pyramid on every pan), a retry pump so a dropped
 fetch heals without a manual pan, and the SD clock below.
 
+## Battery pass (2026-09-02) — saver unreachable, GPS-off base current
+
+Battery-focused sweep of the board code plus every shared power path the M9
+compiles. Verified sound and left alone: `getBattMilliVolts()`'s ADC2
+per-sample filter + 2:1 math; backlight-off (`ledcWrite(ch, 255)` is
+special-cased by the framework to duty 256 = constant HIGH — checked in
+`esp32-hal-ledc.c`, so "off" is truly off, no 1/256 PWM sliver); compass/IMU
+suspend-on-idle actually ticked from the UI loop; the 15 ms keyboard poll; the
+20 s default screen timeout with the 240→80 MHz drop; buzzer noTone + high-Z;
+the (latent) deep-sleep hold sequence; battery-log flash wear (~century-scale
+on SPIFFS at the 5-min cadence). Three findings, two fixed now:
+
+1. **Battery saver was unreachable — FIXED.** The touchSleep idle throttle was
+   fully wired on the M9 (hooks installed + pref restored under
+   `HAS_TOUCH_UI`, every gate predicate functional) but the only enable UI —
+   the Settings→Battery switch — was compiled for T-Deck + V4-R8 only, and the
+   pref defaults OFF with no console path either. So an idle, screen-off,
+   standalone M9 free-spun its loop forever; the whole subsystem was dead
+   code. Both `#if`s (settings row + `sleepIdleToggleCb`) now include
+   `HAS_THINKNODE_M9`. The M9 is arguably the *safest* board for it: the
+   throttle is a plain vTaskDelay in the loop task, wake is the keyboard poll
+   which runs through it (≤50 ms latency on a dark screen), and the M9 sits
+   in `batteryIsCharging()`'s `#else` branch (compile-time false), so the
+   "USB powered" gate can never block — even stronger than the R8, whose
+   runtime voltage heuristic still can (the R8's widening rationale was that
+   its heuristic doesn't block in practice, not compile-time falsity).
+   Matching the R8 precedent, no status-bar indicator (the amber battery
+   tint stays T-Deck-only); the settings row shows the live block reason.
+   VERIFY on hardware — and note the obvious probe is a decoy: the Battery
+   chart's CPU-MHz series sits at 80 on ANY screen-off M9 (that drop belongs
+   to the pre-existing screen timeout, not the throttle), and keypress wake
+   also works saver-off. The discriminating readout is the Battery chart
+   window's "Idle power-save" stats card (wakeCount / % asleep — unguarded,
+   present on the M9). The FULL gate must pass or the counters sit at 0 and
+   the feature looks broken: saver on, screen off, no companion client, AND
+   the BLE + Wi-Fi radios actually off (BLE is on by default in this
+   companion build — "standalone" is not enough; the settings row's block
+   reason names the offender), on battery, mesh idle. Under that regime the
+   counters must MOVE (on a boot where the saver was never engaged they
+   never leave 0). Then confirm a keypress still wakes the dark screen
+   (≤50 ms extra latency is expected).
+
+2. **GPS-off burned Q16 base current — FIXED, magnitude needs the bench.**
+   `WadaNmeaLocationProvider`'s constructor and `stop()` followed the core's
+   convention of parking GPS_RESET *asserted*. Zero-cost on a direct-wired
+   active-LOW reset — but the M9's reset is inverted (GPS_RST1 → R46 → NPN
+   Q16, GPIO HIGH = asserted), so "asserted" held GPIO5 HIGH sourcing
+   (3.3 V − Vbe)/R46 continuously whenever the GPS was OFF (its default
+   state; `initBasicGPS()` stops it at every boot) — for a module whose rail
+   EN had already cut. Both sites now park the line LOW, the zero-current level
+   for *both* circuits (LOW = asserted on direct-wired boards, so nothing
+   changes there; the provider is M9-only today anyway). The clean-reset
+   guarantee is intact: every start path calls `begin()` then `reset()`,
+   which pulses the line explicitly. VERIFY on hardware: R46's value (read
+   it off the board or the schematic) decides whether this saved ~0.3 mA
+   (10k) or ~2.7 mA (1k); and confirm GPS still acquires after an
+   off→on→off→on toggle cycle.
+
+3. **Screen-off leaves the ST7789 panel driving — still open (already on the
+   deferred list).** The M9 branch of `touchScreenBacklight()` kills only the
+   backlight; SLPIN/DISPOFF panel sleep remains "designed, not coded blind"
+   (shared-SPI variant of the T-Deck path). The battery angle strengthens
+   the case: SLPIN stops the oscillator/booster/LC drive (~1–2 mA class) for
+   every screen-off hour, on top of the anti-burn-in argument.
+
+4. **Saver × GPS: mid-session enable ran NMEA into the stock 256 B ring —
+   FIXED (found by this pass's adversarial review of finding 1).** The 4 KB
+   Serial1 RX ring from the TTFF fix is installed at boot ONLY when
+   gps_enabled was already persisted, and `setRxBufferSize` is a no-op on a
+   running UART — so the session where GPS is first enabled ran on 256 B
+   (~22 ms of slack at the M9's 115200 baud, the only saver board at that
+   rate BY DEFAULT — the baud is NVS-overridable on every touch board, so a
+   T-Deck/R8 dialed up to 115200 hits the same wall; at their defaults,
+   38400 / 9600 can't overflow in one park). With the saver newly reachable,
+   every 50 ms park spans ~576 line-rate bytes: a 1 Hz NMEA burst landing
+   inside a park lost its tail. The damage is host-side — MicroNMEA discards
+   checksum-failed sentences, so the host's parsed fix goes stale (worst
+   case, with every burst clipped, it never sees an intact sentence until
+   reboot); the receiver itself keeps its own acquisition regardless. Root
+   cause fixed rather than gating the saver (a screen-off standalone tracker
+   is exactly the saver's target regime): `gpsEnsureBigRxRing()` in main.cpp
+   cycles the UART (end → 4 KB ring → begin at the initBasicGPS pins/baud)
+   and is called from BOTH mid-session "gps on" funnels —
+   `UITask::toggleGPS()` (keyboard GPS_LONG chord, CC chip, settings switch)
+   and the companion `CMD_SET_CUSTOM_VAR("gps")` handler in MyMesh.cpp —
+   right AFTER a successful start (so a refused enable on a GPS-less V4/R8
+   never spends the 4 KB; the just-started cycle is benign — everything
+   Serial1 runs on loopTask, worst case one torn checksum-rejected
+   sentence on the EN-less boards whose modules stream even while
+   "stopped"). Boot-persisted GPS-on takes the unchanged boot path; GPS-off
+   boots still pay 0 extra DRAM until GPS actually starts. VERIFY on
+   hardware: enable GPS mid-session (no reboot) with the saver on, screen
+   off → a fix should still arrive and hold.
+
+Also corrected: BOTH copies of the "keyboard S2 sits on the switched
+peripheral rail" claim — `M9Keyboard.cpp` begin() and the keyboard-backlight
+cache comment in `UITask.cpp`'s M9 branch — now match the schematic-verified
+note in platformio.ini (always-on 3V3 via R3). It matters: a deep-sleeping
+M9 still feeds the S2; only the slider cuts it.
+
 ## Deferred — hardware-verify list
 
 These are left intentionally unset/unwired rather than guessed:


### PR DESCRIPTION
Two commits on a clean beta_75 base.

## M9 battery pass (`d59ce2c`)

A battery-focused audit of the M9 with three fixes:

1. **The battery saver was unreachable on the M9.** The touchSleep machinery (hooks, gates, pref restore) was fully wired under `HAS_TOUCH_UI`, but the only enable UI — the Settings→Battery switch — was compiled for the T-Deck and V4-R8 only, and the pref defaults OFF with no other setter. Both `#if`s now include `HAS_THINKNODE_M9`. The M9 is a natural fit: the throttle is a plain vTaskDelay in the loop task, wake is the keyboard poll that runs through it (≤50 ms latency on a dark screen), and the M9 sits in `batteryIsCharging()`'s `#else` branch (compile-time false), so the "USB powered" gate can never wrongly block. Matching the R8 precedent: no status-bar indicator; the settings row shows the live block reason.

2. **GPS-off burned Q16 base current on the M9.** `WadaNmeaLocationProvider` parked GPS_RESET *asserted* while stopped (the core's convention — free on a direct-wired active-LOW reset). The M9's reset is inverted (GPS_RST1 → R46 → NPN Q16, GPIO HIGH = asserted), so "asserted" sourced (3.3 V − Vbe)/R46 continuously whenever the GPS was OFF — its default state — for a module whose EN rail was already cut. The line now parks LOW: the zero-current level for both circuit styles (LOW *is* asserted on direct-wired boards, so nothing changes there; the provider is M9-only today anyway). Every start path still calls `begin()` then `reset()`, so the clean-reset-at-power-on guarantee holds.

3. **Mid-session GPS enable ran the whole session on the stock 256 B Serial1 ring.** The 4 KB TTFF ring is boot-gated on the persisted `gps_enabled`, and `setRxBufferSize` is a no-op on a running UART — so the session that first enables GPS had ~22 ms of RX slack at the M9's 115200 baud, and with the saver newly reachable, a single 50 ms park clips a whole NMEA burst (host-side: checksum-failed sentences discarded, stale fix until reboot). New `gpsEnsureBigRxRing()` in main.cpp cycles the idle-enough UART (end → 4 KB → begin at the initBasicGPS pins/baud) from BOTH "gps on" funnels — `UITask::toggleGPS()` and the companion `CMD_SET_CUSTOM_VAR("gps")` handler — right after a *successful* start, so a refused enable (GPS-less V4/R8 detect path) never spends the DRAM, and the enable test matches `setSettingValue`'s real semantics (anything but "0").

Also corrects both stale "keyboard S2 on the switched rail" comments (schematic truth per platformio.ini: always-on 3V3 via R3 — it decides the deep-sleep drain budget).

Full record, rationale, and the on-device VERIFY list in `variants/thinknode_m9/M9_PORT.md` → "Battery pass (2026-09-02)". Note for testers: the saver's proof is the Battery chart's *Idle power-save counters moving* (the CPU-at-80 readout is a decoy — that drop belongs to the pre-existing screen timeout), and the gate needs BLE + Wi-Fi actually off.

## Spectrum sweep wall-clock bound (`eb17bcc`)

Carried forward from the audit-pass-3 branch (everything else from that branch is already in beta_75): bounds the spectrum sweep tick by wall clock and records the real per-bin cost.

## Verification

- All 8 PlatformIO envs compile on the beta_75 base.
- The battery pass went through two adversarial multi-agent review rounds; every confirmed finding (including the UART-ring interaction, found by the review of fix 1) is addressed in this diff.
- Flashed and running on an M9 (hash-verified upload); on-device VERIFY items listed in M9_PORT.md.
