### PR TITLE
M9: limit purge confirmation focus

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -10743,7 +10743,7 @@ static void discoveredPurgeApply() {
 }
 static void discoveredPurgeCb(lv_event_t* e) {
   if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
-  showConfirm(TR("Purge all discovered nodes?"), TR("Purge"), discoveredPurgeApply);
+  showConfirm(TR("Purge all discovered nodes?"), TR("Purge"), discoveredPurgeApply, true);
 }
 
 // ---- Discovered settings (cogwheel): a small sheet floated over the modal ----


### PR DESCRIPTION
## Summary
- limit keyboard navigation in the “Purge all discovered nodes?” confirmation to Cancel and Purge
- default the dialog selection to Cancel

Fixes #432

## Testing
- Tested on ThinkNode M9 hardware
- VS Code diagnostics: clean
- git diff --check: clean