### PR TITLE
Show M9 file timestamps directly

### DIFF
--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -23228,7 +23228,15 @@ static void fmRender() {
         localtime_r(&t, &tmv);
         strftime(ts, sizeof ts, "  %d %b %H:%M", &tmv);
       }
+#if defined(HAS_THINKNODE_M9)
+      // The M9's 320 px row cannot show a crash-report filename, size and date
+      // at once. Keep the filename on line one and make metadata immediately
+      // visible below it instead of hiding the timestamp in the marquee tail.
+      if (ts[0]) snprintf(label, sizeof label, "%s\n%s%s", en.name, sz, ts);
+      else       snprintf(label, sizeof label, "%s   %s", en.name, sz);
+#else
       snprintf(label, sizeof label, "%s   %s%s", en.name, sz, ts);
+#endif
     }
     lv_obj_t* row = lv_list_add_btn(s_fm_list, en.isdir ? LV_SYMBOL_DIRECTORY : LV_SYMBOL_FILE, label);
     fmStyleRow(row, COLOR_TEXT);


### PR DESCRIPTION
## Summary
- place M9 file size and modification time on a second line when a valid timestamp exists
- keep long filenames readable while making crash-report dates immediately visible instead of hiding them in the marquee tail
- retain the compact one-line row when the filesystem has no valid timestamp

Fixes #475

## Testing
- verified representative `wadamesh-crash.elf` metadata fits the existing 120-byte row buffer
- VS Code diagnostics: no errors in `src/ui-touch/UITask.cpp`
- `git diff --check`