### PR TITLE
Wio Tracker L2 Tweaks

### DIFF
--- a/src/MyMesh.cpp
+++ b/src/MyMesh.cpp
@@ -3148,7 +3148,7 @@ static inline uint32_t txtFloodFp(mesh::Packet* pkt) {
 
 void MyMesh::sendFloodScoped(const TransportKey& scope, mesh::Packet* pkt, uint32_t delay_millis) {
   uiTrackSentFp(txtFloodFp(pkt));
-  uint8_t phs = (uint8_t)(_prefs.path_hash_mode + 1);
+  const uint8_t phs = floodPathHashSize();
   if (scope.isNull()) {
     sendFlood(pkt, delay_millis, phs);
   } else {
@@ -3170,7 +3170,7 @@ void MyMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, ui
   // is honoured here; otherwise unscoped. Channel/group floods keep default_scope
   // — see the GroupChannel overload below — so public-channel containment is intact.
   if (send_unscoped) {
-    sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);
+    sendFlood(pkt, delay_millis, floodPathHashSize());
   } else if (!send_scope.isNull()) {
     sendFloodScoped(send_scope, pkt, delay_millis);   // explicit per-send override (app CMD_SET_FLOOD_SCOPE)
   } else if (scope_direct_floods) {
@@ -3182,14 +3182,14 @@ void MyMesh::sendFloodScoped(const ContactInfo& recipient, mesh::Packet* pkt, ui
     memcpy(&default_scope.key, _prefs.default_scope_key, sizeof(default_scope.key));
     sendFloodScoped(default_scope, pkt, delay_millis);
   } else {
-    sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);   // default: unscoped (cross-region safe)
+    sendFlood(pkt, delay_millis, floodPathHashSize());   // default: unscoped (cross-region safe)
   }
 }
 void MyMesh::sendFloodScoped(const mesh::GroupChannel& channel, mesh::Packet* pkt, uint32_t delay_millis) {
   uiTrackSentFp(txtFloodFp(pkt));
   // TODO: have per-channel send_scope
   if (send_unscoped) {
-    sendFlood(pkt, delay_millis, _prefs.path_hash_mode + 1);  // app has explicitly requested un-scoped
+    sendFlood(pkt, delay_millis, floodPathHashSize());  // app has explicitly requested un-scoped
   } else {
     TransportKey default_scope;
     memcpy(&default_scope.key, _prefs.default_scope_key, sizeof(default_scope.key));

--- a/src/MyMesh.h
+++ b/src/MyMesh.h
@@ -463,12 +463,19 @@ public:
    *  pending_login so onContactResponse's existing login branch can route
    *  the response. The same branch now also fires
    *  AbstractUITask::onAdminLoginResult so the UI can flip from "logging
-   *  in…" to "logged in" (or "failed"). */
+   *  in…" to "logged in" (or "failed"). Interactive login floods always
+   *  use the legacy-compatible one-byte path hash: older room/repeater
+   *  firmware silently drops packets using the optional wider hashes. */
+  static constexpr uint8_t UI_LOGIN_FLOOD_HASH_SIZE = 1;
   int uiSendAdminLogin(ContactInfo& recipient, const char* password) {
     uiResetPathForLogin(recipient);
     uint32_t est = 0;
+    const uint8_t previous_hash_override = _flood_path_hash_size_override;
+    _flood_path_hash_size_override = UI_LOGIN_FLOOD_HASH_SIZE;
     int r = sendLogin(recipient, password ? password : "", est);
+    _flood_path_hash_size_override = previous_hash_override;
     if (r == MSG_SEND_SENT_FLOOD || r == MSG_SEND_SENT_DIRECT) {
+      // BaseChatMesh::sendLogin() only transmits; MyMesh owns this response matcher.
       memcpy(&pending_login, recipient.id.pub_key, 4);
     }
     // Diagnostic (room-server login trace): which contact/type we sent the login
@@ -1199,6 +1206,12 @@ public:
 
 private:
   bool _companion_retry_enabled = false;  // opt-in; UITask::begin() applies the persisted toggle
+  uint8_t _flood_path_hash_size_override = 0;  // nonzero only during a synchronous compatibility send
+  uint8_t floodPathHashSize() const {
+    return _flood_path_hash_size_override
+        ? _flood_path_hash_size_override
+        : (uint8_t)(_prefs.path_hash_mode + 1);
+  }
   static const uint8_t COMPANION_TEXT_QUEUE_CAPACITY = 16;
   uint8_t companionDetachQueuedText(mesh::Packet* packets[], uint8_t priorities[],
                                     uint32_t scheduled_for[]);

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -2198,6 +2198,7 @@ static lv_obj_t* s_kb_mirror_root = nullptr;
 static lv_obj_t* s_kb_mirror_ta = nullptr;
 /** Real textarea whose text is synced with `s_kb_mirror_ta` while the keyboard is open. */
 static lv_obj_t* s_kb_bind_ta = nullptr;
+static bool s_kb_dismiss_pending = false;
 static bool terminalHandleVirtualKeyboardReady();
 // The T-Deck has a physical keyboard and never shows the on-screen keyboard or
 // the (hidden) mirror strip, so its keys bind STRAIGHT to the visible field —
@@ -6738,7 +6739,11 @@ static void kbMirrorEnsureCreated() {
   }, LV_EVENT_VALUE_CHANGED, nullptr);
   lv_obj_add_event_cb(s_kb_mirror_ta, [](lv_event_t* e) {
     (void)e;
-    terminalHandleVirtualKeyboardReady();
+    if (terminalHandleVirtualKeyboardReady()) return;
+    lv_obj_t* ready_ta = s_kb_bind_ta;
+    if (!ready_ta || !lv_obj_is_valid(ready_ta)) return;
+    kbMirrorSyncToReal();
+    lv_event_send(ready_ta, LV_EVENT_READY, nullptr);
   }, LV_EVENT_READY, nullptr);
 }
 
@@ -7648,6 +7653,15 @@ static void composerSuggestChangedCb(lv_event_t* e) {
 static void keyboardCb(lv_event_t* e) {
   lv_event_code_t code = lv_event_get_code(e);
   if (code == LV_EVENT_READY && terminalHandleVirtualKeyboardReady()) return;
+  if (code == LV_EVENT_READY && s_kb_bind_ta && lv_obj_is_valid(s_kb_bind_ta)) {
+    // LVGL sends READY to the keyboard first and only then to keyboard->ta.
+    // hideKb() below clears keyboard->ta during that first event, so the second
+    // dispatch never happens. Forward it to the real field while the mirror is
+    // still bound; one-line submit fields (notably room Join) receive Enter.
+    lv_obj_t* ready_ta = s_kb_bind_ta;
+    kbMirrorSyncToReal();
+    lv_event_send(ready_ta, LV_EVENT_READY, nullptr);
+  }
 #if defined(HAS_ATTAKY_MESH_KEYBOARD)
   if (code == LV_EVENT_READY || code == LV_EVENT_CANCEL) {
     accentExit(); accentBoxHide();
@@ -9547,6 +9561,7 @@ static void settingsFieldFocusCb(lv_event_t* e) {
   // release IF the press qualified as a click (movement under the scroll
   // threshold), so it's the right hook for "open keyboard on real tap".
   if (code != LV_EVENT_FOCUSED && code != LV_EVENT_CLICKED) return;
+  if (s_kb_dismiss_pending) return;
   if (!g_lv.keyboard) return;
   // Belt-and-suspenders: even CLICKED can fire at the tail end of a flick
   // if the touch happened to lift while still on the textarea. Same guard
@@ -17427,21 +17442,7 @@ static void loginWaitTimeoutCb(lv_timer_t* t) {
     if (localtime_r(&tt, &tmv)) strftime(when, sizeof when, "%H:%M %d %b", &tmv);
   }
   char msg[160];
-  // Multi-byte path hashing is the one setting that makes a login fail EXACTLY like
-  // this: a repeater that predates it, or does not implement it, silently drops 2- and
-  // 3-byte-hash packets, so the request never arrives and no error is ever generated
-  // anywhere. It is opt-in and defaults to 1 byte, but someone who turned it on has no
-  // way to connect that choice to "remote management stopped working" — reported twice
-  // (#278, #280), once explicitly while running 3-byte hashes. Name it here, where the
-  // operator is already looking, rather than leaving them to find it in Settings.
-  const uint8_t phm = the_mesh.getNodePrefs() ? the_mesh.getNodePrefs()->path_hash_mode : 0;
-  if (phm > 0) {
-    snprintf(msg, sizeof msg,
-             TR("No reply. Path hash is %u bytes;\nolder repeaters drop those.\nTry 1 byte (Settings > Radio & Mesh)"),
-             (unsigned)(phm + 1));
-  } else {
-    snprintf(msg, sizeof msg, TR("No reply. Check password, server,\nor device clock (device: %s)"), when);
-  }
+  snprintf(msg, sizeof msg, TR("No reply. Check password, server,\nor device clock (device: %s)"), when);
   g_lv.task->showAlert(msg, 5000);
 }
 static void loginWaitArm(LoginWaitKind kind) {
@@ -17779,10 +17780,23 @@ static void openAdminConsole(const ContactInfo& c) {
 static char  s_admin_pw_attempt[TOUCH_REPEATER_PW_LEN] = {0};
 static bool  s_admin_pw_remember_flag = false;
 
+static void adminPwDismissKeyboardAsync(void*) {
+  hideKb();
+  s_kb_dismiss_pending = false;
+}
+
 static void adminPwSubmitCb(lv_event_t* e) {
   const lv_event_code_t code = lv_event_get_code(e);
   if (code != LV_EVENT_CLICKED && code != LV_EVENT_READY) return;
+  if (s_kb_dismiss_pending) return;
   kbMirrorSyncToReal();
+  s_kb_dismiss_pending = true;
+  lv_indev_t* active_indev = lv_indev_get_act();
+  if (active_indev) lv_indev_wait_release(active_indev);
+  if (lv_async_call(adminPwDismissKeyboardAsync, nullptr) != LV_RES_OK) {
+    hideKb();
+    s_kb_dismiss_pending = false;
+  }
   if (!s_admin_pw_ta) return;
   const char* pw = lv_textarea_get_text(s_admin_pw_ta);
   ContactInfo* c = the_mesh.lookupContactByPubKey(s_admin_pub32, PUB_KEY_SIZE);


### PR DESCRIPTION
## Summary
- forward normal virtual-keyboard Enter events from the mirror field to the bound dialog field
- dismiss the keyboard safely after room/admin login submission
- use legacy-compatible one-byte path hashes for interactive login floods without changing the saved radio preference
- keep login timeout guidance aligned with the compatibility override

## Validation
- verified Enter submits and closes the keyboard on Wio Tracker L2 hardware
- verified the entered password reaches the login encryption boundary unchanged during diagnosis
- `pio project config --json-output`
- editor diagnostics clean
- `git diff --check`

No PlatformIO build was run after removing temporary diagnostics.