### PR TITLE
Allow longer quick replies

### DIFF
--- a/src/helpers/esp32/TouchPrefsStore.h
+++ b/src/helpers/esp32/TouchPrefsStore.h
@@ -89,11 +89,11 @@ bool    touchPrefsSetLangFile(const char* code);
 
 /** User-configurable quick-reply macros: up to 6 short strings the user can
  *  drop into the composer with a single tap (e.g. "ok", "on the way",
- *  "stuck — wait"). idx is 0..5; max length 31 chars + null. Returns the
+ *  "stuck — wait"). idx is 0..5; max length 100 chars + null. Returns the
  *  text length actually written into `out` (0 if the slot is empty or idx
  *  is out of range). `out` is always null-terminated when out_cap > 0. */
 constexpr int TOUCH_QUICK_REPLY_COUNT  = 6;
-constexpr int TOUCH_QUICK_REPLY_MAXLEN = 32;
+constexpr int TOUCH_QUICK_REPLY_MAXLEN = 101;
 int  touchPrefsGetQuickReply(int idx, char* out, int out_cap);
 bool touchPrefsSetQuickReply(int idx, const char* text);
 

--- a/src/ui-touch/UITask.cpp
+++ b/src/ui-touch/UITask.cpp
@@ -12149,8 +12149,8 @@ static void buildQuickReplySettings() {
   int y = 0;
   // Compact form: one row per slot, with the slot index as a tiny prefix
   // label so the user knows which macro they're editing. Single-line
-  // textareas to keep the modal short; macro text caps at 31 chars on the
-  // store side anyway, which fits one line.
+  // textareas keep the six-slot modal compact; longer replies scroll
+  // horizontally while editing.
 #if defined(ESP32)
   for (int i = 0; i < TOUCH_QUICK_REPLY_COUNT; ++i) {
     char buf[TOUCH_QUICK_REPLY_MAXLEN];


### PR DESCRIPTION
## Summary
- increase configurable quick replies from 31 to 100 characters
- keep editor input, persistence truncation, picker display, and composer insertion on the shared limit
- preserve existing quick-reply keys, defaults, and shorter saved values

## Testing
- `platformio run --target upload --environment wio_tracker_l2_companion_radio_touch`
- tested on a Seeed Wio Tracker L2

Fixes #425