### PR TITLE
Store apps: auto-hide the launch title

### DIFF
--- a/src/ui-touch/AppPage.h
+++ b/src/ui-touch/AppPage.h
@@ -50,6 +50,9 @@ void appPageBegin(const char* title, void (*close_fn)());
  *  own chrome (e.g. the Lua Store's tab bar) starts right at the top. */
 void appPageBeginSlim(const char* title, void (*close_fn)());
 
+/** Hide the current page title while retaining its slim Back bar and close hook. */
+void appPageCollapseTitle(void (*close_fn)());
+
 /**
  * Hand the status bar back — but only if `close_fn` is still the installed hook, so a
  * page closing after another one already opened cannot steal the new page's chrome.

--- a/src/ui-touch/LuaAppHost.cpp
+++ b/src/ui-touch/LuaAppHost.cpp
@@ -181,6 +181,7 @@ constexpr size_t kHeapCap     = 256 * 1024;   // per-app PSRAM cap
 constexpr size_t kMaxSrc      = 192 * 1024;   // app source size limit
 constexpr size_t kStoreMax    = 2048;         // per-app persisted KV budget (bytes, serialized)
 constexpr int    kMinTickMs   = 33;           // fastest on_tick cadence (~30 fps)
+constexpr uint32_t kAppTitleMs = 3000;         // identify the app briefly, then reclaim its top row
 
 // Bumped by wada.ui.clear(). Every widget handle records the generation it was
 // created in; a handle from an older one has already been destroyed, so the
@@ -196,8 +197,9 @@ struct Host {
   lua_State*  L = nullptr;
   LuaHeap     heap;
   lv_obj_t*   root = nullptr;        // full-screen overlay on lv_layer_top
-  lv_obj_t*   body = nullptr;        // app content area (below the tall bar)
+  lv_obj_t*   body = nullptr;        // app content area below the slim Back bar
   lv_timer_t* timer = nullptr;
+  lv_timer_t* title_timer = nullptr;
   int         body_w = 0, body_h = 0;   // set at creation — lv_obj_get_width() reads 0 pre-layout
   uint32_t    last_tick = 0;
   int         ref_app   = LUA_NOREF; // the table the chunk returned
@@ -223,6 +225,12 @@ Host* s_h = nullptr;
 uint32_t s_host_generation = 0;
 
 char s_bar_title[40];   // appPageBegin keeps the pointer — must outlive the page
+
+void titleTimerCb(lv_timer_t* timer) {
+  if (!s_h || s_h->title_timer != timer) return;
+  s_h->title_timer = nullptr;
+  appPageCollapseTitle(&luaAppDismiss);
+}
 
 // ---------------------------------------------------------------------------
 // guarded callback invocation
@@ -2674,6 +2682,7 @@ void hostTeardown() {
   }
   luaHostKeepAwake(false);          // an app cannot hold the screen after it closes
   if (h->timer) { lv_timer_del(h->timer); h->timer = nullptr; }
+  if (h->title_timer) { lv_timer_del(h->title_timer); h->title_timer = nullptr; }
   if (s_net_poll) { lv_timer_del(s_net_poll); s_net_poll = nullptr; }
   if (h->L && s_net_cb != LUA_NOREF) { luaL_unref(h->L, LUA_REGISTRYINDEX, s_net_cb); }
   s_net_cb = LUA_NOREF;              // a worker fetch may still land; netDeliver sees no app and drops it
@@ -2730,8 +2739,8 @@ bool luaAppLaunch(const char* id, const char* title, const char* src, size_t len
   openSandbox(h->L);
   openWada(h->L);
 
-  // UI scaffold: full-screen overlay + tall "< title" bar via AppPage, exactly
-  // like SnakeGame. Body = the content area apps build into.
+  // UI scaffold: full-screen overlay + a slim "< title" bar. The title identifies
+  // the app briefly, then collapses to Back-only so it cannot cover app content.
   h->root = lv_obj_create(lv_layer_top());
   lv_obj_remove_style_all(h->root);
   lv_obj_set_size(h->root, lv_disp_get_hor_res(nullptr), lv_disp_get_ver_res(nullptr));
@@ -2770,9 +2779,11 @@ bool luaAppLaunch(const char* id, const char* title, const char* src, size_t len
   lv_obj_add_event_cb(h->body, pressCb, LV_EVENT_RELEASED, nullptr);
 
   snprintf(s_bar_title, sizeof s_bar_title, "%s", h->title);
-  appPageBegin(s_bar_title, &luaAppDismiss);
+  appPageBeginSlim(s_bar_title, &luaAppDismiss);
 
   s_h = h;
+  h->title_timer = lv_timer_create(titleTimerCb, kAppTitleMs, nullptr);
+  if (h->title_timer) lv_timer_set_repeat_count(h->title_timer, 1);
   storeLoad();
 
   // button-callback table

--- a/src/ui-touch/LuaAppHost.h
+++ b/src/ui-touch/LuaAppHost.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 // Lua app host (LUA_APPS.md Phase 1). Runs ONE sandboxed Lua app at a time as a
-// full-screen AppPage overlay, exactly like SnakeGame: tall "< title"
-// bar, status-bar-tap dismiss, async teardown. Apps are event-driven (the script
+// full-screen AppPage overlay with a slim "< title" bar that becomes Back-only
+// after launch, status-bar-tap dismiss, and async teardown. Apps are event-driven (the script
 // returns {on_open,on_tick,on_input,on_close}) and every callback runs under an
 // instruction budget + pcall — an app error or runaway loop becomes a toast and
 // a clean close, never a watchdog reset. All app memory lives in PSRAM.

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -1737,6 +1737,14 @@ void appPageBeginSlim(const char* title, void (*close_fn)()) {
   updateGlobalStatusBar();
 }
 
+void appPageCollapseTitle(void (*close_fn)()) {
+  if (s_apppage_close != close_fn) return;
+  s_apppage_title = "";
+  s_apppage_slim = true;
+  statusBarSetTall(false);
+  updateGlobalStatusBar();
+}
+
 void appPageEnd(void (*close_fn)()) {
   if (s_apppage_close != close_fn) return;   // a different page owns the bar now — leave it
   s_apppage_title = nullptr;


### PR DESCRIPTION
## Summary
- launch Store/Lua apps with a slim title bar so app content is not covered
- hide the app name after three seconds while retaining the Back affordance
- cancel the one-shot title timer during teardown and guard status-bar ownership

## Testing
- VS Code diagnostics
- app-page and timer lifecycle review
- git diff validation

Closes #455