### PR TITLE
Add Pager special-character picker shortcut

### DIFF
--- a/TLORA_PAGER_SHORTCUTS.md
+++ b/TLORA_PAGER_SHORTCUTS.md
@@ -17,9 +17,9 @@ on both.
   (press the knob) to select. It's your only pointing device, so almost
   every screen is navigable with turn + click alone.
 
-Everything below only fires while you're **not** actively typing into a text
-field — if a field is focused and you're typing into it, letters type
-normally and these combos step out of the way.
+Unless a row explicitly says it applies to a text field, the shortcuts below
+only fire while you're **not** actively typing. Letters continue to type
+normally while a field is active.
 
 ## Bottom menu shortcuts
 
@@ -45,6 +45,7 @@ while editing a text field, where the keys type normally.
 | Hold ~1 s, then release | **Back**: closes a popup → closes an open chat → goes Home → Esc (whichever applies first) | **Backspace held ~1 s** |
 | **Fn (Alt) + turn**, on a main tab | Move between the 5 main tabs (Mail / Contacts / Home / Map / Settings) | **M / C / H / A / S** jumps directly |
 | **Fn (Alt) + turn**, inside a settings page or chat | Scroll the page up/down | none — encoder only |
+| **Fn (Alt) + short click**, with a text field focused | Open the special-character picker | none — encoder only |
 | Turn, with a dropdown open | Scroll through the dropdown's options | none — encoder only |
 | Turn, with the accent picker open | Cycle through the accent variants (see below) | none — encoder only (Fn+Space to enter is shared) |
 | Turn, with the @-mention list open | Cycle through matching contacts (see below) | none — encoder only |
@@ -128,6 +129,15 @@ return to letters.
    _  $  ;  ?  !  ,  .
 [Space]
 ```
+
+### Symbols not on the keyboard
+
+While any text field is focused, including a Wi-Fi or repeater password:
+
+1. Hold **Fn (Alt)** and short-click the encoder to open **Special characters**.
+2. Turn the encoder to highlight a symbol such as `%`, `<`, `>`, or `€`.
+3. Short-click the encoder or press **Enter** to insert it.
+4. Hold the encoder for about one second to close the picker without inserting.
 
 ### Shift and Caps Lock
 
@@ -247,6 +257,7 @@ that changes keyboard language.
 | Hold encoder ~1s (or hold Backspace ~1s) | Back |
 | Fn + turn (main tab) | Switch tabs |
 | Fn + turn (page/chat) | Scroll |
+| Fn + encoder click (text field focused) | Open special-character picker |
 | Fn tap alone | Use the symbol layer for the next key |
 | Fn double-tap | Lock the symbol layer; tap Fn again to unlock |
 | Hold Shift + letter | Momentary uppercase |

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -38835,14 +38835,28 @@ static void updatePagerEncoder(unsigned long now) {
   static bool     s_was_held    = false;
   static uint32_t s_press_start = 0;
   static bool     s_long_fired  = false;
+  static bool     s_press_consumed = false;
 
   if (held && !s_was_held) {
     s_press_start = now;
     s_long_fired  = false;
-  } else if (held && !s_long_fired && (now - s_press_start) >= kLongPressMs) {
+    s_press_consumed = false;
+    // The keyboard layer lacks %, <, >, and several non-ASCII symbols. Holding
+    // Fn before pressing the knob opens the shared picker for the active field.
+    if (pagerKeyboardAltHeld() && !s_emoji_sheet && !s_mentionnav_active &&
+        !s_accentnav_active && !navOpenDropdown()) {
+      lv_obj_t* ta = navFocusedTextarea();
+      if (ta && lv_obj_is_valid(ta)) {
+        pagerKeyboardMarkAltUsed();
+        openSpecialPicker(ta);
+        s_press_consumed = true;
+      }
+    }
+  } else if (held && !s_press_consumed && !s_long_fired &&
+             (now - s_press_start) >= kLongPressMs) {
     pagerNavGoBack();   // see pagerNavGoBack() above for the ladder + rationale
     s_long_fired = true;
-  } else if (!held && s_was_held && !s_long_fired) {
+  } else if (!held && s_was_held && !s_press_consumed && !s_long_fired) {
     // Released before the long-press threshold -> short click, same as a
     // keyboard Enter: on a focused chat bubble that means the per-message
     // action menu (navEnterBubble), not a plain ENTER keypress -- mirrors
@@ -38851,6 +38865,7 @@ static void updatePagerEncoder(unsigned long now) {
     else if (s_accentnav_active)    accentNavConfirm();  // picking an accent: confirm the highlighted one
     else if (!navEnterBubble())     navPushTap(LV_KEY_ENTER);
   }
+  if (!held && s_was_held) s_press_consumed = false;
   s_was_held = held;
 }
 #endif


### PR DESCRIPTION
## Summary
- open the existing special-character picker with Fn plus a short encoder click while a text field is focused
- insert missing symbols such as `%`, `<`, `>`, and `€` with the existing turn-and-click picker controls
- consume the Fn chord so releasing Fn does not also latch the physical symbol layer
- document the workflow in the Pager keyboard guide

## Validation
- hardware tested on LilyGo T-LoRa Pager
- confirmed missing symbols can be selected and inserted into text fields
- Pager modifier and keyboard-state host tests pass
- `git diff --check` passes
- VS Code diagnostics report no errors in changed files

Fixes #435