### PR TITLE
Focus M9 composer when opening chats

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -5077,14 +5077,25 @@ static void navMaybeRebuild() {
   // When a chat just opened, drop focus on its composer so typing goes straight in (issue: textfield
   // not auto-selected). Only on the open transition, so new messages don't steal focus mid-typing.
   bool focus_set = false;   // true once we deliberately focus a COLLECTED obj (else LVGL defaults to the first item)
+  // A still-valid hint can belong to the page behind a newly opened overlay. Only a hint
+  // collected into this rebuild may suppress the new-chat composer fallback (#436).
+  lv_obj_t* collected_focus_hint = nullptr;
   if (s_nav_focus_hint && lv_obj_is_valid(s_nav_focus_hint)) {
     // One-shot explicit focus hint — e.g. turning keyboard-nav ON keeps the highlight on the switch you
     // just toggled instead of snapping the settings list to the top (issue #45).
     const int n = s_nav_count < kNavMax ? s_nav_count : kNavMax;
-    for (int i = 0; i < n; i++) if (s_nav_objs[i] == s_nav_focus_hint) { lv_group_focus_obj(s_nav_focus_hint); focus_set = true; break; }
-    s_nav_focus_hint = nullptr;   // consume regardless (one-shot)
+    for (int i = 0; i < n; i++) {
+      if (s_nav_objs[i] == s_nav_focus_hint) { collected_focus_hint = s_nav_focus_hint; break; }
+    }
+  }
+  s_nav_focus_hint = nullptr;   // consume regardless (one-shot)
+  if (collected_focus_hint) {
+    lv_group_focus_obj(collected_focus_hint);
+    focus_set = true;
   } else if (chat && chat != s_nav_prev_chat && chat->composer_ta && lv_obj_is_valid(chat->composer_ta)) {
     lv_group_focus_obj(chat->composer_ta);   // chat just opened → focus the composer
+    s_nav_ta_editing = true;
+    navSyncCursor();                         // hardware input is ready immediately
     focus_set = true;
   } else if (on_page && !s_nav_prev_on_page && s_nav_page_focus && lv_obj_is_valid(s_nav_page_focus)) {
     // #45: just returned to the page from an overlay/chat — restore the item we left from so the


### PR DESCRIPTION
## Summary
- ignore one-shot focus hints that belong to the screen behind a newly opened chat
- focus the active chat composer when entering a DM, room, or channel
- enter textarea edit mode immediately so M9 keyboard input works without an extra Enter press

## Root cause
The first virtualized-history render could preserve the still-focused inbox row as a valid pointer. Because that object was not part of the newly collected chat focus tree, the hint selected nothing while suppressing the composer fallback. `showKb()` still painted a cursor, leaving visual focus and actual keypad focus out of sync.

## Validation
- hardware tested on ThinkNode M9: opening a chat leaves the composer ready for immediate keyboard input
- `git diff --check` passes
- VS Code diagnostics report no errors in `UITask.cpp`

Fixes #436