### PR TITLE
Fix At-a-glance zero-hop count

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -57071,10 +57071,12 @@ void UITask::newMsgImpl(uint8_t path_len, const char* from_name, const char* tex
     char glance_title[96];
     {
       char hops[24] = "";
-      if (path_len == 0)                       snprintf(hops, sizeof hops, " \xC2\xB7 %s", TR("direct"));
-      else if (path_len != OUT_PATH_UNKNOWN)   snprintf(hops, sizeof hops, " \xC2\xB7 %u %s",
-                                                        (unsigned)path_len,
-                                                        path_len == 1 ? TR("hop") : TR("hops"));
+      if (path_len != OUT_PATH_UNKNOWN) {
+        const uint8_t hop_count = (uint8_t)(path_len & 0x3F);
+        if (hop_count == 0) snprintf(hops, sizeof hops, " \xC2\xB7 %s", TR("direct"));
+        else snprintf(hops, sizeof hops, " \xC2\xB7 %u %s", (unsigned)hop_count,
+                      hop_count == 1 ? TR("hop") : TR("hops"));
+      }
       // A channel post names the speaker as well as the room; a direct message
       // is already titled with the sender, so naming them twice adds nothing.
       if (channel && sender && sender[0])


### PR DESCRIPTION
## Summary
- decode the packed flood-path descriptor before formatting the At-a-glance hop count
- preserve unknown-path handling and direct/singular/plural labels

Fixes #484

## Testing
- verified packed values: `0x40 -> 0`, `0x41 -> 1`, `0x82 -> 2` hops
- VS Code diagnostics: no errors in `src/ui-touch/UITask.cpp`
- `git diff --check`