### PR TITLE
M9: make Ctrl toggle the Control Center

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -40801,14 +40801,14 @@ static bool m9HandleNavKey(int key) {
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_CTRL:
       // The controller latches ONE key and resolves layers itself, so CTRL can
-      // never chord — bind the standalone press to the Control Center, a
-      // one-press quick-settings key matching its label.
+      // never chord — bind the standalone press to toggle the Control Center,
+      // a one-press quick-settings key matching its label.
       if (s_setup_root) return true;
       // The CC must never stack OVER the power menu: Back's ladder peels
       // power first and would close it invisibly beneath the CC (the reverse
       // stacking is fine — openPowerMenu() closes the CC itself).
       if (s_power_menu) closePowerMenu();
-      openControlCenter();
+      toggleControlCenter();
       s_nav_show = true; if (g_lv.task) g_lv.task->noteUserInput(); return true;
     case M9_KEY_HOME:
       if (s_setup_root) return true;


### PR DESCRIPTION
## Summary
- make the M9 Ctrl key close the Control Center when it is already open
- preserve the existing behavior that closes the power menu before opening the Control Center

## Testing
- tested on ThinkNode M9 hardware
- VS Code diagnostics
- git diff validation

Closes #454